### PR TITLE
fix: window.location.originの使用を削除

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -8,17 +8,19 @@ async function fetchFromGAS<T>(
     path: string,
     params?: Record<string, string>
 ): Promise<ApiResponse<T>> {
-    const url = new URL("/api/gas", window.location.origin);
-    url.searchParams.append("path", path);
+    const searchParams = new URLSearchParams();
+    searchParams.append("path", path);
 
     if (params) {
         Object.entries(params).forEach(([key, value]) => {
-            url.searchParams.append(key, value);
+            searchParams.append(key, value);
         });
     }
 
+    const url = `/api/gas?${searchParams.toString()}`;
+
     try {
-        const response = await fetch(url.toString(), {
+        const response = await fetch(url, {
             method: "GET",
             headers: {
                 "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- サーバーサイドレンダリング時に「window is not defined」エラーが発生していた問題を修正
- `window.location.origin`の代わりに相対パスを使用

## Test plan

- [ ] PC画面でページが正常に表示されること
- [ ] カレンダー、機材一覧、お知らせページが動作すること