### PR TITLE
style: テーマカラーを#2a83a2に変更

### DIFF
--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -1,10 +1,18 @@
 @import url("https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c&family=Zen+Maru+Gothic&display=swap");
 @import "tailwindcss";
-@plugin "daisyui";
+@plugin "daisyui" {
+    themes: light --default, dark --prefersDark;
+}
 
-/* daisyUIテーマ設定 */
-@theme {
-    --daisyui-themes: light, dark;
+/* カスタムテーマカラー設定 */
+[data-theme="light"] {
+    --color-primary: #2a83a2;
+    --color-primary-content: #ffffff;
+}
+
+[data-theme="dark"] {
+    --color-primary: #2a83a2;
+    --color-primary-content: #ffffff;
 }
 
 div {


### PR DESCRIPTION
## Summary
- プライマリカラーをカスタムカラー(#2a83a2)に変更
- ボタン、バッジ、アイコン、カレンダーのハイライトなどに適用
- ライトモード・ダークモード両方に対応

## Test plan
- [ ] ボタンの色が#2a83a2に変更されていることを確認
- [ ] バッジ、アイコンの色が変更されていることを確認
- [ ] ダークモードでも同じ色が適用されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)