### PR TITLE
キャッシュ形式の互換性を修正

### DIFF
--- a/src/shared/lib/cache-policy.ts
+++ b/src/shared/lib/cache-policy.ts
@@ -17,7 +17,7 @@ export const CACHE_TTL_MS = {
 export const CLIENT_CACHE_KEYS = {
     calendar: "nb-portal-calendar-cache",
     items: "nb-portal-items-cache",
-    members: "nb-portal-members-cache",
+    members: "nb-portal-members-cache-v2",
     notifications: "nb-portal-notifications-cache",
     meetingMemoDraft: "nb-portal-meeting-memo-draft",
 } as const;

--- a/src/shared/lib/client-cache.ts
+++ b/src/shared/lib/client-cache.ts
@@ -5,6 +5,16 @@ export interface CachedData<T> {
     timestamp: number;
 }
 
+function isCachedData<T>(value: unknown): value is CachedData<T> {
+    if (!value || typeof value !== "object") return false;
+
+    return (
+        "data" in value &&
+        "timestamp" in value &&
+        typeof value.timestamp === "number"
+    );
+}
+
 export function getClientCacheEntry<T>(
     key: string,
     ttlMs: number
@@ -26,9 +36,15 @@ export function getStaleClientCacheEntry<T>(key: string): CachedData<T> | null {
         const cached = sessionStorage.getItem(key);
         if (!cached) return null;
 
-        const parsed = JSON.parse(cached) as CachedData<T>;
+        const parsed = JSON.parse(cached) as unknown;
+        if (!isCachedData<T>(parsed)) {
+            sessionStorage.removeItem(key);
+            return null;
+        }
+
         return parsed;
     } catch {
+        sessionStorage.removeItem(key);
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- 旧形式の sessionStorage キャッシュを CachedData として扱わないようガードを追加
- 名簿キャッシュキーを v2 に変更し、本番に残っている旧 `nb-portal-members-cache` を読まないよう修正

## Verification
- npx tsc --noEmit
- npm run build

## Cause
前回変更で名簿キャッシュを `{ data, timestamp }` 形式に統一しましたが、既存ユーザーの `sessionStorage` には旧形式 `{ headers, members }` が残ります。その状態で `cached.data` を読むと `undefined` になり、`data.headers` 参照で落ちていました。