### PR TITLE
通知とデータ更新の再検証を追加

### DIFF
--- a/app/(authenticated)/notifications/NotificationsContent.tsx
+++ b/app/(authenticated)/notifications/NotificationsContent.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState } from "react";
 import { PushNotificationToggle } from "@/src/features/push-notification";
 import { HelpButton } from "@/src/features/help";
+import {
+    getClientCache,
+    setClientCache,
+} from "@/src/shared/lib/client-cache";
 
 interface Notification {
     eventId: string;
@@ -18,6 +22,9 @@ interface NotificationsContentProps {
     userEmail: string | null;
 }
 
+const NOTIFICATIONS_CACHE_KEY = "nb-portal-notifications-cache";
+const NOTIFICATIONS_CACHE_TTL = 5 * 60 * 1000;
+
 export function NotificationsContent({ userEmail }: NotificationsContentProps) {
     const [notifications, setNotifications] = useState<Notification[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -25,11 +32,26 @@ export function NotificationsContent({ userEmail }: NotificationsContentProps) {
 
     useEffect(() => {
         const fetchNotifications = async () => {
+            const cached = getClientCache<Notification[]>(
+                NOTIFICATIONS_CACHE_KEY,
+                NOTIFICATIONS_CACHE_TTL
+            );
+            if (cached) {
+                setNotifications(cached);
+                setIsLoading(false);
+                return;
+            }
+
             try {
                 const res = await fetch("/api/gas?path=notifications&limit=50");
                 const data = await res.json();
                 if (data.success) {
-                    setNotifications(data.data || []);
+                    const nextNotifications = data.data || [];
+                    setNotifications(nextNotifications);
+                    setClientCache(
+                        NOTIFICATIONS_CACHE_KEY,
+                        nextNotifications
+                    );
                 } else {
                     setError(data.error || "データの取得に失敗しました");
                 }

--- a/app/api/absence/route.ts
+++ b/app/api/absence/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { auth } from "@/src/auth";
 import {
     absenceSubmitSchema,
@@ -70,6 +71,10 @@ export async function POST(request: NextRequest) {
         });
 
         const data = await response.json();
+
+        if (data?.success === true) {
+            revalidateTag("absences", "max");
+        }
 
         return NextResponse.json(data);
     } catch (error) {

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { auth } from "@/src/auth";
 import {
     itemCreateSchema,
@@ -54,6 +55,9 @@ export async function POST(request: NextRequest) {
         });
 
         const data = await response.json();
+        if (data?.success === true) {
+            revalidateTag("items", "max");
+        }
         return NextResponse.json(data);
     } catch (error) {
         console.error("API route error:", error);
@@ -112,6 +116,9 @@ export async function PUT(request: NextRequest) {
         });
 
         const data = await response.json();
+        if (data?.success === true) {
+            revalidateTag("items", "max");
+        }
         return NextResponse.json(data);
     } catch (error) {
         console.error("API route error:", error);
@@ -170,6 +177,9 @@ export async function DELETE(request: NextRequest) {
         });
 
         const data = await response.json();
+        if (data?.success === true) {
+            revalidateTag("items", "max");
+        }
         return NextResponse.json(data);
     } catch (error) {
         console.error("API route error:", error);


### PR DESCRIPTION
## 概要
- 通知一覧に sessionStorage キャッシュを追加
- 欠席送信後に absences タグを revalidate
- 機材の追加・更新・削除後に items タグを revalidate

## 確認
- npm run build を実行
- 既存の VAPID 環境変数未設定により api/push-send でビルド失敗することを確認
- 今回の差分起因のビルドエラーは確認されず