### PR TITLE
fix: PDFファイルのX-Frame-OptionsをSAMEORIGINに変更

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,6 +35,16 @@ const nextConfig: NextConfig = {
                 source: "/:path*",
                 headers: securityHeaders,
             },
+            {
+                // PDFファイルはiframeでの表示を同一オリジンから許可
+                source: "/documents/:path*.pdf",
+                headers: [
+                    {
+                        key: "X-Frame-Options",
+                        value: "SAMEORIGIN",
+                    },
+                ],
+            },
         ];
     },
 };


### PR DESCRIPTION
## Summary

- iframeでPDFを表示する際に「接続が拒否されました」エラーが発生していた問題を修正
- `/documents/*.pdf`のX-Frame-OptionsをDENYからSAMEORIGINに変更

## 原因

セキュリティヘッダー追加時に全ページにX-Frame-Options: DENYを設定したため、
同一オリジン内のiframeでもPDFが表示できなくなっていた

## Test plan

- [ ] PC版でドキュメントページから「機材構成表」を開けること