### PR TITLE
feat: Microsoftプロファイル画像をlocalStorageに保存して表示

### DIFF
--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -4,8 +4,11 @@ import { AnalogClock } from "@/features/analog-clock";
 import { WeatherWidget } from "@/features/weather";
 import { ScheduleCard } from "@/features/schedule-card";
 import { DateDisplay } from "@/features/date-display";
+import { ProfileImageSaver } from "@/features/profile-image";
+import { auth } from "@/src/auth";
 
 export default async function HomePage() {
+    const session = await auth();
     let absences: Absence[] = [];
     let schedules: Schedule[] = [];
     let error: string | null = null;
@@ -82,8 +85,10 @@ export default async function HomePage() {
         });
 
     return (
-        <div className="p-4 sm:p-6 lg:p-10 max-w-full">
-            <h1
+        <>
+            <ProfileImageSaver profileImage={session?.profileImage} />
+            <div className="p-4 sm:p-6 lg:p-10 max-w-full">
+                <h1
                 className="font-bold mb-8 max-lg:hidden"
                 style={{ fontSize: "clamp(1.5rem, 4vw, 2.25rem)" }}
             >
@@ -442,6 +447,7 @@ export default async function HomePage() {
                     </div>
                 </div>
             </div>
-        </div>
+            </div>
+        </>
     );
 }

--- a/app/(authenticated)/more/MoreClient.tsx
+++ b/app/(authenticated)/more/MoreClient.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { signOut } from "next-auth/react";
 import packageJson from "@/package.json";
+import { ProfileAvatar } from "@/features/profile-image";
 
 interface BusTime {
     hour: number;
@@ -436,18 +437,7 @@ export default function MoreClient({ user }: MoreClientProps) {
                                 アカウント情報
                             </h2>
                             <div className="flex items-center gap-4 mt-2">
-                                <div className="avatar placeholder">
-                                    <div className="bg-primary text-primary-content rounded-full w-12 flex items-center justify-center">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            viewBox="0 0 448 512"
-                                            className="w-6 h-6"
-                                            fill="currentColor"
-                                        >
-                                            <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
-                                        </svg>
-                                    </div>
-                                </div>
+                                <ProfileAvatar name={user.name} size="md" />
                                 <div className="flex-1 min-w-0">
                                     <p className="font-medium text-base truncate">
                                         {user.name}

--- a/src/features/profile-image/ProfileAvatar.tsx
+++ b/src/features/profile-image/ProfileAvatar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getProfileImageKey } from "./ProfileImageSaver";
+
+interface ProfileAvatarProps {
+    name?: string | null;
+    size?: "sm" | "md";
+}
+
+export function ProfileAvatar({ name, size = "md" }: ProfileAvatarProps) {
+    const [imageUrl, setImageUrl] = useState<string | null>(null);
+    const sizeClass = size === "sm" ? "w-10" : "w-12";
+    const iconClass = size === "sm" ? "w-5 h-5" : "w-6 h-6";
+
+    useEffect(() => {
+        const image = localStorage.getItem(getProfileImageKey());
+        if (image) {
+            setImageUrl(image);
+        }
+    }, []);
+
+    return (
+        <div className="avatar placeholder">
+            {imageUrl ? (
+                <div className={`rounded-full ${sizeClass}`}>
+                    <img
+                        src={imageUrl}
+                        alt={name || "プロフィール画像"}
+                    />
+                </div>
+            ) : (
+                <div
+                    className={`bg-primary text-primary-content rounded-full ${sizeClass} flex items-center justify-center`}
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 448 512"
+                        className={iconClass}
+                        fill="currentColor"
+                    >
+                        <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
+                    </svg>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/features/profile-image/ProfileImageSaver.tsx
+++ b/src/features/profile-image/ProfileImageSaver.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+
+const PROFILE_IMAGE_KEY = "nb-portal-profile-image";
+
+interface ProfileImageSaverProps {
+    profileImage?: string | null;
+}
+
+export function ProfileImageSaver({ profileImage }: ProfileImageSaverProps) {
+    useEffect(() => {
+        if (profileImage) {
+            // localStorageに保存（まだ保存されていない場合のみ）
+            const existing = localStorage.getItem(PROFILE_IMAGE_KEY);
+            if (!existing) {
+                localStorage.setItem(PROFILE_IMAGE_KEY, profileImage);
+            }
+        }
+    }, [profileImage]);
+
+    return null;
+}
+
+export function useProfileImage(): string | null {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem(PROFILE_IMAGE_KEY);
+}
+
+export function getProfileImageKey(): string {
+    return PROFILE_IMAGE_KEY;
+}

--- a/src/features/profile-image/index.ts
+++ b/src/features/profile-image/index.ts
@@ -1,0 +1,6 @@
+export {
+    ProfileImageSaver,
+    useProfileImage,
+    getProfileImageKey,
+} from "./ProfileImageSaver";
+export { ProfileAvatar } from "./ProfileAvatar";

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -3,11 +3,14 @@ import "next-auth";
 declare module "next-auth" {
     interface Session {
         studentId?: string;
+        profileImage?: string;
     }
 }
 
 declare module "next-auth/jwt" {
     interface JWT {
         studentId?: string;
+        profileImage?: string;
+        profileImageFetched?: boolean;
     }
 }

--- a/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/src/widgets/sidebar/ui/Sidebar.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { ThemeToggle } from "@/features/theme-toggle";
+import { ProfileAvatar } from "@/features/profile-image";
 import { auth, signOut } from "@/src/auth";
 import { SidebarClient } from "./SidebarClient";
 import { SidebarNav } from "./SidebarNav";
@@ -51,18 +52,10 @@ export default async function Sidebar({ children }: SidebarProps) {
                     {session?.user && (
                         <div className="p-4 border-t border-base-300 space-y-3">
                             <div className="flex items-center gap-3">
-                                <div className="avatar placeholder">
-                                    <div className="bg-primary text-primary-content rounded-full w-10 flex items-center justify-center">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            viewBox="0 0 448 512"
-                                            className="w-5 h-5"
-                                            fill="currentColor"
-                                        >
-                                            <path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512l388.6 0c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304l-91.4 0z" />
-                                        </svg>
-                                    </div>
-                                </div>
+                                <ProfileAvatar
+                                    name={session.user.name}
+                                    size="sm"
+                                />
                                 <div className="flex-1 min-w-0">
                                     <p
                                         className="font-medium truncate"


### PR DESCRIPTION
## Summary
- ログイン時にMicrosoft Graph APIから96x96のプロファイル画像を取得
- 画像をlocalStorageに保存して以降はそこから読み込む
- MoreページとSidebarでProfileAvatarコンポーネントを使用

## 注意
- セッションに画像データを含めるため、Cookieサイズ制限（431エラー）が発生する可能性あり
- その場合は別の方法（DB/外部ストレージ）への移行が必要

## Test plan
- [ ] Cookieをクリアしてから再ログイン
- [ ] プロファイル画像が表示されることを確認
- [ ] 431エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)