### PR TITLE
PWA向けに保存ポリシーを調整

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -6,6 +6,7 @@ import type { Absence } from "@/src/shared/types/api";
 import { HelpButton } from "@/src/features/help";
 import {
     getClientCacheEntry,
+    getStaleClientCacheEntry,
     setClientCache,
 } from "@/src/shared/lib/client-cache";
 import {
@@ -182,11 +183,22 @@ export default function CalendarPage() {
             } catch (err) {
                 if (isCancelled) return;
 
-                setError(
-                    err instanceof Error
-                        ? err.message
-                        : "データの取得に失敗しました"
-                );
+                const stale = getStaleClientCacheEntry<{
+                    schedules: Schedule[];
+                    absences: Absence[];
+                }>(CLIENT_CACHE_KEYS.calendar, {
+                    maxAgeMs: CACHE_TTL_MS.stalePageData,
+                });
+                if (stale) {
+                    setSchedules(stale.data.schedules);
+                    setAbsences(stale.data.absences);
+                } else {
+                    setError(
+                        err instanceof Error
+                            ? err.message
+                            : "データの取得に失敗しました"
+                    );
+                }
             } finally {
                 if (!isCancelled) {
                     setIsLoading(false);

--- a/app/(authenticated)/items/page.tsx
+++ b/app/(authenticated)/items/page.tsx
@@ -86,7 +86,8 @@ export default function ItemsPage() {
             }
         } catch (err) {
             const cache = getStaleClientCacheEntry<Item[]>(
-                CLIENT_CACHE_KEYS.items
+                CLIENT_CACHE_KEYS.items,
+                { maxAgeMs: CACHE_TTL_MS.stalePageData }
             );
             if (cache) {
                 setItems(cache.data);

--- a/app/(authenticated)/members/page.tsx
+++ b/app/(authenticated)/members/page.tsx
@@ -220,7 +220,8 @@ export default function MembersPage() {
             setError(null);
         } catch (fetchError) {
             const stale = getStaleClientCacheEntry<MembersData>(
-                CLIENT_CACHE_KEYS.members
+                CLIENT_CACHE_KEYS.members,
+                { maxAgeMs: CACHE_TTL_MS.stalePageData }
             );
             if (stale) {
                 applyMembersData(stale.data);

--- a/app/(authenticated)/notifications/NotificationsContent.tsx
+++ b/app/(authenticated)/notifications/NotificationsContent.tsx
@@ -60,7 +60,8 @@ export function NotificationsContent({ userEmail }: NotificationsContentProps) {
                 }
             } catch (err) {
                 const stale = getStaleClientCacheEntry<Notification[]>(
-                    CLIENT_CACHE_KEYS.notifications
+                    CLIENT_CACHE_KEYS.notifications,
+                    { maxAgeMs: CACHE_TTL_MS.stalePageData }
                 );
                 if (stale) {
                     setNotifications(stale.data);

--- a/src/features/meeting-memo/ui/MeetingMemoForm.tsx
+++ b/src/features/meeting-memo/ui/MeetingMemoForm.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CLIENT_CACHE_KEYS } from "@/src/shared/lib/cache-policy";
+import {
+    CACHE_TTL_MS,
+    CLIENT_CACHE_KEYS,
+} from "@/src/shared/lib/cache-policy";
+import {
+    getClientCache,
+    setClientCache,
+} from "@/src/shared/lib/client-cache";
 
 const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"] as const;
 const LOCATIONS = ["Discord", "クラブ棟前", "部室", "その他"] as const;
@@ -128,14 +135,15 @@ export function MeetingMemoForm() {
         if (typeof window === "undefined") return;
 
         try {
-            const draft = sessionStorage.getItem(
-                CLIENT_CACHE_KEYS.meetingMemoDraft
+            const draft = getClientCache<Partial<MemoFormData>>(
+                CLIENT_CACHE_KEYS.meetingMemoDraft,
+                CACHE_TTL_MS.meetingMemoDraft
             );
             if (!draft) return;
 
-            setFormData(normalizeDraft(JSON.parse(draft) as Partial<MemoFormData>));
+            setFormData(normalizeDraft(draft));
         } catch {
-            sessionStorage.removeItem(CLIENT_CACHE_KEYS.meetingMemoDraft);
+            // 壊れた下書きは client-cache.ts のキャッシュヘルパー側で破棄される
         } finally {
             hasRestoredDraftRef.current = true;
         }
@@ -147,9 +155,9 @@ export function MeetingMemoForm() {
         }
 
         try {
-            sessionStorage.setItem(
+            setClientCache(
                 CLIENT_CACHE_KEYS.meetingMemoDraft,
-                JSON.stringify(formData)
+                formData
             );
         } catch {
             // 保存できない場合は無視

--- a/src/shared/lib/cache-policy.ts
+++ b/src/shared/lib/cache-policy.ts
@@ -12,6 +12,8 @@ export const CACHE_SECONDS = {
 
 export const CACHE_TTL_MS = {
     pageData: CACHE_SECONDS.gasData * 1000,
+    stalePageData: 24 * 60 * 60 * 1000,
+    meetingMemoDraft: 10 * 60 * 1000,
 } as const;
 
 export const CLIENT_CACHE_KEYS = {

--- a/src/shared/lib/client-cache.ts
+++ b/src/shared/lib/client-cache.ts
@@ -5,6 +5,21 @@ export interface CachedData<T> {
     timestamp: number;
 }
 
+type ClientCacheStorage = "local" | "session";
+
+interface ClientCacheOptions {
+    storage?: ClientCacheStorage;
+}
+
+interface StaleClientCacheOptions extends ClientCacheOptions {
+    maxAgeMs?: number;
+}
+
+function getStorage(storage: ClientCacheStorage): Storage | null {
+    if (typeof window === "undefined") return null;
+    return storage === "local" ? localStorage : sessionStorage;
+}
+
 function isCachedData<T>(value: unknown): value is CachedData<T> {
     if (!value || typeof value !== "object") return false;
 
@@ -17,48 +32,71 @@ function isCachedData<T>(value: unknown): value is CachedData<T> {
 
 export function getClientCacheEntry<T>(
     key: string,
-    ttlMs: number
+    ttlMs: number,
+    options: ClientCacheOptions = {}
 ): CachedData<T> | null {
-    const cached = getStaleClientCacheEntry<T>(key);
+    const cached = getStaleClientCacheEntry<T>(key, options);
     if (!cached) return null;
 
     if (Date.now() - cached.timestamp > ttlMs) {
+        clearClientCache(key, options);
         return null;
     }
 
     return cached;
 }
 
-export function getStaleClientCacheEntry<T>(key: string): CachedData<T> | null {
-    if (typeof window === "undefined") return null;
+export function getStaleClientCacheEntry<T>(
+    key: string,
+    options: StaleClientCacheOptions = {}
+): CachedData<T> | null {
+    const storage = getStorage(options.storage ?? "local");
+    if (!storage) return null;
 
     try {
-        const cached = sessionStorage.getItem(key);
+        const cached = storage.getItem(key);
         if (!cached) return null;
 
         const parsed = JSON.parse(cached) as unknown;
         if (!isCachedData<T>(parsed)) {
-            sessionStorage.removeItem(key);
+            storage.removeItem(key);
+            return null;
+        }
+
+        if (
+            options.maxAgeMs !== undefined &&
+            Date.now() - parsed.timestamp > options.maxAgeMs
+        ) {
+            storage.removeItem(key);
             return null;
         }
 
         return parsed;
     } catch {
-        sessionStorage.removeItem(key);
+        storage.removeItem(key);
         return null;
     }
 }
 
-export function getClientCache<T>(key: string, ttlMs: number): T | null {
-    const cached = getClientCacheEntry<T>(key, ttlMs);
+export function getClientCache<T>(
+    key: string,
+    ttlMs: number,
+    options: ClientCacheOptions = {}
+): T | null {
+    const cached = getClientCacheEntry<T>(key, ttlMs, options);
     return cached ? cached.data : null;
 }
 
-export function setClientCache<T>(key: string, data: T): void {
-    if (typeof window === "undefined") return;
+export function setClientCache<T>(
+    key: string,
+    data: T,
+    options: ClientCacheOptions = {}
+): void {
+    const storage = getStorage(options.storage ?? "local");
+    if (!storage) return;
 
     try {
-        sessionStorage.setItem(
+        storage.setItem(
             key,
             JSON.stringify({
                 data,
@@ -70,7 +108,10 @@ export function setClientCache<T>(key: string, data: T): void {
     }
 }
 
-export function clearClientCache(key: string): void {
-    if (typeof window === "undefined") return;
-    sessionStorage.removeItem(key);
+export function clearClientCache(
+    key: string,
+    options: ClientCacheOptions = {}
+): void {
+    const storage = getStorage(options.storage ?? "local");
+    storage?.removeItem(key);
 }


### PR DESCRIPTION
## Summary
- クライアントキャッシュの既定保存先を localStorage に変更し、PWA 再起動後も短期キャッシュを使えるように調整
- stale fallback に 24 時間の上限を追加
- カレンダーの通信失敗時にも stale fallback を利用
- 部会メモ下書きを localStorage + 10 分 TTL で復元するよう変更

## Verification
- npx tsc --noEmit
- npm run build

Note: build 時に daisyUI の @property warning は出ますが、ビルドは成功しています。