### PR TITLE
feat: モバイルPDFビューアーにピンチズーム機能を追加

### DIFF
--- a/app/(authenticated)/documents/PdfViewer.tsx
+++ b/app/(authenticated)/documents/PdfViewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -17,7 +17,14 @@ export default function PdfViewer({ src }: PdfViewerProps) {
     const [numPages, setNumPages] = useState<number | null>(null);
     const [currentPage, setCurrentPage] = useState(1);
     const [containerWidth, setContainerWidth] = useState<number>(0);
+    const [scale, setScale] = useState(1);
+    const [position, setPosition] = useState({ x: 0, y: 0 });
+    const [isDragging, setIsDragging] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
+    const lastTouchRef = useRef<{ x: number; y: number } | null>(null);
+    const lastDistanceRef = useRef<number | null>(null);
+    const lastPinchCenterRef = useRef<{ x: number; y: number } | null>(null);
     const filename = src.split("/").pop() || "document.pdf";
 
     // コンテナの幅を監視
@@ -35,6 +42,12 @@ export default function PdfViewer({ src }: PdfViewerProps) {
         return () => window.removeEventListener("resize", updateWidth);
     }, [isFullscreen]);
 
+    // ページ変更時にズームをリセット
+    useEffect(() => {
+        setScale(1);
+        setPosition({ x: 0, y: 0 });
+    }, [currentPage]);
+
     const onDocumentLoadSuccess = ({ numPages }: { numPages: number }) => {
         setNumPages(numPages);
         setCurrentPage(1);
@@ -47,6 +60,101 @@ export default function PdfViewer({ src }: PdfViewerProps) {
     const goToNextPage = () => {
         setCurrentPage((prev) => Math.min(prev + 1, numPages || 1));
     };
+
+    const resetZoom = useCallback(() => {
+        setScale(1);
+        setPosition({ x: 0, y: 0 });
+    }, []);
+
+    const handleTouchStart = useCallback((e: React.TouchEvent) => {
+        if (e.touches.length === 2) {
+            const dx = e.touches[0].clientX - e.touches[1].clientX;
+            const dy = e.touches[0].clientY - e.touches[1].clientY;
+            lastDistanceRef.current = Math.sqrt(dx * dx + dy * dy);
+            lastPinchCenterRef.current = {
+                x: (e.touches[0].clientX + e.touches[1].clientX) / 2,
+                y: (e.touches[0].clientY + e.touches[1].clientY) / 2,
+            };
+        } else if (e.touches.length === 1) {
+            setIsDragging(true);
+            lastTouchRef.current = {
+                x: e.touches[0].clientX,
+                y: e.touches[0].clientY,
+            };
+        }
+    }, []);
+
+    const handleTouchMove = useCallback(
+        (e: React.TouchEvent) => {
+            if (e.touches.length === 2 && lastDistanceRef.current !== null) {
+                e.preventDefault();
+                const dx = e.touches[0].clientX - e.touches[1].clientX;
+                const dy = e.touches[0].clientY - e.touches[1].clientY;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+                const delta = distance / lastDistanceRef.current;
+                const newScale = Math.min(Math.max(scale * delta, 1), 5);
+
+                const centerX =
+                    (e.touches[0].clientX + e.touches[1].clientX) / 2;
+                const centerY =
+                    (e.touches[0].clientY + e.touches[1].clientY) / 2;
+
+                if (containerRef.current && lastPinchCenterRef.current) {
+                    const rect = containerRef.current.getBoundingClientRect();
+                    const pinchX = centerX - rect.left;
+                    const pinchY = centerY - rect.top;
+                    const contentX = (pinchX - position.x) / scale;
+                    const contentY = (pinchY - position.y) / scale;
+                    const newX = pinchX - contentX * newScale;
+                    const newY = pinchY - contentY * newScale;
+                    setPosition({ x: newX, y: newY });
+                }
+
+                setScale(newScale);
+                lastDistanceRef.current = distance;
+                lastPinchCenterRef.current = { x: centerX, y: centerY };
+
+                if (newScale <= 1) {
+                    setPosition({ x: 0, y: 0 });
+                }
+            } else if (
+                e.touches.length === 1 &&
+                isDragging &&
+                lastTouchRef.current &&
+                scale > 1
+            ) {
+                const deltaX = e.touches[0].clientX - lastTouchRef.current.x;
+                const deltaY = e.touches[0].clientY - lastTouchRef.current.y;
+                setPosition((prev) => ({
+                    x: prev.x + deltaX,
+                    y: prev.y + deltaY,
+                }));
+                lastTouchRef.current = {
+                    x: e.touches[0].clientX,
+                    y: e.touches[0].clientY,
+                };
+            }
+        },
+        [isDragging, scale, position]
+    );
+
+    const handleTouchEnd = useCallback(() => {
+        setIsDragging(false);
+        lastTouchRef.current = null;
+        lastDistanceRef.current = null;
+        lastPinchCenterRef.current = null;
+        if (scale <= 1) {
+            setPosition({ x: 0, y: 0 });
+        }
+    }, [scale]);
+
+    const handleDoubleClick = useCallback(() => {
+        if (scale > 1) {
+            resetZoom();
+        } else {
+            setScale(2);
+        }
+    }, [scale, resetZoom]);
 
     return (
         <>
@@ -153,109 +261,158 @@ export default function PdfViewer({ src }: PdfViewerProps) {
                         <span className="text-sm font-medium truncate flex-1 mr-2">
                             {filename.replace(".pdf", "")}
                         </span>
-                        <button
-                            onClick={() => setIsFullscreen(false)}
-                            className="btn btn-sm btn-ghost gap-1"
-                        >
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                className="h-5 w-5"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
+                        <div className="flex items-center gap-2">
+                            {scale > 1 && (
+                                <button
+                                    onClick={resetZoom}
+                                    className="btn btn-sm btn-ghost gap-1"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        className="h-4 w-4"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke="currentColor"
+                                    >
+                                        <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth={2}
+                                            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM13 10H7"
+                                        />
+                                    </svg>
+                                    リセット
+                                </button>
+                            )}
+                            <button
+                                onClick={() => {
+                                    setIsFullscreen(false);
+                                    resetZoom();
+                                }}
+                                className="btn btn-sm btn-ghost gap-1"
                             >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M6 18L18 6M6 6l12 12"
-                                />
-                            </svg>
-                            閉じる
-                        </button>
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-5 w-5"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M6 18L18 6M6 6l12 12"
+                                    />
+                                </svg>
+                                閉じる
+                            </button>
+                        </div>
                     </div>
 
                     {/* PDFコンテンツ */}
                     <div
                         ref={containerRef}
-                        className="flex-1 overflow-auto bg-base-300"
+                        className="flex-1 overflow-hidden bg-base-300 touch-none"
+                        onTouchStart={handleTouchStart}
+                        onTouchMove={handleTouchMove}
+                        onTouchEnd={handleTouchEnd}
+                        onDoubleClick={handleDoubleClick}
                     >
-                        <Document
-                            file={src}
-                            onLoadSuccess={onDocumentLoadSuccess}
-                            loading={
-                                <div className="flex items-center justify-center h-full">
-                                    <span className="loading loading-spinner loading-lg"></span>
-                                </div>
-                            }
-                            error={
-                                <div className="flex items-center justify-center h-full">
-                                    <p className="text-error">
-                                        PDFの読み込みに失敗しました
-                                    </p>
-                                </div>
-                            }
+                        <div
+                            ref={contentRef}
+                            className="w-full h-full overflow-auto"
+                            style={{
+                                transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale})`,
+                                transformOrigin: "0 0",
+                                transition: isDragging
+                                    ? "none"
+                                    : "transform 0.1s",
+                            }}
                         >
-                            <Page
-                                pageNumber={currentPage}
-                                width={containerWidth || undefined}
+                            <Document
+                                file={src}
+                                onLoadSuccess={onDocumentLoadSuccess}
                                 loading={
-                                    <div className="flex items-center justify-center py-8">
-                                        <span className="loading loading-spinner loading-md"></span>
+                                    <div className="flex items-center justify-center h-full">
+                                        <span className="loading loading-spinner loading-lg"></span>
                                     </div>
                                 }
-                            />
-                        </Document>
+                                error={
+                                    <div className="flex items-center justify-center h-full">
+                                        <p className="text-error">
+                                            PDFの読み込みに失敗しました
+                                        </p>
+                                    </div>
+                                }
+                            >
+                                <Page
+                                    pageNumber={currentPage}
+                                    width={containerWidth || undefined}
+                                    loading={
+                                        <div className="flex items-center justify-center py-8">
+                                            <span className="loading loading-spinner loading-md"></span>
+                                        </div>
+                                    }
+                                />
+                            </Document>
+                        </div>
                     </div>
 
                     {/* フッター（ページ操作） */}
-                    {numPages && numPages > 1 && (
-                        <div className="flex items-center justify-center gap-4 p-3 border-t border-base-300 bg-base-200">
-                            <button
-                                onClick={goToPrevPage}
-                                disabled={currentPage <= 1}
-                                className="btn btn-sm btn-ghost"
-                            >
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    className="h-5 w-5"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                >
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={2}
-                                        d="M15 19l-7-7 7-7"
-                                    />
-                                </svg>
-                            </button>
-                            <span className="text-sm">
-                                {currentPage} / {numPages}
-                            </span>
-                            <button
-                                onClick={goToNextPage}
-                                disabled={currentPage >= numPages}
-                                className="btn btn-sm btn-ghost"
-                            >
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    className="h-5 w-5"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                >
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={2}
-                                        d="M9 5l7 7-7 7"
-                                    />
-                                </svg>
-                            </button>
+                    <div className="flex items-center justify-between p-3 border-t border-base-300 bg-base-200">
+                        <div className="text-xs text-base-content/60">
+                            ピンチで拡大・縮小
                         </div>
-                    )}
+                        {numPages && numPages > 1 && (
+                            <div className="flex items-center gap-4">
+                                <button
+                                    onClick={goToPrevPage}
+                                    disabled={currentPage <= 1}
+                                    className="btn btn-sm btn-ghost"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        className="h-5 w-5"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke="currentColor"
+                                    >
+                                        <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth={2}
+                                            d="M15 19l-7-7 7-7"
+                                        />
+                                    </svg>
+                                </button>
+                                <span className="text-sm">
+                                    {currentPage} / {numPages}
+                                </span>
+                                <button
+                                    onClick={goToNextPage}
+                                    disabled={currentPage >= numPages}
+                                    className="btn btn-sm btn-ghost"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        className="h-5 w-5"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke="currentColor"
+                                    >
+                                        <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth={2}
+                                            d="M9 5l7 7-7 7"
+                                        />
+                                    </svg>
+                                </button>
+                            </div>
+                        )}
+                        {(!numPages || numPages <= 1) && <div />}
+                    </div>
                 </div>
             )}
         </>


### PR DESCRIPTION
## Summary
- ピンチイン/アウトでズーム（1倍〜5倍）
- ダブルタップで2倍ズーム/リセット
- ズーム時のドラッグ移動
- ズームリセットボタン（拡大時に表示）
- ページ変更時に自動でズームリセット
- フッターに「ピンチで拡大・縮小」のヒントを表示

## Test plan
- [ ] モバイルでピンチズームが動作することを確認
- [ ] ダブルタップでズーム/リセットが動作することを確認
- [ ] ズーム時にドラッグで移動できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)