### PR TITLE
improve: 画像ビューアーのSVG表示を改善

### DIFF
--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -157,13 +157,14 @@ function ImageViewer({ src, onClose }: { src: string; onClose: () => void }) {
                 <img
                     src={src}
                     alt="拡大画像"
-                    className="max-h-[90vh] max-w-[95vw] object-contain select-none"
+                    className="max-h-[95vh] w-[95vw] object-contain select-none"
                     style={{
                         transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale})`,
                         transition: isDragging ? "none" : "transform 0.1s",
                         willChange: "transform",
                         backfaceVisibility: "hidden",
                         WebkitBackfaceVisibility: "hidden",
+                        backgroundColor: src.endsWith(".svg") ? "white" : undefined,
                     }}
                     onDoubleClick={handleDoubleClick}
                     draggable={false}


### PR DESCRIPTION
## Summary
- 画像ビューアーの横幅を95vwに拡大
- SVGファイルの場合は背景を白に設定

## Test plan
- [ ] SVG画像が大きく表示されることを確認
- [ ] SVGの背景が白で表示されることを確認