### PR TITLE
fix: 欠席連絡のバリデーションスキーマの種別値を修正

### DIFF
--- a/src/shared/lib/validation.ts
+++ b/src/shared/lib/validation.ts
@@ -14,7 +14,7 @@ export const absenceSubmitSchema = z.object({
         .max(20, "学籍番号が長すぎます")
         .regex(/^[A-Za-z0-9-]+$/, "学籍番号の形式が不正です"),
     name: z.string().min(1, "名前は必須です").max(50, "名前が長すぎます"),
-    type: z.enum(["absence", "late", "stepOut", "earlyLeave"], {
+    type: z.enum(["欠席", "遅刻", "中抜け", "早退"], {
         error: "無効な欠席種別です",
     }),
     reason: z.string().min(1, "理由は必須です").max(500, "理由が長すぎます"),


### PR DESCRIPTION
## 概要

- 欠席連絡送信時に400エラーが発生するバグを修正
- バリデーションスキーマの `type` enum値が英語（`absence`, `late`, `stepOut`, `earlyLeave`）だったため、フロントエンドとGASが使用する日本語値（`欠席`, `遅刻`, `中抜け`, `早退`）と不一致だった

## 変更内容

- `src/shared/lib/validation.ts`: `absenceSubmitSchema` の `type` enumを日本語値に修正

## テスト

- TypeScript型チェック: 成功