### PR TITLE
improve: モバイルPDFビューアーでGoogle Docs Viewerを使用

### DIFF
--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -375,6 +375,16 @@ function PdfViewer({ src }: { src: string }) {
     const [isFullscreen, setIsFullscreen] = useState(false);
     const filename = src.split("/").pop() || "document.pdf";
 
+    // Google Docs Viewer用のURL（モバイル用）
+    const getGoogleDocsViewerUrl = () => {
+        const baseUrl =
+            typeof window !== "undefined"
+                ? window.location.origin
+                : "https://nb-portal.vercel.app";
+        const fullUrl = `${baseUrl}${src}`;
+        return `https://docs.google.com/viewer?url=${encodeURIComponent(fullUrl)}&embedded=true`;
+    };
+
     return (
         <>
             <div className="space-y-6">
@@ -501,7 +511,7 @@ function PdfViewer({ src }: { src: string }) {
                         </button>
                     </div>
                     <iframe
-                        src={src}
+                        src={getGoogleDocsViewerUrl()}
                         className="flex-1 w-full border-0"
                         title={filename}
                     />


### PR DESCRIPTION
## Summary
- モバイルPDFビューアーでGoogle Docs Viewerを使用するよう変更
- iOS Safariでの複数ページ表示とピンチズームに対応

## Test plan
- [ ] モバイルでPDFを開いて複数ページが表示されることを確認
- [ ] ピンチズームで拡大・縮小ができることを確認
- [ ] 閉じるボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)