### PR TITLE
refactor: ZoomableImageをimgタグに統一してシンプル化

### DIFF
--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -131,40 +131,21 @@ function ZoomableImage({ src, alt }: { src: string; alt: string }) {
             onTouchEnd={handleTouchEnd}
             onDoubleClick={handleDoubleClick}
         >
-            {src.endsWith(".svg") ? (
-                <>
-                    <object
-                        data={src}
-                        type="image/svg+xml"
-                        className="w-full select-none pointer-events-none"
-                        style={{
-                            transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale})`,
-                            transformOrigin: "center center",
-                            transition: isDragging ? "none" : "transform 0.1s",
-                            willChange: "transform",
-                            backfaceVisibility: "hidden",
-                            WebkitBackfaceVisibility: "hidden",
-                        }}
-                    />
-                    <div className="absolute inset-0" />
-                </>
-            ) : (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                    src={src}
-                    alt={alt}
-                    className="w-full select-none pointer-events-none"
-                    style={{
-                        transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale})`,
-                        transformOrigin: "center center",
-                        transition: isDragging ? "none" : "transform 0.1s",
-                        willChange: "transform",
-                        backfaceVisibility: "hidden",
-                        WebkitBackfaceVisibility: "hidden",
-                    }}
-                    draggable={false}
-                />
-            )}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+                src={src}
+                alt={alt}
+                className="w-full select-none pointer-events-none"
+                style={{
+                    transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale})`,
+                    transformOrigin: "center center",
+                    transition: isDragging ? "none" : "transform 0.1s",
+                    willChange: "transform",
+                    backfaceVisibility: "hidden",
+                    WebkitBackfaceVisibility: "hidden",
+                }}
+                draggable={false}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## 概要
ZoomableImageコンポーネントをimgタグに統一

## 変更内容
- SVG用のobjectタグを削除し、すべてimgタグで表示
- 条件分岐を削除してコードをシンプル化
- SVGもimgタグでベクター品質を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)