### PR TITLE
update: Dockの下部パディングをさらに増加

### DIFF
--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -15,7 +15,7 @@ export default async function AuthenticatedLayout({
             {/* 小画面用のコンテンツラッパー */}
             <div className="lg:hidden flex flex-col min-h-dvh">
                 <Header />
-                <div className="flex-1 pb-20">{children}</div>
+                <div className="flex-1 pb-28">{children}</div>
             </div>
 
             {/* Bottom dock - 小画面のみ表示 */}

--- a/src/widgets/dock/ui/Dock.tsx
+++ b/src/widgets/dock/ui/Dock.tsx
@@ -10,7 +10,7 @@ export default function Dock() {
         <div
             className="dock dock-md fixed bottom-0 left-0 right-0 z-30 lg:hidden bg-base-100 border-t border-base-300 pt-9"
             style={{
-                paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 2.5rem)",
+                paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 4rem)",
             }}
         >
             <Link


### PR DESCRIPTION
## Summary
- Dockの下部パディングを2.5rem → 4remに増加
- コンテンツのpadding-bottomをpb-20 → pb-28に調整

## Test plan
- [ ] モバイル表示でDockが適切に表示されることを確認
- [ ] コンテンツがDockと重ならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)