### PR TITLE
fix: モバイルでのPDF表示をボタン方式に変更

### DIFF
--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -372,58 +372,51 @@ function ZoomableImage({ src, alt }: { src: string; alt: string }) {
 
 // PDFビューアーコンポーネント
 function PdfViewer({ src }: { src: string }) {
-    const [isFullscreen, setIsFullscreen] = useState(false);
     const filename = src.split("/").pop() || "document.pdf";
 
     return (
-        <>
-            <div className="space-y-6">
-                <section>
-                    <div className="w-full">
-                        <iframe
-                            src={src}
-                            className="w-full h-[70vh] lg:h-screen border border-base-300 rounded-lg"
-                            title={filename}
-                        />
-                    </div>
-                    <div className="flex items-center justify-center gap-2 mt-2">
-                        <p className="text-sm text-base-content/60">
-                            PDFビューアーで表示中
-                        </p>
-                        <button
-                            onClick={() => setIsFullscreen(true)}
-                            className="btn btn-ghost btn-xs lg:hidden gap-1"
+        <div className="space-y-6">
+            {/* PC用: iframeで表示 */}
+            <section className="hidden lg:block">
+                <div className="w-full">
+                    <iframe
+                        src={src}
+                        className="w-full h-screen border border-base-300 rounded-lg"
+                        title={filename}
+                    />
+                </div>
+                <p className="text-sm text-base-content/60 mt-2 text-center">
+                    PDFビューアーで表示中
+                </p>
+            </section>
+
+            {/* モバイル用: ボタンで開く */}
+            <section className="lg:hidden">
+                <div className="flex flex-col items-center gap-4 py-8">
+                    <div className="p-6 rounded-full bg-base-200">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 384 512"
+                            className="h-16 w-16 text-error"
+                            fill="currentColor"
                         >
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                className="h-4 w-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"
-                                />
-                            </svg>
-                            全画面
-                        </button>
+                            <path d="M0 64C0 28.7 28.7 0 64 0L224 0l0 128c0 17.7 14.3 32 32 32l128 0 0 288c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64L0 64zm384 64l-128 0L256 0 384 128z" />
+                        </svg>
                     </div>
-                </section>
-
-                <div className="divider"></div>
-
-                <div className="flex justify-center">
+                    <p className="text-base-content/60 text-center">
+                        PDFファイルを表示するには
+                        <br />
+                        下のボタンをタップしてください
+                    </p>
                     <a
                         href={src}
-                        download
-                        className="btn btn-primary btn-sm gap-2"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-primary gap-2"
                     >
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
-                            className="h-4 w-4"
+                            className="h-5 w-5"
                             fill="none"
                             viewBox="0 0 24 24"
                             stroke="currentColor"
@@ -432,55 +425,46 @@ function PdfViewer({ src }: { src: string }) {
                                 strokeLinecap="round"
                                 strokeLinejoin="round"
                                 strokeWidth={2}
-                                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
                             />
                         </svg>
-                        PDFをダウンロード
+                        PDFを開く
                     </a>
                 </div>
+            </section>
 
-                <div className="divider"></div>
+            <div className="divider"></div>
 
-                <div className="text-sm text-base-content/60 text-right">
-                    <p>{filename.replace(".pdf", "")}</p>
-                </div>
+            <div className="flex justify-center">
+                <a
+                    href={src}
+                    download
+                    className="btn btn-outline btn-sm gap-2"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                        />
+                    </svg>
+                    PDFをダウンロード
+                </a>
             </div>
 
-            {/* 全画面モーダル（モバイル用） */}
-            {isFullscreen && (
-                <div className="fixed inset-0 z-50 bg-white flex flex-col">
-                    <div className="flex items-center justify-between p-2 border-b border-base-300">
-                        <span className="text-sm font-medium truncate flex-1">
-                            {filename}
-                        </span>
-                        <button
-                            onClick={() => setIsFullscreen(false)}
-                            className="btn btn-circle btn-ghost btn-sm"
-                        >
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                className="h-5 w-5"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M6 18L18 6M6 6l12 12"
-                                />
-                            </svg>
-                        </button>
-                    </div>
-                    <iframe
-                        src={src}
-                        className="flex-1 w-full border-0"
-                        title={filename}
-                    />
-                </div>
-            )}
-        </>
+            <div className="divider"></div>
+
+            <div className="text-sm text-base-content/60 text-right">
+                <p>{filename.replace(".pdf", "")}</p>
+            </div>
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary
- モバイルSafariでiframeによるPDF表示が正しく動作しない問題を修正
- モバイルではPDFアイコンと「PDFを開く」ボタンを表示し、タップで新しいタブでPDFを開くように変更
- PCでは従来通りiframeでPDFを直接表示

## Test plan
- [ ] モバイルでPDFを開くボタンが表示されることを確認
- [ ] ボタンタップでPDFが新しいタブで開くことを確認
- [ ] PCではiframeでPDFが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)