### PR TITLE
fix: 通知許可を拒否してもトグルをオフ状態に維持

### DIFF
--- a/src/features/push-notification/ui/PushNotificationToggle.tsx
+++ b/src/features/push-notification/ui/PushNotificationToggle.tsx
@@ -91,7 +91,12 @@ export default function PushNotificationToggle({
             // 通知許可をリクエスト
             const permission = await Notification.requestPermission();
             if (permission !== "granted") {
-                setState("denied");
+                // ブラウザで完全にブロックされている場合のみdenied
+                // キャンセルや後での場合はunsubscribedのまま（再度オンにできる）
+                if (Notification.permission === "denied") {
+                    setState("denied");
+                }
+                // それ以外（default）はunsubscribedのまま
                 return;
             }
 


### PR DESCRIPTION
## Summary
- 通知許可ダイアログでキャンセルや後でを選んだ場合、トグルをオフ状態のまま維持
- ブラウザ設定で完全にブロックした場合のみ「ブロック中」表示
- 任意のタイミングで再度オンにできるように改善

## Test plan
- [ ] 通知許可ダイアログで「許可しない」を選んでもトグルがオフのままであることを確認
- [ ] 再度トグルをオンにすると許可ダイアログが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)