### PR TITLE
fix: モバイルでのアンカーリンクが動作しない問題を修正

### DIFF
--- a/app/(authenticated)/documents/AnchorLink.tsx
+++ b/app/(authenticated)/documents/AnchorLink.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+interface AnchorLinkProps {
+    targetId: string;
+    children: React.ReactNode;
+    className?: string;
+}
+
+export default function AnchorLink({
+    targetId,
+    children,
+    className,
+}: AnchorLinkProps) {
+    const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+
+        // 同じIDを持つすべての要素を取得
+        const elements = document.querySelectorAll(`#${targetId}`);
+
+        // 可視状態の要素を見つける
+        for (const element of elements) {
+            const rect = element.getBoundingClientRect();
+            const style = window.getComputedStyle(element);
+
+            // 要素が表示されているかチェック
+            if (
+                style.display !== "none" &&
+                style.visibility !== "hidden" &&
+                rect.width > 0 &&
+                rect.height > 0
+            ) {
+                element.scrollIntoView({ behavior: "smooth" });
+                // URLにハッシュを追加
+                history.pushState(null, "", `#${targetId}`);
+                break;
+            }
+        }
+    };
+
+    return (
+        <a href={`#${targetId}`} onClick={handleClick} className={className}>
+            {children}
+        </a>
+    );
+}

--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import mermaid from "mermaid";
 import dynamic from "next/dynamic";
+import AnchorLink from "./AnchorLink";
 
 // react-pdfはサーバーサイドで実行できないため、動的インポートを使用
 const PdfViewer = dynamic(() => import("./PdfViewer"), {
@@ -466,12 +467,12 @@ const documents: Document[] = [
                             },
                         ].map((item) => (
                             <li key={item.id}>
-                                <a
-                                    href={`#${item.id}`}
+                                <AnchorLink
+                                    targetId={item.id}
                                     className="link link-hover"
                                 >
                                     {item.label}
-                                </a>
+                                </AnchorLink>
                             </li>
                         ))}
                     </ul>
@@ -512,12 +513,12 @@ const documents: Document[] = [
                             },
                         ].map((item) => (
                             <li key={item.id}>
-                                <a
-                                    href={`#${item.id}`}
+                                <AnchorLink
+                                    targetId={item.id}
                                     className="link link-primary"
                                 >
                                     {item.label}
-                                </a>
+                                </AnchorLink>
                             </li>
                         ))}
                     </ol>


### PR DESCRIPTION
## Summary
- 重複IDを持つ要素から可視状態のものを見つけてスクロールするAnchorLinkコンポーネントを追加
- 雨天マニュアルの目次リンクをAnchorLinkに変更
- レイアウトでchildrenが2回レンダリングされることによるID重複問題に対応

## Test plan
- [ ] モバイルで雨天マニュアルの目次リンクをタップし、正しくスクロールすることを確認
- [ ] PCでも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)