### PR TITLE
update: 画像ビューアのダブルクリック/タップズームの説明を削除

### DIFF
--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -369,12 +369,9 @@ function ZoomableImage({ src, alt }: { src: string; alt: string }) {
                     </button>
                     <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-gray-500 text-sm text-center">
                         <span className="hidden lg:inline">
-                            ホイールで拡大・縮小 / ダブルクリックで3倍ズーム /
-                            ドラッグで移動
+                            ホイールで拡大・縮小 / ドラッグで移動
                         </span>
-                        <span className="lg:hidden">
-                            ピンチで拡大・縮小 / ダブルタップで3倍ズーム
-                        </span>
+                        <span className="lg:hidden">ピンチで拡大・縮小</span>
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Summary
- 画像ビューアのヘルプテキストからダブルクリック/ダブルタップでの3倍ズーム説明を削除
- PC: ホイールで拡大・縮小 / ドラッグで移動
- モバイル: ピンチで拡大・縮小

## Test plan
- [ ] 画像ビューアを開いて説明テキストが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)