### PR TITLE
feat: Microsoftアカウントのプロファイル画像を表示

### DIFF
--- a/app/(authenticated)/more/MoreClient.tsx
+++ b/app/(authenticated)/more/MoreClient.tsx
@@ -72,6 +72,7 @@ function formatTime(hour: number, minute: number): string {
 interface User {
     name?: string | null;
     email?: string | null;
+    image?: string | null;
 }
 
 interface MoreClientProps {
@@ -437,16 +438,25 @@ export default function MoreClient({ user }: MoreClientProps) {
                             </h2>
                             <div className="flex items-center gap-4 mt-2">
                                 <div className="avatar placeholder">
-                                    <div className="bg-primary text-primary-content rounded-full w-12 flex items-center justify-center">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            viewBox="0 0 448 512"
-                                            className="w-6 h-6"
-                                            fill="currentColor"
-                                        >
-                                            <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
-                                        </svg>
-                                    </div>
+                                    {user.image ? (
+                                        <div className="rounded-full w-12">
+                                            <img
+                                                src={user.image}
+                                                alt={user.name || "プロフィール画像"}
+                                            />
+                                        </div>
+                                    ) : (
+                                        <div className="bg-primary text-primary-content rounded-full w-12 flex items-center justify-center">
+                                            <svg
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                viewBox="0 0 448 512"
+                                                className="w-6 h-6"
+                                                fill="currentColor"
+                                            >
+                                                <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
+                                            </svg>
+                                        </div>
+                                    )}
                                 </div>
                                 <div className="flex-1 min-w-0">
                                     <p className="font-medium text-base truncate">

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,6 +3,30 @@ import MicrosoftEntraID from "next-auth/providers/microsoft-entra-id";
 
 const tenantId = process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID;
 
+// Microsoft Graph APIからプロファイル画像を取得
+const fetchProfileImage = async (
+    accessToken: string
+): Promise<string | null> => {
+    try {
+        const response = await fetch(
+            "https://graph.microsoft.com/v1.0/me/photo/$value",
+            {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+            }
+        );
+        if (!response.ok) return null;
+
+        const arrayBuffer = await response.arrayBuffer();
+        const base64 = Buffer.from(arrayBuffer).toString("base64");
+        const contentType = response.headers.get("content-type") || "image/jpeg";
+        return `data:${contentType};base64,${base64}`;
+    } catch {
+        return null;
+    }
+};
+
 // メールアドレスから学籍番号（最初の7文字）を抽出
 const extractStudentId = (email: string | null | undefined): string | null => {
     if (!email) return null;
@@ -58,17 +82,27 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
             return true;
         },
-        async jwt({ token, user }) {
-            // 初回ログイン時にstudentIdをトークンに追加
+        async jwt({ token, user, account }) {
+            // 初回ログイン時にstudentIdとプロファイル画像をトークンに追加
             if (user?.email) {
                 token.studentId = extractStudentId(user.email);
+            }
+            // アクセストークンでプロファイル画像を取得
+            if (account?.access_token) {
+                const image = await fetchProfileImage(account.access_token);
+                if (image) {
+                    token.picture = image;
+                }
             }
             return token;
         },
         async session({ session, token }) {
-            // セッションにstudentIdを追加
+            // セッションにstudentIdとプロファイル画像を追加
             if (token.studentId) {
                 session.studentId = token.studentId as string;
+            }
+            if (token.picture && session.user) {
+                session.user.image = token.picture as string;
             }
             return session;
         },

--- a/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/src/widgets/sidebar/ui/Sidebar.tsx
@@ -52,16 +52,28 @@ export default async function Sidebar({ children }: SidebarProps) {
                         <div className="p-4 border-t border-base-300 space-y-3">
                             <div className="flex items-center gap-3">
                                 <div className="avatar placeholder">
-                                    <div className="bg-primary text-primary-content rounded-full w-10 flex items-center justify-center">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            viewBox="0 0 448 512"
-                                            className="w-5 h-5"
-                                            fill="currentColor"
-                                        >
-                                            <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
-                                        </svg>
-                                    </div>
+                                    {session.user.image ? (
+                                        <div className="rounded-full w-10">
+                                            <img
+                                                src={session.user.image}
+                                                alt={
+                                                    session.user.name ||
+                                                    "プロフィール画像"
+                                                }
+                                            />
+                                        </div>
+                                    ) : (
+                                        <div className="bg-primary text-primary-content rounded-full w-10 flex items-center justify-center">
+                                            <svg
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                viewBox="0 0 448 512"
+                                                className="w-5 h-5"
+                                                fill="currentColor"
+                                            >
+                                                <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
+                                            </svg>
+                                        </div>
+                                    )}
                                 </div>
                                 <div className="flex-1 min-w-0">
                                     <p


### PR DESCRIPTION
## Summary
- Microsoft Graph APIを使用してプロファイル画像を取得
- ログイン時にプロファイル画像をセッションに保存
- MoreページとSidebarでプロファイル画像を表示（画像がない場合はデフォルトアイコン）

## Test plan
- [ ] 一度ログアウトして再ログインする
- [ ] Moreページでプロファイル画像が表示されることを確認
- [ ] Sidebarでプロファイル画像が表示されることを確認
- [ ] プロファイル画像が設定されていないアカウントではデフォルトアイコンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)