### PR TITLE
feat: 部員認証機能を追加

### DIFF
--- a/app/unauthorized/page.tsx
+++ b/app/unauthorized/page.tsx
@@ -1,0 +1,66 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export default function UnauthorizedPage() {
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-base-200">
+            <div className="card w-96 bg-base-100 shadow-xl">
+                <div className="card-body items-center text-center">
+                    {/* Logo */}
+                    <div className="mb-4">
+                        <Image
+                            src="/nb_logo.png"
+                            alt="NB Logo"
+                            width={180}
+                            height={72}
+                            priority
+                            className="w-auto h-auto"
+                        />
+                    </div>
+
+                    {/* Error Icon */}
+                    <div className="text-error mb-4">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className="h-16 w-16"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                            />
+                        </svg>
+                    </div>
+
+                    <h1 className="card-title text-2xl mb-2 text-error">
+                        アクセス権限がありません
+                    </h1>
+                    <p className="text-base-content/70 mb-6">
+                        このアプリケーションは部員専用です。
+                        <br />
+                        部員登録がされていないアカウントではアクセスできません。
+                    </p>
+
+                    <div className="flex flex-col gap-2 w-full">
+                        <Link
+                            href="/login"
+                            className="btn btn-primary w-full"
+                        >
+                            別のアカウントでログイン
+                        </Link>
+                        <Link
+                            href="/"
+                            className="btn btn-outline btn-neutral w-full"
+                        >
+                            トップページに戻る
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,6 +3,30 @@ import MicrosoftEntraID from "next-auth/providers/microsoft-entra-id";
 
 const tenantId = process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID;
 
+// メールアドレスから学籍番号（最初の7文字）を抽出
+const extractStudentId = (email: string | null | undefined): string | null => {
+    if (!email) return null;
+    // メールアドレスの@より前の部分を取得し、最初の7文字を返す
+    const localPart = email.split("@")[0];
+    return localPart.substring(0, 7).toLowerCase();
+};
+
+// 部員確認API呼び出し
+const verifyMember = async (identifier: string): Promise<boolean> => {
+    try {
+        const apiUrl = process.env.NEXT_PUBLIC_GAS_API_URL;
+        if (!apiUrl) return false;
+
+        const res = await fetch(
+            `${apiUrl}?path=verify-member&identifier=${encodeURIComponent(identifier)}`
+        );
+        const data = await res.json();
+        return data.success && data.isMember === true;
+    } catch {
+        return false;
+    }
+};
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
     providers: [
         MicrosoftEntraID({
@@ -16,15 +40,32 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
     pages: {
         signIn: "/login",
+        error: "/unauthorized",
     },
     callbacks: {
+        async signIn({ user }) {
+            // メールアドレスから学籍番号を抽出
+            const studentId = extractStudentId(user.email);
+            if (!studentId) {
+                return false;
+            }
+
+            // 部員確認
+            const isMember = await verifyMember(studentId);
+            if (!isMember) {
+                return "/unauthorized";
+            }
+
+            return true;
+        },
         authorized({ auth, request: { nextUrl } }) {
             const isLoggedIn = !!auth?.user;
             const isOnLoginPage = nextUrl.pathname === "/login";
             const isOnRootPage = nextUrl.pathname === "/";
+            const isOnUnauthorizedPage = nextUrl.pathname === "/unauthorized";
 
-            // ログインページとルートページは認証不要
-            if (isOnLoginPage || isOnRootPage) {
+            // ログインページ、ルートページ、未認可ページは認証不要
+            if (isOnLoginPage || isOnRootPage || isOnUnauthorizedPage) {
                 return true;
             }
 


### PR DESCRIPTION
## Summary
- GASにmembersシートのA列と学籍番号を照合するverify-member APIを追加
- Next.jsのsignInコールバックでメールアドレスから学籍番号（最初の7文字）を抽出し部員確認
- 非部員は/unauthorizedページにリダイレクトされる

## Test plan
- [ ] membersシートに学籍番号を登録
- [ ] 登録された学籍番号のアカウントでログインできることを確認
- [ ] 未登録のアカウントでログインすると/unauthorizedにリダイレクトされることを確認
- [ ] GASを再デプロイしてverify-member APIを有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)