### PR TITLE
revert: プロファイル画像機能を元に戻す（Cookie容量超過対策）

### DIFF
--- a/app/(authenticated)/more/MoreClient.tsx
+++ b/app/(authenticated)/more/MoreClient.tsx
@@ -72,7 +72,6 @@ function formatTime(hour: number, minute: number): string {
 interface User {
     name?: string | null;
     email?: string | null;
-    image?: string | null;
 }
 
 interface MoreClientProps {
@@ -438,25 +437,16 @@ export default function MoreClient({ user }: MoreClientProps) {
                             </h2>
                             <div className="flex items-center gap-4 mt-2">
                                 <div className="avatar placeholder">
-                                    {user.image ? (
-                                        <div className="rounded-full w-12">
-                                            <img
-                                                src={user.image}
-                                                alt={user.name || "プロフィール画像"}
-                                            />
-                                        </div>
-                                    ) : (
-                                        <div className="bg-primary text-primary-content rounded-full w-12 flex items-center justify-center">
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                viewBox="0 0 448 512"
-                                                className="w-6 h-6"
-                                                fill="currentColor"
-                                            >
-                                                <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
-                                            </svg>
-                                        </div>
-                                    )}
+                                    <div className="bg-primary text-primary-content rounded-full w-12 flex items-center justify-center">
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            viewBox="0 0 448 512"
+                                            className="w-6 h-6"
+                                            fill="currentColor"
+                                        >
+                                            <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
+                                        </svg>
+                                    </div>
                                 </div>
                                 <div className="flex-1 min-w-0">
                                     <p className="font-medium text-base truncate">

--- a/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/src/widgets/sidebar/ui/Sidebar.tsx
@@ -52,28 +52,16 @@ export default async function Sidebar({ children }: SidebarProps) {
                         <div className="p-4 border-t border-base-300 space-y-3">
                             <div className="flex items-center gap-3">
                                 <div className="avatar placeholder">
-                                    {session.user.image ? (
-                                        <div className="rounded-full w-10">
-                                            <img
-                                                src={session.user.image}
-                                                alt={
-                                                    session.user.name ||
-                                                    "プロフィール画像"
-                                                }
-                                            />
-                                        </div>
-                                    ) : (
-                                        <div className="bg-primary text-primary-content rounded-full w-10 flex items-center justify-center">
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                viewBox="0 0 448 512"
-                                                className="w-5 h-5"
-                                                fill="currentColor"
-                                            >
-                                                <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
-                                            </svg>
-                                        </div>
-                                    )}
+                                    <div className="bg-primary text-primary-content rounded-full w-10 flex items-center justify-center">
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            viewBox="0 0 448 512"
+                                            className="w-5 h-5"
+                                            fill="currentColor"
+                                        >
+                                            <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
+                                        </svg>
+                                    </div>
                                 </div>
                                 <div className="flex-1 min-w-0">
                                     <p


### PR DESCRIPTION
## Summary
- プロファイル画像機能を元に戻す
- JWTセッションにBase64画像やアクセストークンを保存するとCookieサイズ制限を超えるため

## 原因
- HTTPステータス431 (Request Header Fields Too Large) が発生
- JWTセッションはCookieに保存されるため、大きなデータを保存できない

## 今後の対応
- プロファイル画像機能を実装するにはDBセッションへの移行が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)