### PR TITLE
GASへの再取得を減らす

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ScheduleCard } from "@/features/schedule-card";
 import type { Absence } from "@/src/shared/types/api";
 import { HelpButton } from "@/src/features/help";
 import {
-    getClientCache,
+    getClientCacheEntry,
     setClientCache,
 } from "@/src/shared/lib/client-cache";
 
@@ -67,6 +67,8 @@ interface EventForm {
 
 const CALENDAR_CACHE_KEY = "nb-portal-calendar-cache";
 const CALENDAR_CACHE_TTL = 5 * 60 * 1000;
+const CALENDAR_REFRESH_INTERVAL = 5 * 60 * 1000;
+const CALENDAR_REFETCH_COOLDOWN = 60 * 1000;
 
 export default function CalendarPage() {
     const [schedules, setSchedules] = useState<Schedule[]>([]);
@@ -83,6 +85,7 @@ export default function CalendarPage() {
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
+    const lastFetchAtRef = useRef(0);
     const [addForm, setAddForm] = useState<EventForm>({
         title: "",
         where: "",
@@ -117,18 +120,30 @@ export default function CalendarPage() {
     useEffect(() => {
         let isCancelled = false;
 
-        const cached = getClientCache<{
+        const cached = getClientCacheEntry<{
             schedules: Schedule[];
             absences: Absence[];
         }>(CALENDAR_CACHE_KEY, CALENDAR_CACHE_TTL);
 
         if (cached) {
-            setSchedules(cached.schedules);
-            setAbsences(cached.absences);
+            setSchedules(cached.data.schedules);
+            setAbsences(cached.data.absences);
             setIsLoading(false);
+            lastFetchAtRef.current = cached.timestamp;
         }
 
-        const fetchData = async (showLoading: boolean) => {
+        const fetchData = async (
+            showLoading: boolean,
+            force = false
+        ) => {
+            const now = Date.now();
+            if (
+                !force &&
+                now - lastFetchAtRef.current < CALENDAR_REFETCH_COOLDOWN
+            ) {
+                return;
+            }
+
             if (showLoading) {
                 setIsLoading(true);
             }
@@ -156,6 +171,7 @@ export default function CalendarPage() {
                         schedules: nextSchedules,
                         absences: nextAbsences,
                     });
+                    lastFetchAtRef.current = Date.now();
                 } else {
                     setError(
                         schedulesData.error || "データの取得に失敗しました"
@@ -176,11 +192,13 @@ export default function CalendarPage() {
             }
         };
 
-        void fetchData(!cached);
+        if (!cached) {
+            void fetchData(true, true);
+        }
 
         const interval = setInterval(() => {
             void fetchData(false);
-        }, 60 * 1000);
+        }, CALENDAR_REFRESH_INTERVAL);
 
         const handleVisibilityChange = () => {
             if (document.visibilityState === "visible") {
@@ -397,6 +415,7 @@ export default function CalendarPage() {
                         schedules: next,
                         absences,
                     });
+                    lastFetchAtRef.current = Date.now();
                     return next;
                 });
 
@@ -540,6 +559,7 @@ export default function CalendarPage() {
                         schedules: next,
                         absences,
                     });
+                    lastFetchAtRef.current = Date.now();
                     return next;
                 });
 
@@ -622,6 +642,7 @@ export default function CalendarPage() {
                         schedules: next,
                         absences,
                     });
+                    lastFetchAtRef.current = Date.now();
                     return next;
                 });
 

--- a/src/shared/api/server.ts
+++ b/src/shared/api/server.ts
@@ -1,24 +1,30 @@
 import type { ApiResponse, Item, Schedule, Absence } from "../types/api";
 import { auth } from "@/src/auth";
 import { gasApiPathSchema, type GasApiPath } from "../lib/validation";
+import { unstable_cache } from "next/cache";
 
 const GAS_API_URL = process.env.NEXT_PUBLIC_GAS_API_URL;
 
 /**
- * サーバーサイドからGAS APIを直接呼び出す
- * Server Componentsで使用する
- * セッション認証と入力バリデーションを行う
+ * 認証済みセッションを要求する
  */
-async function fetchFromGASServer<T>(
-    path: GasApiPath,
-    params?: Record<string, string>
-): Promise<ApiResponse<T>> {
-    // セッション認証
+async function requireAuthenticatedSession() {
     const session = await auth();
     if (!session) {
         throw new Error("Unauthorized");
     }
 
+    return session;
+}
+
+/**
+ * サーバーサイドからGAS APIを直接呼び出す
+ * Server Componentsで使用する
+ */
+async function fetchFromGASServer<T>(
+    path: GasApiPath,
+    params?: Record<string, string>
+): Promise<ApiResponse<T>> {
     if (!GAS_API_URL) {
         throw new Error("GAS API URL not configured");
     }
@@ -44,7 +50,6 @@ async function fetchFromGASServer<T>(
             headers: {
                 "Content-Type": "application/json",
             },
-            cache: "no-store",
         });
 
         if (!response.ok) {
@@ -59,18 +64,49 @@ async function fetchFromGASServer<T>(
     }
 }
 
+const getItemsCached = unstable_cache(
+    async () => fetchFromGASServer<Item[]>("items"),
+    ["gas-items"],
+    { tags: ["items"] }
+);
+
+const getSchedulesCached = unstable_cache(
+    async () => fetchFromGASServer<Schedule[]>("schedules"),
+    ["gas-schedules"],
+    { tags: ["schedules"] }
+);
+
+const getAbsencesCached = unstable_cache(
+    async (date?: string) =>
+        fetchFromGASServer<Absence[]>(
+            "absences",
+            date ? { date } : undefined
+        ),
+    ["gas-absences"],
+    { tags: ["absences"] }
+);
+
+const getEventAbsencesCached = unstable_cache(
+    async (eventId: string) =>
+        fetchFromGASServer<Absence[]>("event-absences", { eventId }),
+    ["gas-event-absences"],
+    { tags: ["absences"] }
+);
+
 /**
  * Items取得API（サーバーサイド用）
  */
 export async function getItemsServer(): Promise<ApiResponse<Item[]>> {
-    return fetchFromGASServer<Item[]>("items");
+    await requireAuthenticatedSession();
+    return getItemsCached();
 }
 
 /**
  * Schedules取得API（サーバーサイド用）
  */
 export async function getSchedulesServer(): Promise<ApiResponse<Schedule[]>> {
-    return fetchFromGASServer<Schedule[]>("schedules");
+    await requireAuthenticatedSession();
+    return getSchedulesCached();
 }
 
 /**
@@ -79,8 +115,8 @@ export async function getSchedulesServer(): Promise<ApiResponse<Schedule[]>> {
 export async function getAbsencesServer(
     date?: string
 ): Promise<ApiResponse<Absence[]>> {
-    const params = date ? { date } : undefined;
-    return fetchFromGASServer<Absence[]>("absences", params);
+    await requireAuthenticatedSession();
+    return getAbsencesCached(date);
 }
 
 /**
@@ -89,5 +125,6 @@ export async function getAbsencesServer(
 export async function getEventAbsencesServer(
     eventId: string
 ): Promise<ApiResponse<Absence[]>> {
-    return fetchFromGASServer<Absence[]>("event-absences", { eventId });
+    await requireAuthenticatedSession();
+    return getEventAbsencesCached(eventId);
 }

--- a/src/shared/lib/client-cache.ts
+++ b/src/shared/lib/client-cache.ts
@@ -1,11 +1,14 @@
 "use client";
 
-interface CachedData<T> {
+export interface CachedData<T> {
     data: T;
     timestamp: number;
 }
 
-export function getClientCache<T>(key: string, ttlMs: number): T | null {
+export function getClientCacheEntry<T>(
+    key: string,
+    ttlMs: number
+): CachedData<T> | null {
     if (typeof window === "undefined") return null;
 
     try {
@@ -18,10 +21,15 @@ export function getClientCache<T>(key: string, ttlMs: number): T | null {
             return null;
         }
 
-        return parsed.data;
+        return parsed;
     } catch {
         return null;
     }
+}
+
+export function getClientCache<T>(key: string, ttlMs: number): T | null {
+    const cached = getClientCacheEntry<T>(key, ttlMs);
+    return cached ? cached.data : null;
 }
 
 export function setClientCache<T>(key: string, data: T): void {


### PR DESCRIPTION
## Summary
- cache server-side GAS reads used by the home page
- reduce calendar polling and skip immediate refetch when client cache is still fresh
- add cooldown tracking to the client cache helpers so visibility-based refetches do not hammer GAS
