### PR TITLE
fix: 画像ビューアーの拡大時に白い線が表示される問題を修正

### DIFF
--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -159,8 +159,11 @@ function ImageViewer({ src, onClose }: { src: string; onClose: () => void }) {
                     alt="拡大画像"
                     className="max-h-[90vh] max-w-[95vw] object-contain select-none"
                     style={{
-                        transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
+                        transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale})`,
                         transition: isDragging ? "none" : "transform 0.1s",
+                        willChange: "transform",
+                        backfaceVisibility: "hidden",
+                        WebkitBackfaceVisibility: "hidden",
                     }}
                     onDoubleClick={handleDoubleClick}
                     draggable={false}


### PR DESCRIPTION
## Summary
- translate3dでGPUアクセラレーションを有効化
- will-change, backfaceVisibilityでサブピクセルレンダリング問題を軽減

## Test plan
- [ ] 画像ビューアーでピンチズーム時に白い線が表示されないことを確認