### PR TITLE
キャッシュ方針を統一する

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -8,6 +8,10 @@ import {
     getClientCacheEntry,
     setClientCache,
 } from "@/src/shared/lib/client-cache";
+import {
+    CACHE_TTL_MS,
+    CLIENT_CACHE_KEYS,
+} from "@/src/shared/lib/cache-policy";
 
 // イベントカラーの定義
 export const EVENT_COLORS = [
@@ -65,9 +69,7 @@ interface EventForm {
     color: EventColorId;
 }
 
-const CALENDAR_CACHE_KEY = "nb-portal-calendar-cache";
-const CALENDAR_CACHE_TTL = 5 * 60 * 1000;
-const CALENDAR_REFRESH_INTERVAL = 5 * 60 * 1000;
+const CALENDAR_REFRESH_INTERVAL = CACHE_TTL_MS.pageData;
 const CALENDAR_REFETCH_COOLDOWN = 60 * 1000;
 
 export default function CalendarPage() {
@@ -123,7 +125,7 @@ export default function CalendarPage() {
         const cached = getClientCacheEntry<{
             schedules: Schedule[];
             absences: Absence[];
-        }>(CALENDAR_CACHE_KEY, CALENDAR_CACHE_TTL);
+        }>(CLIENT_CACHE_KEYS.calendar, CACHE_TTL_MS.pageData);
 
         if (cached) {
             setSchedules(cached.data.schedules);
@@ -167,7 +169,7 @@ export default function CalendarPage() {
                     setSchedules(nextSchedules);
                     setAbsences(nextAbsences);
                     setError(null);
-                    setClientCache(CALENDAR_CACHE_KEY, {
+                    setClientCache(CLIENT_CACHE_KEYS.calendar, {
                         schedules: nextSchedules,
                         absences: nextAbsences,
                     });
@@ -192,7 +194,9 @@ export default function CalendarPage() {
             }
         };
 
-        if (!cached) {
+        if (cached) {
+            void fetchData(false);
+        } else {
             void fetchData(true, true);
         }
 
@@ -411,7 +415,7 @@ export default function CalendarPage() {
                 };
                 setSchedules((prev) => {
                     const next = [...prev, newSchedule];
-                    setClientCache(CALENDAR_CACHE_KEY, {
+                    setClientCache(CLIENT_CACHE_KEYS.calendar, {
                         schedules: next,
                         absences,
                     });
@@ -555,7 +559,7 @@ export default function CalendarPage() {
                         const scheduleValues = Object.values(schedule);
                         return String(scheduleValues[0]) !== eventId;
                     });
-                    setClientCache(CALENDAR_CACHE_KEY, {
+                    setClientCache(CLIENT_CACHE_KEYS.calendar, {
                         schedules: next,
                         absences,
                     });
@@ -638,7 +642,7 @@ export default function CalendarPage() {
                         }
                         return schedule;
                     });
-                    setClientCache(CALENDAR_CACHE_KEY, {
+                    setClientCache(CLIENT_CACHE_KEYS.calendar, {
                         schedules: next,
                         absences,
                     });

--- a/app/(authenticated)/items/page.tsx
+++ b/app/(authenticated)/items/page.tsx
@@ -2,10 +2,17 @@
 
 import { useEffect, useState, useRef } from "react";
 import { HelpButton } from "@/src/features/help";
-
-interface Item {
-    [key: string]: string | number | boolean | Date;
-}
+import type { Item } from "@/src/shared/types/api";
+import {
+    clearClientCache,
+    getClientCacheEntry,
+    getStaleClientCacheEntry,
+    setClientCache,
+} from "@/src/shared/lib/client-cache";
+import {
+    CACHE_TTL_MS,
+    CLIENT_CACHE_KEYS,
+} from "@/src/shared/lib/cache-policy";
 
 type CategoryFilter = "all" | "MIC" | "SPK" | "CAB" | "OTHER";
 type ItemCategory = "MIC" | "SPK" | "CAB" | "OTH";
@@ -17,47 +24,9 @@ const CATEGORY_MAP: Record<string, string> = {
     OTH: "その他",
 };
 
-const CACHE_KEY = "nb-portal-items-cache";
-const CACHE_DURATION = 2 * 60 * 60 * 1000;
-
-interface CachedData {
-    items: Item[];
-    timestamp: number;
-}
-
 const getCategoryFromItemId = (itemId: string): string => {
     const prefix = String(itemId).substring(0, 3).toUpperCase();
     return CATEGORY_MAP[prefix] || "その他";
-};
-
-const getCache = (): CachedData | null => {
-    if (typeof window === "undefined") return null;
-    try {
-        const cached = localStorage.getItem(CACHE_KEY);
-        if (!cached) return null;
-        return JSON.parse(cached) as CachedData;
-    } catch {
-        return null;
-    }
-};
-
-const setCache = (items: Item[]): void => {
-    if (typeof window === "undefined") return;
-    try {
-        const data: CachedData = { items, timestamp: Date.now() };
-        localStorage.setItem(CACHE_KEY, JSON.stringify(data));
-    } catch {
-        // localStorage容量超過時は無視
-    }
-};
-
-const clearCache = (): void => {
-    if (typeof window === "undefined") return;
-    localStorage.removeItem(CACHE_KEY);
-};
-
-const isCacheValid = (cache: CachedData): boolean => {
-    return Date.now() - cache.timestamp < CACHE_DURATION;
 };
 
 export default function ItemsPage() {
@@ -93,28 +62,34 @@ export default function ItemsPage() {
 
     const fetchItems = async (useCache = true) => {
         if (useCache) {
-            const cache = getCache();
-            if (cache && isCacheValid(cache)) {
-                setItems(cache.items);
+            const cache = getClientCacheEntry<Item[]>(
+                CLIENT_CACHE_KEYS.items,
+                CACHE_TTL_MS.pageData
+            );
+            if (cache) {
+                setItems(cache.data);
                 setIsLoading(false);
-                return;
             }
         }
 
         try {
-            const res = await fetch("/api/gas?path=items");
+            const res = await fetch("/api/gas?path=items", {
+                cache: "no-store",
+            });
             const data = await res.json();
             if (data.success) {
                 const fetchedItems = data.data || [];
                 setItems(fetchedItems);
-                setCache(fetchedItems);
+                setClientCache(CLIENT_CACHE_KEYS.items, fetchedItems);
             } else {
                 setError(data.error || "データの取得に失敗しました");
             }
         } catch (err) {
-            const cache = getCache();
+            const cache = getStaleClientCacheEntry<Item[]>(
+                CLIENT_CACHE_KEYS.items
+            );
             if (cache) {
-                setItems(cache.items);
+                setItems(cache.data);
             } else {
                 setError(
                     err instanceof Error
@@ -175,7 +150,7 @@ export default function ItemsPage() {
             if (data.success) {
                 setIsCreateModalOpen(false);
                 setCreateForm({ category: "MIC", name: "", count: 1 });
-                clearCache();
+                clearClientCache(CLIENT_CACHE_KEYS.items);
                 await fetchItems(false);
             } else {
                 setModalError(data.error || "登録に失敗しました");
@@ -211,7 +186,7 @@ export default function ItemsPage() {
                 setIsEditModalOpen(false);
                 setSelectedItem(null);
                 setEditForm({ name: "" });
-                clearCache();
+                clearClientCache(CLIENT_CACHE_KEYS.items);
                 await fetchItems(false);
             } else {
                 setModalError(data.error || "更新に失敗しました");
@@ -240,7 +215,7 @@ export default function ItemsPage() {
             if (data.success) {
                 setIsDeleteModalOpen(false);
                 setSelectedItem(null);
-                clearCache();
+                clearClientCache(CLIENT_CACHE_KEYS.items);
                 await fetchItems(false);
             } else {
                 setModalError(data.error || "削除に失敗しました");

--- a/app/(authenticated)/members/page.tsx
+++ b/app/(authenticated)/members/page.tsx
@@ -6,8 +6,15 @@ import type {
     MembersData,
     SheetCellValue,
 } from "@/src/shared/types/api";
-
-const MEMBERS_CACHE_KEY = "nb-portal-members-cache";
+import {
+    getClientCacheEntry,
+    getStaleClientCacheEntry,
+    setClientCache,
+} from "@/src/shared/lib/client-cache";
+import {
+    CACHE_TTL_MS,
+    CLIENT_CACHE_KEYS,
+} from "@/src/shared/lib/cache-policy";
 
 const HEADER_LABELS: Record<string, string> = {
     studentnumber: "学籍番号",
@@ -157,29 +164,6 @@ const isNicknameHeader = (header: string): boolean =>
 const isBooleanHeader = (header: string): boolean =>
     header.trim().toLowerCase().startsWith("is");
 
-const getMembersCache = (): MembersData | null => {
-    if (typeof window === "undefined") return null;
-
-    try {
-        const cached = sessionStorage.getItem(MEMBERS_CACHE_KEY);
-        if (!cached) return null;
-        return JSON.parse(cached) as MembersData;
-    } catch {
-        sessionStorage.removeItem(MEMBERS_CACHE_KEY);
-        return null;
-    }
-};
-
-const setMembersCache = (data: MembersData): void => {
-    if (typeof window === "undefined") return;
-
-    try {
-        sessionStorage.setItem(MEMBERS_CACHE_KEY, JSON.stringify(data));
-    } catch {
-        // キャッシュできない場合は画面表示だけ更新する
-    }
-};
-
 export default function MembersPage() {
     const [headers, setHeaders] = useState<string[]>([]);
     const [members, setMembers] = useState<MemberRow[]>([]);
@@ -202,11 +186,20 @@ export default function MembersPage() {
     const applyMembersData = useCallback((data: MembersData) => {
         setHeaders(data.headers);
         setMembers(data.members);
-        setMembersCache(data);
     }, []);
 
     const fetchMembers = useCallback(async () => {
-        setIsLoading(true);
+        const cached = getClientCacheEntry<MembersData>(
+            CLIENT_CACHE_KEYS.members,
+            CACHE_TTL_MS.pageData
+        );
+        if (cached) {
+            applyMembersData(cached.data);
+            setIsLoading(false);
+        } else {
+            setIsLoading(true);
+        }
+
         try {
             const response = await fetch("/api/gas?path=members", {
                 cache: "no-store",
@@ -223,27 +216,27 @@ export default function MembersPage() {
             }
 
             applyMembersData(data.data);
+            setClientCache(CLIENT_CACHE_KEYS.members, data.data);
             setError(null);
         } catch (fetchError) {
-            setError(
-                fetchError instanceof Error
-                    ? fetchError.message
-                    : "名簿の取得に失敗しました"
+            const stale = getStaleClientCacheEntry<MembersData>(
+                CLIENT_CACHE_KEYS.members
             );
+            if (stale) {
+                applyMembersData(stale.data);
+            } else {
+                setError(
+                    fetchError instanceof Error
+                        ? fetchError.message
+                        : "名簿の取得に失敗しました"
+                );
+            }
         } finally {
             setIsLoading(false);
         }
     }, [applyMembersData]);
 
     useEffect(() => {
-        const cached = getMembersCache();
-        if (cached) {
-            setHeaders(cached.headers);
-            setMembers(cached.members);
-            setIsLoading(false);
-            return;
-        }
-
         void fetchMembers();
     }, [fetchMembers]);
 
@@ -318,6 +311,7 @@ export default function MembersPage() {
             members: nextMembers,
         };
         applyMembersData(nextData);
+        setClientCache(CLIENT_CACHE_KEYS.members, nextData);
     };
 
     const openCreateModal = () => {

--- a/app/(authenticated)/notifications/NotificationsContent.tsx
+++ b/app/(authenticated)/notifications/NotificationsContent.tsx
@@ -4,9 +4,14 @@ import { useEffect, useState } from "react";
 import { PushNotificationToggle } from "@/src/features/push-notification";
 import { HelpButton } from "@/src/features/help";
 import {
-    getClientCache,
+    getClientCacheEntry,
+    getStaleClientCacheEntry,
     setClientCache,
 } from "@/src/shared/lib/client-cache";
+import {
+    CACHE_TTL_MS,
+    CLIENT_CACHE_KEYS,
+} from "@/src/shared/lib/cache-policy";
 
 interface Notification {
     eventId: string;
@@ -22,9 +27,6 @@ interface NotificationsContentProps {
     userEmail: string | null;
 }
 
-const NOTIFICATIONS_CACHE_KEY = "nb-portal-notifications-cache";
-const NOTIFICATIONS_CACHE_TTL = 5 * 60 * 1000;
-
 export function NotificationsContent({ userEmail }: NotificationsContentProps) {
     const [notifications, setNotifications] = useState<Notification[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -32,35 +34,43 @@ export function NotificationsContent({ userEmail }: NotificationsContentProps) {
 
     useEffect(() => {
         const fetchNotifications = async () => {
-            const cached = getClientCache<Notification[]>(
-                NOTIFICATIONS_CACHE_KEY,
-                NOTIFICATIONS_CACHE_TTL
+            const cached = getClientCacheEntry<Notification[]>(
+                CLIENT_CACHE_KEYS.notifications,
+                CACHE_TTL_MS.pageData
             );
             if (cached) {
-                setNotifications(cached);
+                setNotifications(cached.data);
                 setIsLoading(false);
-                return;
             }
 
             try {
-                const res = await fetch("/api/gas?path=notifications&limit=50");
+                const res = await fetch("/api/gas?path=notifications&limit=50", {
+                    cache: "no-store",
+                });
                 const data = await res.json();
                 if (data.success) {
                     const nextNotifications = data.data || [];
                     setNotifications(nextNotifications);
                     setClientCache(
-                        NOTIFICATIONS_CACHE_KEY,
+                        CLIENT_CACHE_KEYS.notifications,
                         nextNotifications
                     );
                 } else {
                     setError(data.error || "データの取得に失敗しました");
                 }
             } catch (err) {
-                setError(
-                    err instanceof Error
-                        ? err.message
-                        : "データの取得に失敗しました"
+                const stale = getStaleClientCacheEntry<Notification[]>(
+                    CLIENT_CACHE_KEYS.notifications
                 );
+                if (stale) {
+                    setNotifications(stale.data);
+                } else {
+                    setError(
+                        err instanceof Error
+                            ? err.message
+                            : "データの取得に失敗しました"
+                    );
+                }
             } finally {
                 setIsLoading(false);
             }

--- a/app/api/absence/route.ts
+++ b/app/api/absence/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { auth } from "@/src/auth";
+import { CACHE_TAGS } from "@/src/shared/lib/cache-policy";
 import {
     absenceSubmitSchema,
     formatValidationErrors,
@@ -73,7 +74,7 @@ export async function POST(request: NextRequest) {
         const data = await response.json();
 
         if (data?.success === true) {
-            revalidateTag("absences", "max");
+            revalidateTag(CACHE_TAGS.absences, "max");
         }
 
         return NextResponse.json(data);

--- a/app/api/gas/route.ts
+++ b/app/api/gas/route.ts
@@ -7,6 +7,9 @@ import {
 } from "@/src/shared/lib/validation";
 
 const GAS_API_URL = process.env.NEXT_PUBLIC_GAS_API_URL;
+const NO_STORE_HEADERS = {
+    "Cache-Control": "no-store, max-age=0",
+};
 
 /**
  * GAS APIへのプロキシエンドポイント
@@ -84,7 +87,7 @@ export async function GET(request: NextRequest) {
         });
 
         const data = await response.json();
-        return NextResponse.json(data);
+        return NextResponse.json(data, { headers: NO_STORE_HEADERS });
     } catch (error) {
         console.error("GAS API proxy error:", error);
         return NextResponse.json(

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { auth } from "@/src/auth";
+import { CACHE_TAGS } from "@/src/shared/lib/cache-policy";
 import {
     itemCreateSchema,
     itemUpdateSchema,
@@ -56,7 +57,7 @@ export async function POST(request: NextRequest) {
 
         const data = await response.json();
         if (data?.success === true) {
-            revalidateTag("items", "max");
+            revalidateTag(CACHE_TAGS.items, "max");
         }
         return NextResponse.json(data);
     } catch (error) {
@@ -117,7 +118,7 @@ export async function PUT(request: NextRequest) {
 
         const data = await response.json();
         if (data?.success === true) {
-            revalidateTag("items", "max");
+            revalidateTag(CACHE_TAGS.items, "max");
         }
         return NextResponse.json(data);
     } catch (error) {
@@ -178,7 +179,7 @@ export async function DELETE(request: NextRequest) {
 
         const data = await response.json();
         if (data?.success === true) {
-            revalidateTag("items", "max");
+            revalidateTag(CACHE_TAGS.items, "max");
         }
         return NextResponse.json(data);
     } catch (error) {

--- a/app/api/members/route.ts
+++ b/app/api/members/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { auth } from "@/src/auth";
+import { CACHE_TAGS } from "@/src/shared/lib/cache-policy";
 import {
     formatValidationErrors,
     memberCreateSchema,
@@ -57,7 +58,7 @@ export async function POST(request: NextRequest) {
 
         const data = await response.json();
         if (data?.success === true) {
-            revalidateTag("members", "max");
+            revalidateTag(CACHE_TAGS.members, "max");
         }
 
         return NextResponse.json(data);
@@ -120,7 +121,7 @@ export async function PUT(request: NextRequest) {
 
         const data = await response.json();
         if (data?.success === true) {
-            revalidateTag("members", "max");
+            revalidateTag(CACHE_TAGS.members, "max");
         }
 
         return NextResponse.json(data);
@@ -183,7 +184,7 @@ export async function DELETE(request: NextRequest) {
 
         const data = await response.json();
         if (data?.success === true) {
-            revalidateTag("members", "max");
+            revalidateTag(CACHE_TAGS.members, "max");
         }
 
         return NextResponse.json(data);

--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { auth } from "@/src/auth";
+import { CACHE_TAGS } from "@/src/shared/lib/cache-policy";
 
 const GAS_API_URL = process.env.NEXT_PUBLIC_GAS_API_URL;
 
@@ -52,8 +53,8 @@ export async function POST(request: NextRequest) {
         const data = await response.json();
 
         if (data?.success === true) {
-            revalidateTag("schedules", "max");
-            revalidateTag("notifications", "max");
+            revalidateTag(CACHE_TAGS.schedules, "max");
+            revalidateTag(CACHE_TAGS.notifications, "max");
         }
 
         return NextResponse.json(data);
@@ -104,8 +105,8 @@ export async function DELETE(request: NextRequest) {
         const data = await response.json();
 
         if (data?.success === true) {
-            revalidateTag("schedules", "max");
-            revalidateTag("notifications", "max");
+            revalidateTag(CACHE_TAGS.schedules, "max");
+            revalidateTag(CACHE_TAGS.notifications, "max");
         }
 
         return NextResponse.json(data);
@@ -162,8 +163,8 @@ export async function PUT(request: NextRequest) {
         const data = await response.json();
 
         if (data?.success === true) {
-            revalidateTag("schedules", "max");
-            revalidateTag("notifications", "max");
+            revalidateTag(CACHE_TAGS.schedules, "max");
+            revalidateTag(CACHE_TAGS.notifications, "max");
         }
 
         return NextResponse.json(data);

--- a/src/features/meeting-memo/ui/MeetingMemoForm.tsx
+++ b/src/features/meeting-memo/ui/MeetingMemoForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { CLIENT_CACHE_KEYS } from "@/src/shared/lib/cache-policy";
 
 const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"] as const;
 const LOCATIONS = ["Discord", "クラブ棟前", "部室", "その他"] as const;
@@ -24,8 +25,6 @@ interface MemoFormData {
     nextMeetingTime: string;
     nextMeetingLocation: string;
 }
-
-const MEMO_DRAFT_CACHE_KEY = "nb-portal-meeting-memo-draft";
 
 const generateId = () => Math.random().toString(36).substring(2, 9);
 
@@ -129,12 +128,14 @@ export function MeetingMemoForm() {
         if (typeof window === "undefined") return;
 
         try {
-            const draft = sessionStorage.getItem(MEMO_DRAFT_CACHE_KEY);
+            const draft = sessionStorage.getItem(
+                CLIENT_CACHE_KEYS.meetingMemoDraft
+            );
             if (!draft) return;
 
             setFormData(normalizeDraft(JSON.parse(draft) as Partial<MemoFormData>));
         } catch {
-            sessionStorage.removeItem(MEMO_DRAFT_CACHE_KEY);
+            sessionStorage.removeItem(CLIENT_CACHE_KEYS.meetingMemoDraft);
         } finally {
             hasRestoredDraftRef.current = true;
         }
@@ -147,7 +148,7 @@ export function MeetingMemoForm() {
 
         try {
             sessionStorage.setItem(
-                MEMO_DRAFT_CACHE_KEY,
+                CLIENT_CACHE_KEYS.meetingMemoDraft,
                 JSON.stringify(formData)
             );
         } catch {

--- a/src/shared/api/server.ts
+++ b/src/shared/api/server.ts
@@ -8,6 +8,7 @@ import type {
 import { auth } from "@/src/auth";
 import { gasApiPathSchema, type GasApiPath } from "../lib/validation";
 import { unstable_cache } from "next/cache";
+import { CACHE_SECONDS, CACHE_TAGS } from "../lib/cache-policy";
 
 const GAS_API_URL = process.env.NEXT_PUBLIC_GAS_API_URL;
 
@@ -73,19 +74,19 @@ async function fetchFromGASServer<T>(
 const getItemsCached = unstable_cache(
     async () => fetchFromGASServer<Item[]>("items"),
     ["gas-items"],
-    { tags: ["items"] }
+    { tags: [CACHE_TAGS.items], revalidate: CACHE_SECONDS.gasData }
 );
 
 const getSchedulesCached = unstable_cache(
     async () => fetchFromGASServer<Schedule[]>("schedules"),
     ["gas-schedules"],
-    { tags: ["schedules"] }
+    { tags: [CACHE_TAGS.schedules], revalidate: CACHE_SECONDS.gasData }
 );
 
 const getMembersCached = unstable_cache(
     async () => fetchFromGASServer<MembersData>("members"),
     ["gas-members"],
-    { tags: ["members"] }
+    { tags: [CACHE_TAGS.members], revalidate: CACHE_SECONDS.gasData }
 );
 
 const getAbsencesCached = unstable_cache(
@@ -95,14 +96,14 @@ const getAbsencesCached = unstable_cache(
             date ? { date } : undefined
         ),
     ["gas-absences"],
-    { tags: ["absences"] }
+    { tags: [CACHE_TAGS.absences], revalidate: CACHE_SECONDS.gasData }
 );
 
 const getEventAbsencesCached = unstable_cache(
     async (eventId: string) =>
         fetchFromGASServer<Absence[]>("event-absences", { eventId }),
     ["gas-event-absences"],
-    { tags: ["absences"] }
+    { tags: [CACHE_TAGS.absences], revalidate: CACHE_SECONDS.gasData }
 );
 
 /**

--- a/src/shared/lib/cache-policy.ts
+++ b/src/shared/lib/cache-policy.ts
@@ -1,0 +1,23 @@
+export const CACHE_TAGS = {
+    items: "items",
+    schedules: "schedules",
+    members: "members",
+    absences: "absences",
+    notifications: "notifications",
+} as const;
+
+export const CACHE_SECONDS = {
+    gasData: 5 * 60,
+} as const;
+
+export const CACHE_TTL_MS = {
+    pageData: CACHE_SECONDS.gasData * 1000,
+} as const;
+
+export const CLIENT_CACHE_KEYS = {
+    calendar: "nb-portal-calendar-cache",
+    items: "nb-portal-items-cache",
+    members: "nb-portal-members-cache",
+    notifications: "nb-portal-notifications-cache",
+    meetingMemoDraft: "nb-portal-meeting-memo-draft",
+} as const;

--- a/src/shared/lib/client-cache.ts
+++ b/src/shared/lib/client-cache.ts
@@ -9,6 +9,17 @@ export function getClientCacheEntry<T>(
     key: string,
     ttlMs: number
 ): CachedData<T> | null {
+    const cached = getStaleClientCacheEntry<T>(key);
+    if (!cached) return null;
+
+    if (Date.now() - cached.timestamp > ttlMs) {
+        return null;
+    }
+
+    return cached;
+}
+
+export function getStaleClientCacheEntry<T>(key: string): CachedData<T> | null {
     if (typeof window === "undefined") return null;
 
     try {
@@ -16,11 +27,6 @@ export function getClientCacheEntry<T>(
         if (!cached) return null;
 
         const parsed = JSON.parse(cached) as CachedData<T>;
-        if (Date.now() - parsed.timestamp > ttlMs) {
-            sessionStorage.removeItem(key);
-            return null;
-        }
-
         return parsed;
     } catch {
         return null;


### PR DESCRIPTION
## Summary
- 共通のキャッシュタグ・TTL・クライアントキャッシュキーを追加
- 共有データのクライアントキャッシュを sessionStorage + 5分 TTL + stale fallback に統一
- サーバー側 unstable_cache に revalidate を追加し、更新 API のタグ無効化を共通定義化
- /api/gas に no-store レスポンスヘッダーを追加

## Verification
- npx tsc --noEmit
- npm run build

Note: npm run lint は既存の React Compiler 系 lint エラーで失敗します。今回の変更外です。