### PR TITLE
カレンダー取得を定期更新する

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -4,6 +4,10 @@ import { useEffect, useState } from "react";
 import { ScheduleCard } from "@/features/schedule-card";
 import type { Absence } from "@/src/shared/types/api";
 import { HelpButton } from "@/src/features/help";
+import {
+    getClientCache,
+    setClientCache,
+} from "@/src/shared/lib/client-cache";
 
 // イベントカラーの定義
 export const EVENT_COLORS = [
@@ -61,6 +65,9 @@ interface EventForm {
     color: EventColorId;
 }
 
+const CALENDAR_CACHE_KEY = "nb-portal-calendar-cache";
+const CALENDAR_CACHE_TTL = 5 * 60 * 1000;
+
 export default function CalendarPage() {
     const [schedules, setSchedules] = useState<Schedule[]>([]);
     const [absences, setAbsences] = useState<Absence[]>([]);
@@ -108,36 +115,89 @@ export default function CalendarPage() {
     });
 
     useEffect(() => {
-        const fetchData = async () => {
+        let isCancelled = false;
+
+        const cached = getClientCache<{
+            schedules: Schedule[];
+            absences: Absence[];
+        }>(CALENDAR_CACHE_KEY, CALENDAR_CACHE_TTL);
+
+        if (cached) {
+            setSchedules(cached.schedules);
+            setAbsences(cached.absences);
+            setIsLoading(false);
+        }
+
+        const fetchData = async (showLoading: boolean) => {
+            if (showLoading) {
+                setIsLoading(true);
+            }
+
             try {
-                // API Routes経由でGAS APIにアクセス
+                // キャッシュを表示していても、裏で必ず最新データを取得する
                 const [schedulesRes, absencesRes] = await Promise.all([
-                    fetch("/api/gas?path=schedules"),
-                    fetch("/api/gas?path=absences"),
+                    fetch("/api/gas?path=schedules", { cache: "no-store" }),
+                    fetch("/api/gas?path=absences", { cache: "no-store" }),
                 ]);
                 const schedulesData = await schedulesRes.json();
                 const absencesData = await absencesRes.json();
+
+                if (isCancelled) return;
+
                 if (schedulesData.success) {
-                    setSchedules(schedulesData.data || []);
+                    const nextSchedules = schedulesData.data || [];
+                    const nextAbsences = absencesData.success
+                        ? absencesData.data || []
+                        : [];
+                    setSchedules(nextSchedules);
+                    setAbsences(nextAbsences);
+                    setError(null);
+                    setClientCache(CALENDAR_CACHE_KEY, {
+                        schedules: nextSchedules,
+                        absences: nextAbsences,
+                    });
                 } else {
                     setError(
                         schedulesData.error || "データの取得に失敗しました"
                     );
                 }
-                if (absencesData.success) {
-                    setAbsences(absencesData.data || []);
-                }
             } catch (err) {
+                if (isCancelled) return;
+
                 setError(
                     err instanceof Error
                         ? err.message
                         : "データの取得に失敗しました"
                 );
             } finally {
-                setIsLoading(false);
+                if (!isCancelled) {
+                    setIsLoading(false);
+                }
             }
         };
-        fetchData();
+
+        void fetchData(!cached);
+
+        const interval = setInterval(() => {
+            void fetchData(false);
+        }, 60 * 1000);
+
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === "visible") {
+                void fetchData(false);
+            }
+        };
+
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+
+        return () => {
+            isCancelled = true;
+            clearInterval(interval);
+            document.removeEventListener(
+                "visibilitychange",
+                handleVisibilityChange
+            );
+        };
     }, []);
 
     // 活動日のマップを作成（YYYY-MM-DD形式 -> イベント数）
@@ -331,7 +391,14 @@ export default function CalendarPage() {
                     END_DD: data.data.endDate || "",
                     COLOR: data.data.color || "primary",
                 };
-                setSchedules((prev) => [...prev, newSchedule]);
+                setSchedules((prev) => {
+                    const next = [...prev, newSchedule];
+                    setClientCache(CALENDAR_CACHE_KEY, {
+                        schedules: next,
+                        absences,
+                    });
+                    return next;
+                });
 
                 // モーダルを閉じる
                 closeModal();
@@ -464,12 +531,17 @@ export default function CalendarPage() {
 
             if (data.success) {
                 // ローカル状態から削除
-                setSchedules((prev) =>
-                    prev.filter((schedule) => {
+                setSchedules((prev) => {
+                    const next = prev.filter((schedule) => {
                         const scheduleValues = Object.values(schedule);
                         return String(scheduleValues[0]) !== eventId;
-                    })
-                );
+                    });
+                    setClientCache(CALENDAR_CACHE_KEY, {
+                        schedules: next,
+                        absences,
+                    });
+                    return next;
+                });
 
                 // モーダルを閉じる
                 closeEditModal();
@@ -524,8 +596,8 @@ export default function CalendarPage() {
 
             if (data.success) {
                 // ローカル状態を更新
-                setSchedules((prev) =>
-                    prev.map((schedule) => {
+                setSchedules((prev) => {
+                    const next = prev.map((schedule) => {
                         const scheduleValues = Object.values(schedule);
                         if (String(scheduleValues[0]) === eventId) {
                             return {
@@ -545,8 +617,13 @@ export default function CalendarPage() {
                             };
                         }
                         return schedule;
-                    })
-                );
+                    });
+                    setClientCache(CALENDAR_CACHE_KEY, {
+                        schedules: next,
+                        absences,
+                    });
+                    return next;
+                });
 
                 // 編集モーダルと詳細モーダルを閉じる（日付が変わった可能性があるため）
                 closeEditModal();

--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { auth } from "@/src/auth";
 
 const GAS_API_URL = process.env.NEXT_PUBLIC_GAS_API_URL;
@@ -50,6 +51,11 @@ export async function POST(request: NextRequest) {
 
         const data = await response.json();
 
+        if (data?.success === true) {
+            revalidateTag("schedules", "max");
+            revalidateTag("notifications", "max");
+        }
+
         return NextResponse.json(data);
     } catch (error) {
         console.error("API route error:", error);
@@ -96,6 +102,11 @@ export async function DELETE(request: NextRequest) {
         });
 
         const data = await response.json();
+
+        if (data?.success === true) {
+            revalidateTag("schedules", "max");
+            revalidateTag("notifications", "max");
+        }
 
         return NextResponse.json(data);
     } catch (error) {
@@ -149,6 +160,11 @@ export async function PUT(request: NextRequest) {
         });
 
         const data = await response.json();
+
+        if (data?.success === true) {
+            revalidateTag("schedules", "max");
+            revalidateTag("notifications", "max");
+        }
 
         return NextResponse.json(data);
     } catch (error) {

--- a/src/shared/lib/client-cache.ts
+++ b/src/shared/lib/client-cache.ts
@@ -1,0 +1,46 @@
+"use client";
+
+interface CachedData<T> {
+    data: T;
+    timestamp: number;
+}
+
+export function getClientCache<T>(key: string, ttlMs: number): T | null {
+    if (typeof window === "undefined") return null;
+
+    try {
+        const cached = sessionStorage.getItem(key);
+        if (!cached) return null;
+
+        const parsed = JSON.parse(cached) as CachedData<T>;
+        if (Date.now() - parsed.timestamp > ttlMs) {
+            sessionStorage.removeItem(key);
+            return null;
+        }
+
+        return parsed.data;
+    } catch {
+        return null;
+    }
+}
+
+export function setClientCache<T>(key: string, data: T): void {
+    if (typeof window === "undefined") return;
+
+    try {
+        sessionStorage.setItem(
+            key,
+            JSON.stringify({
+                data,
+                timestamp: Date.now(),
+            } satisfies CachedData<T>)
+        );
+    } catch {
+        // セッションストレージに保存できない場合は無視
+    }
+}
+
+export function clearClientCache(key: string): void {
+    if (typeof window === "undefined") return;
+    sessionStorage.removeItem(key);
+}


### PR DESCRIPTION
## 概要
- カレンダー表示でキャッシュ表示後も裏で最新データを再取得
- 1 分ごとの定期更新とタブ復帰時の再取得を追加
- 取得キャッシュ用のクライアントユーティリティを追加

## 確認
- 
> nb-portal@1.6.2 build
> next build

▲ Next.js 16.1.1 (Turbopack)

  Creating an optimized production build ...
/*! 🌼 daisyUI 5.5.8 */
✓ Compiled successfully in 7.0s
  Running TypeScript ...
  Collecting page data using 9 workers ... を実行
- 既存の VAPID 環境変数未設定により  でビルド失敗することを確認
- カレンダー差分起因のビルドエラーは確認されず