### PR TITLE
change: 欠席連絡の理由を選択式に変更 (v1.6.0)

### DIFF
--- a/app/(authenticated)/absence/page.tsx
+++ b/app/(authenticated)/absence/page.tsx
@@ -13,7 +13,8 @@ function AbsenceFormContent() {
         studentNumber: "",
         name: "",
         type: "",
-        reason: "",
+        reasonCategory: "",
+        reasonDetail: "",
         isStepOut: false,
         timeStepOut: "",
         timeReturn: "",
@@ -39,7 +40,8 @@ function AbsenceFormContent() {
                 studentNumber: formData.studentNumber,
                 name: formData.name,
                 type: formData.type,
-                reason: formData.reason,
+                reason: formData.reasonCategory,
+                reasonDetail: formData.reasonDetail || undefined,
                 timeStepOut: formData.timeStepOut || undefined,
                 timeReturn: formData.timeReturn || undefined,
                 timeLeavingEarly: formData.timeLeavingEarly || undefined,
@@ -56,7 +58,8 @@ function AbsenceFormContent() {
                     studentNumber: "",
                     name: "",
                     type: "",
-                    reason: "",
+                    reasonCategory: "",
+                    reasonDetail: "",
                     isStepOut: false,
                     timeStepOut: "",
                     timeReturn: "",
@@ -196,7 +199,7 @@ function AbsenceFormContent() {
                             </select>
                         </div>
 
-                        {/* 理由 */}
+                        {/* 理由カテゴリ */}
                         <div className="form-control">
                             <label className="label">
                                 <span
@@ -208,18 +211,56 @@ function AbsenceFormContent() {
                                     理由 <span className="text-error">*</span>
                                 </span>
                             </label>
-                            <textarea
-                                placeholder="欠席・遅刻の理由を入力してください"
-                                className="textarea textarea-bordered w-full h-24"
-                                value={formData.reason}
+                            <select
+                                className="select select-bordered w-full"
+                                value={formData.reasonCategory}
                                 onChange={(e) =>
                                     setFormData({
                                         ...formData,
-                                        reason: e.target.value,
+                                        reasonCategory: e.target.value,
                                     })
                                 }
                                 required
+                            >
+                                <option value="">選択してください</option>
+                                <option value="体調不良">体調不良</option>
+                                <option value="授業">授業</option>
+                                <option value="家庭の都合">家庭の都合</option>
+                                <option value="その他">その他</option>
+                            </select>
+                        </div>
+
+                        {/* 詳細（任意） */}
+                        <div className="form-control">
+                            <label className="label">
+                                <span
+                                    className="label-text font-semibold"
+                                    style={{
+                                        fontSize: "clamp(0.875rem, 2vw, 1rem)",
+                                    }}
+                                >
+                                    詳細
+                                    <span className="text-base-content/50 font-normal ml-2">
+                                        任意
+                                    </span>
+                                </span>
+                            </label>
+                            <textarea
+                                placeholder="補足があれば入力してください"
+                                className="textarea textarea-bordered w-full h-24"
+                                value={formData.reasonDetail}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        reasonDetail: e.target.value,
+                                    })
+                                }
                             />
+                            <label className="label">
+                                <span className="label-text-alt text-base-content/50">
+                                    詳細はスプレッドシートにのみ記録されます
+                                </span>
+                            </label>
                         </div>
 
                         {/* 中抜けの場合 */}

--- a/gas/main.js
+++ b/gas/main.js
@@ -1163,6 +1163,7 @@ const handlePostAbsence = (postData) => {
             name,
             type,
             reason,
+            reasonDetail,
             timeStepOut,
             timeReturn,
             timeLeavingEarly,
@@ -1188,7 +1189,7 @@ const handlePostAbsence = (postData) => {
             "yyyy/MM/dd HH:mm:ss"
         );
 
-        // 列順: A:タイムスタンプ, B:EVENT_ID, C:学籍番号, D:氏名, E:種別, F:理由, G:早退時間, H:抜ける時間, I:戻る時間
+        // 列順: A:タイムスタンプ, B:EVENT_ID, C:学籍番号, D:氏名, E:種別, F:理由, G:詳細, H:早退時間, I:抜ける時間, J:戻る時間
         const rowData = [
             timestamp,
             eventId,
@@ -1196,6 +1197,7 @@ const handlePostAbsence = (postData) => {
             name,
             type,
             reason,
+            reasonDetail || "",
             timeLeavingEarly || "",
             timeStepOut || "",
             timeReturn || "",
@@ -1208,7 +1210,7 @@ const handlePostAbsence = (postData) => {
             PropertiesService.getScriptProperties().getProperty("WEBHOOK_URL");
 
         if (webhookURL) {
-            let body = `**新しい欠席連絡**\n`;
+            let body = `**欠席連絡**\n`;
             body += `**氏名**: ${name}\n`;
             body += `**種別**: ${type}`;
 
@@ -1243,6 +1245,9 @@ const handlePostAbsence = (postData) => {
             }
 
             bodyText += `\n理由: ${reason}\n`;
+            if (reasonDetail) {
+                bodyText += `詳細: ${reasonDetail}\n`;
+            }
             bodyText += `\n送信日時: ${timestamp}\n`;
 
             MailApp.sendEmail(email, subject, bodyText, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -79,6 +79,7 @@ export interface AbsenceSubmitData {
     name: string;
     type: string;
     reason: string;
+    reasonDetail?: string;
     timeStepOut?: string;
     timeReturn?: string;
     timeLeavingEarly?: string;

--- a/src/shared/lib/validation.ts
+++ b/src/shared/lib/validation.ts
@@ -17,7 +17,10 @@ export const absenceSubmitSchema = z.object({
     type: z.enum(["欠席", "遅刻", "中抜け", "早退"], {
         error: "無効な欠席種別です",
     }),
-    reason: z.string().min(1, "理由は必須です").max(500, "理由が長すぎます"),
+    reason: z.enum(["体調不良", "授業", "家庭の都合", "その他"], {
+        error: "無効な理由カテゴリです",
+    }),
+    reasonDetail: z.string().max(500, "詳細が長すぎます").optional(),
     timeStepOut: z.string().max(10).optional(),
     timeReturn: z.string().max(10).optional(),
     timeLeavingEarly: z.string().max(10).optional(),


### PR DESCRIPTION
## 概要

- 欠席連絡の理由フィールドを自由入力からカテゴリ選択式に変更
- プライバシーに配慮し、Discordにはカテゴリのみ通知
- バージョンを1.6.0に更新

## 変更内容

- **フロントエンド**: 理由をセレクト(体調不良/授業/家庭の都合/その他)に変更、任意の詳細テキストエリアを追加
- **バリデーション**: reasonをenum化、reasonDetailを任意フィールドとして追加
- **APIクライアント**: AbsenceSubmitDataにreasonDetailフィールド追加
- **GAS**: スプレッドシートに詳細列(G列)を追加、Discord通知はカテゴリのみ、メール通知には詳細も含める

## 通知先ごとの表示内容

| 通知先 | 理由カテゴリ | 詳細 |
|---|---|---|
| Discord | 表示 | 非表示 |
| メール(本人宛) | 表示 | 表示 |
| スプレッドシート | 表示 | 表示 |