### PR TITLE
refactor: 全ページのローディング表示をスケルトンスタイルに統一

### DIFF
--- a/app/(authenticated)/bus/loading.tsx
+++ b/app/(authenticated)/bus/loading.tsx
@@ -1,0 +1,22 @@
+export default function BusLoading() {
+    return (
+        <div className="p-4 lg:p-6 w-full">
+            <div className="max-w-4xl mx-auto">
+                {/* ヘッダー Skeleton */}
+                <div className="flex items-center gap-3 mb-6">
+                    <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                    <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse"></div>
+                </div>
+
+                {/* バスダイヤ Skeleton */}
+                <div className="card bg-base-100 shadow-xl border border-base-300">
+                    <div className="card-body">
+                        <div className="flex items-center justify-center py-12">
+                            <span className="loading loading-spinner loading-lg text-primary"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/(authenticated)/bus/page.tsx
+++ b/app/(authenticated)/bus/page.tsx
@@ -63,8 +63,23 @@ export default function BusSchedulePage() {
 
     if (isLoading) {
         return (
-            <div className="p-4 lg:p-6 w-full h-full flex items-center justify-center">
-                <span className="loading loading-spinner loading-lg"></span>
+            <div className="p-4 lg:p-6 w-full">
+                <div className="max-w-4xl mx-auto">
+                    {/* ヘッダー Skeleton */}
+                    <div className="flex items-center gap-3 mb-6">
+                        <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                        <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse"></div>
+                    </div>
+
+                    {/* バスダイヤ Skeleton */}
+                    <div className="card bg-base-100 shadow-xl border border-base-300">
+                        <div className="card-body">
+                            <div className="flex items-center justify-center py-12">
+                                <span className="loading loading-spinner loading-lg text-primary"></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -687,8 +687,23 @@ export default function CalendarPage() {
 
     if (isLoading) {
         return (
-            <div className="p-4 lg:p-6 w-full h-full flex items-center justify-center">
-                <span className="loading loading-spinner loading-lg"></span>
+            <div className="p-4 lg:p-6 w-full">
+                <div className="max-w-7xl mx-auto">
+                    {/* ヘッダー Skeleton */}
+                    <div className="flex items-center gap-3 mb-6">
+                        <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                        <div className="h-8 w-40 bg-base-300 rounded-lg animate-pulse"></div>
+                    </div>
+
+                    {/* スケジュール一覧 Skeleton */}
+                    <div className="card bg-base-100 shadow-xl border border-base-300">
+                        <div className="card-body">
+                            <div className="flex items-center justify-center py-12">
+                                <span className="loading loading-spinner loading-lg text-primary"></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/app/(authenticated)/items/page.tsx
+++ b/app/(authenticated)/items/page.tsx
@@ -116,8 +116,23 @@ export default function ItemsPage() {
 
     if (isLoading) {
         return (
-            <div className="p-4 lg:p-6 w-full h-full flex items-center justify-center">
-                <span className="loading loading-spinner loading-lg"></span>
+            <div className="p-4 lg:p-6 w-full">
+                <div className="max-w-7xl mx-auto">
+                    {/* ヘッダー Skeleton */}
+                    <div className="flex items-center gap-3 mb-6">
+                        <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                        <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse"></div>
+                    </div>
+
+                    {/* 物品一覧 Skeleton */}
+                    <div className="card bg-base-100 shadow-xl border border-base-300">
+                        <div className="card-body">
+                            <div className="flex items-center justify-center py-12">
+                                <span className="loading loading-spinner loading-lg text-primary"></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/app/(authenticated)/notifications/NotificationsContent.tsx
+++ b/app/(authenticated)/notifications/NotificationsContent.tsx
@@ -65,8 +65,52 @@ export function NotificationsContent({ userEmail }: NotificationsContentProps) {
 
     if (isLoading) {
         return (
-            <div className="p-4 lg:p-6 w-full h-full flex items-center justify-center">
-                <span className="loading loading-spinner loading-lg"></span>
+            <div className="p-4 lg:p-6 w-full">
+                <div className="max-w-4xl mx-auto">
+                    {/* ヘッダー Skeleton */}
+                    <div className="flex items-center gap-3 mb-6">
+                        <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
+                        <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse"></div>
+                    </div>
+
+                    {/* プッシュ通知設定 Skeleton */}
+                    <div className="card bg-base-100 shadow-xl border border-base-300 mb-6">
+                        <div className="card-body p-4">
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-3">
+                                    <div className="h-5 w-5 bg-base-300 rounded animate-pulse"></div>
+                                    <div className="space-y-2">
+                                        <div className="h-4 w-24 bg-base-300 rounded animate-pulse"></div>
+                                        <div className="h-3 w-32 bg-base-300 rounded animate-pulse"></div>
+                                    </div>
+                                </div>
+                                <div className="h-6 w-12 bg-base-300 rounded-full animate-pulse"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* 通知一覧 Skeleton */}
+                    <div className="space-y-3">
+                        {[...Array(3)].map((_, i) => (
+                            <div
+                                key={i}
+                                className="card bg-base-100 shadow-xl border border-base-300"
+                            >
+                                <div className="card-body p-4">
+                                    <div className="flex items-start gap-3">
+                                        <div className="h-9 w-9 bg-base-300 rounded-lg animate-pulse"></div>
+                                        <div className="flex-1 space-y-2">
+                                            <div className="h-4 w-3/4 bg-base-300 rounded animate-pulse"></div>
+                                            <div className="h-5 w-1/2 bg-base-300 rounded animate-pulse"></div>
+                                            <div className="h-3 w-24 bg-base-300 rounded animate-pulse"></div>
+                                        </div>
+                                        <div className="h-3 w-12 bg-base-300 rounded animate-pulse"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
## Summary
- 全ページのクライアント側ローディング状態をスケルトン+カードスタイルに統一
- bus/loading.tsx を新規作成
- サーバー側loading.tsxとクライアント側isLoading状態の見た目を一致させ、切り替わり時の違和感を解消

## Test plan
- [ ] 各ページ（items, bus, calendar, notifications）の初回ロード時にスケルトン表示を確認
- [ ] クライアント側のデータフェッチ中も同じスケルトンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)