### PR TITLE
feat: PDFビューアーに125%の拡大オプションを追加

### DIFF
--- a/app/(authenticated)/documents/PdfViewer.tsx
+++ b/app/(authenticated)/documents/PdfViewer.tsx
@@ -14,6 +14,7 @@ interface PdfViewerProps {
 
 const SCALE_OPTIONS = [
     { value: 1, label: "100%" },
+    { value: 1.25, label: "125%" },
     { value: 1.5, label: "150%" },
     { value: 1.75, label: "175%" },
     { value: 2, label: "200%" },
@@ -57,7 +58,9 @@ export default function PdfViewer({ src }: PdfViewerProps) {
             // PDFファイルを取得
             const response = await fetch(src);
             const blob = await response.blob();
-            const file = new File([blob], filename, { type: "application/pdf" });
+            const file = new File([blob], filename, {
+                type: "application/pdf",
+            });
 
             // ファイル共有がサポートされているかチェック
             if (navigator.canShare && navigator.canShare({ files: [file] })) {


### PR DESCRIPTION
## Summary
- PDFビューアーのスケールオプションに125%を追加
- 100%と150%の間の中間的な拡大率を選択可能に

🤖 Generated with [Claude Code](https://claude.com/claude-code)