### PR TITLE
fix: 予定詳細のインデントをサンプルに合わせて修正

### DIFF
--- a/src/features/meeting-memo/ui/MeetingMemoForm.tsx
+++ b/src/features/meeting-memo/ui/MeetingMemoForm.tsx
@@ -114,7 +114,7 @@ export function MeetingMemoForm() {
                           }
                           const detailLines = item.details
                               .split("\n")
-                              .map((line) => `    ${line}`)
+                              .map((line) => `    　${line}`)
                               .join("\n");
                           return `${titleLine}\n${detailLines}`;
                       })


### PR DESCRIPTION
## Summary
- 予定詳細のインデントを「4スペース + 全角スペース」に修正
- サンプルメモのフォーマットに準拠

## Test plan
- [ ] 予定に詳細を入力してプレビューを確認
- [ ] 出力されるマークダウンが「    　詳細」の形式になっていることを確認