### PR TITLE
improve: ローディング表示をダッシュボードと同じスタイルに統一

### DIFF
--- a/app/(authenticated)/absence/loading.tsx
+++ b/app/(authenticated)/absence/loading.tsx
@@ -1,12 +1,19 @@
 export default function AbsenceLoading() {
     return (
-        <div className="p-6 max-w-4xl mx-auto">
-            <div className="h-9 w-32 bg-base-300 rounded-lg animate-pulse mb-6"></div>
+        <div className="p-4 lg:p-6 w-full">
+            <div className="max-w-4xl mx-auto">
+                {/* ヘッダー Skeleton */}
+                <div className="flex items-center gap-3 mb-6">
+                    <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                    <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse"></div>
+                </div>
 
-            <div className="card bg-base-100 shadow-xl border border-base-300">
-                <div className="card-body">
-                    <div className="flex items-center justify-center py-12">
-                        <span className="loading loading-spinner loading-lg text-primary"></span>
+                {/* フォーム Skeleton */}
+                <div className="card bg-base-100 shadow-xl border border-base-300">
+                    <div className="card-body">
+                        <div className="flex items-center justify-center py-12">
+                            <span className="loading loading-spinner loading-lg text-primary"></span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/(authenticated)/calendar/loading.tsx
+++ b/app/(authenticated)/calendar/loading.tsx
@@ -1,11 +1,14 @@
 export default function CalendarLoading() {
     return (
-        <div className="p-6 max-w-7xl mx-auto">
-            <div className="h-9 w-40 bg-base-300 rounded-lg animate-pulse mb-6"></div>
+        <div className="p-4 lg:p-6 w-full">
+            <div className="max-w-7xl mx-auto">
+                {/* ヘッダー Skeleton */}
+                <div className="flex items-center gap-3 mb-6">
+                    <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                    <div className="h-8 w-40 bg-base-300 rounded-lg animate-pulse"></div>
+                </div>
 
-            {/* スケジュール一覧 Skeleton */}
-            <section className="mb-8">
-                <div className="h-8 w-36 bg-base-300 rounded animate-pulse mb-4"></div>
+                {/* スケジュール一覧 Skeleton */}
                 <div className="card bg-base-100 shadow-xl border border-base-300">
                     <div className="card-body">
                         <div className="flex items-center justify-center py-12">
@@ -13,7 +16,7 @@ export default function CalendarLoading() {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
         </div>
     );
 }

--- a/app/(authenticated)/items/loading.tsx
+++ b/app/(authenticated)/items/loading.tsx
@@ -1,11 +1,14 @@
 export default function ItemsLoading() {
     return (
-        <div className="p-6 max-w-7xl mx-auto">
-            <div className="h-9 w-32 bg-base-300 rounded-lg animate-pulse mb-6"></div>
+        <div className="p-4 lg:p-6 w-full">
+            <div className="max-w-7xl mx-auto">
+                {/* ヘッダー Skeleton */}
+                <div className="flex items-center gap-3 mb-6">
+                    <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                    <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse"></div>
+                </div>
 
-            {/* 物品一覧 Skeleton */}
-            <section className="mb-8">
-                <div className="h-8 w-28 bg-base-300 rounded animate-pulse mb-4"></div>
+                {/* 物品一覧 Skeleton */}
                 <div className="card bg-base-100 shadow-xl border border-base-300">
                     <div className="card-body">
                         <div className="flex items-center justify-center py-12">
@@ -13,7 +16,7 @@ export default function ItemsLoading() {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
         </div>
     );
 }

--- a/app/(authenticated)/notifications/loading.tsx
+++ b/app/(authenticated)/notifications/loading.tsx
@@ -1,7 +1,51 @@
-export default function Loading() {
+export default function NotificationsLoading() {
     return (
-        <div className="p-4 lg:p-6 w-full h-full flex items-center justify-center">
-            <span className="loading loading-spinner loading-lg"></span>
+        <div className="p-4 lg:p-6 w-full">
+            <div className="max-w-4xl mx-auto">
+                {/* ヘッダー Skeleton */}
+                <div className="flex items-center gap-3 mb-6">
+                    <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                    <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse"></div>
+                </div>
+
+                {/* プッシュ通知設定 Skeleton */}
+                <div className="card bg-base-100 shadow-xl border border-base-300 mb-6">
+                    <div className="card-body p-4">
+                        <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-3">
+                                <div className="h-5 w-5 bg-base-300 rounded animate-pulse"></div>
+                                <div className="space-y-2">
+                                    <div className="h-4 w-24 bg-base-300 rounded animate-pulse"></div>
+                                    <div className="h-3 w-32 bg-base-300 rounded animate-pulse"></div>
+                                </div>
+                            </div>
+                            <div className="h-6 w-12 bg-base-300 rounded-full animate-pulse"></div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* 通知一覧 Skeleton */}
+                <div className="space-y-3">
+                    {[...Array(3)].map((_, i) => (
+                        <div
+                            key={i}
+                            className="card bg-base-100 shadow-xl border border-base-300"
+                        >
+                            <div className="card-body p-4">
+                                <div className="flex items-start gap-3">
+                                    <div className="h-9 w-9 bg-base-300 rounded-lg animate-pulse"></div>
+                                    <div className="flex-1 space-y-2">
+                                        <div className="h-4 w-3/4 bg-base-300 rounded animate-pulse"></div>
+                                        <div className="h-5 w-1/2 bg-base-300 rounded animate-pulse"></div>
+                                        <div className="h-3 w-24 bg-base-300 rounded animate-pulse"></div>
+                                    </div>
+                                    <div className="h-3 w-12 bg-base-300 rounded animate-pulse"></div>
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- 各ページのローディング表示をダッシュボードと同じスタイルに統一
- カード（shadow-xl border border-base-300）を使用したスケルトン表示
- 見出しにアイコンスケルトンを追加

## 対象ページ
- absence
- calendar
- items
- notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)