### PR TITLE
fix: 予定詳細を入れ子リスト形式に修正

### DIFF
--- a/src/features/meeting-memo/ui/MeetingMemoForm.tsx
+++ b/src/features/meeting-memo/ui/MeetingMemoForm.tsx
@@ -114,7 +114,7 @@ export function MeetingMemoForm() {
                           }
                           const detailLines = item.details
                               .split("\n")
-                              .map((line) => `    　${line}`)
+                              .map((line) => `    -   ${line}`)
                               .join("\n");
                           return `${titleLine}\n${detailLines}`;
                       })


### PR DESCRIPTION
## Summary
- 詳細行を入れ子リスト形式「    -   内容」に変更

## 出力例
```
-   1/31(土), 2/1(日), 2/2(月) でぃめじゃんリハ兼講習会
    -   ( **予定** )
    -   でぃめじゃんリハをやってる隣で 1, 2 年が講習会を行う形
```