### PR TITLE
権限取得と権限入力UIを追加

### DIFF
--- a/app/(authenticated)/members/page.tsx
+++ b/app/(authenticated)/members/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+    MEMBER_PERMISSION_LABELS,
+    MEMBER_PERMISSIONS,
+} from "@/src/shared/types/api";
 import type {
     MemberRow,
     MembersData,
@@ -55,13 +59,18 @@ const getBooleanStatusLabel = (checked: boolean): string =>
 
 const normalizeEditableValues = (
     values: string[],
+    headers: string[],
     sourceValues: SheetCellValue[] = []
 ): Array<string | boolean> =>
-    values.map((value, index) =>
-        isBooleanCell(sourceValues[index] ?? value)
+    values.map((value, index) => {
+        if (isPermissionHeader(headers[index]) && value.trim() === "") {
+            return "TMP_NORMAL";
+        }
+
+        return isBooleanCell(sourceValues[index] ?? value)
             ? getBooleanCellValue(value)
-            : value
-    );
+            : value;
+    });
 
 function BooleanToggle({
     checked,
@@ -93,16 +102,19 @@ function BooleanToggle({
 }
 
 function MemberField({
+    header,
     label,
     value,
     sourceValue,
     onChange,
 }: {
+    header: string;
     label: string;
     value: string;
     sourceValue?: SheetCellValue;
     onChange: (value: string) => void;
 }) {
+    const isPermission = isPermissionHeader(header);
     const isBoolean = isBooleanCell(sourceValue ?? value);
     const shouldUseTextarea = value.includes("\n") || value.length > 60;
 
@@ -111,7 +123,22 @@ function MemberField({
             <div className="label pt-0">
                 <span className="label-text font-medium">{label}</span>
             </div>
-            {isBoolean ? (
+            {isPermission ? (
+                <select
+                    className="select select-bordered w-full"
+                    value={value || "TMP_NORMAL"}
+                    onChange={(event) => onChange(event.target.value)}
+                >
+                    {MEMBER_PERMISSIONS.map((permission) => (
+                        <option
+                            key={permission}
+                            value={permission}
+                        >
+                            {MEMBER_PERMISSION_LABELS[permission]}
+                        </option>
+                    ))}
+                </select>
+            ) : isBoolean ? (
                 <div className="flex items-center justify-between rounded-lg bg-base-200 px-4 py-3">
                     <span className="text-sm text-base-content/70">
                         {getBooleanStatusLabel(getBooleanCellValue(value))}
@@ -160,6 +187,9 @@ const isNameHeader = (header: string): boolean =>
 
 const isNicknameHeader = (header: string): boolean =>
     header.trim().toLowerCase() === "nickname";
+
+const isPermissionHeader = (header: string): boolean =>
+    header.trim().toLowerCase() === "permission";
 
 const isBooleanHeader = (header: string): boolean =>
     header.trim().toLowerCase().startsWith("is");
@@ -245,7 +275,10 @@ export default function MembersPage() {
         () =>
             headers
                 .map((header, index) => ({ header, index }))
-                .filter(({ header }) => !isNameHeader(header))
+                .filter(
+                    ({ header }) =>
+                        !isNameHeader(header) && !isPermissionHeader(header)
+                )
                 .map(({ index }) => index),
         [headers]
     );
@@ -360,7 +393,7 @@ export default function MembersPage() {
     const handleCreate = async () => {
         setIsSubmitting(true);
         setModalError(null);
-        const values = normalizeEditableValues(createValues);
+        const values = normalizeEditableValues(createValues, headers);
 
         try {
             const response = await fetch("/api/members", {
@@ -396,6 +429,7 @@ export default function MembersPage() {
         setModalError(null);
         const values = normalizeEditableValues(
             editValues,
+            headers,
             editingMember.values
         );
 
@@ -717,6 +751,7 @@ export default function MembersPage() {
                             {headers.map((header, index) => (
                                 <MemberField
                                     key={`${header}-${index}`}
+                                    header={header}
                                     label={getHeaderLabel(header)}
                                     value={createValues[index] || ""}
                                     onChange={(value) => {
@@ -784,6 +819,7 @@ export default function MembersPage() {
                             {headers.map((header, index) => (
                                 <MemberField
                                     key={`${header}-${index}`}
+                                    header={header}
                                     label={getHeaderLabel(header)}
                                     value={editValues[index] || ""}
                                     sourceValue={editingMember.values[index]}

--- a/gas/main.js
+++ b/gas/main.js
@@ -1257,10 +1257,12 @@ const handleVerifyMember = (e) => {
         const normalizedIdentifier = String(identifier).toLowerCase().trim();
 
         let memberName = null;
+        let memberPermission = null;
         const isMember = values.some((row) => {
             const studentId = String(row[0]).toLowerCase().trim();
             if (studentId === normalizedIdentifier) {
                 memberName = String(row[2] || "").trim() || null;
+                memberPermission = String(row[7] || "").trim() || null;
                 return true;
             }
             return false;
@@ -1271,6 +1273,7 @@ const handleVerifyMember = (e) => {
             isMember: isMember,
             identifier: identifier,
             name: memberName,
+            permission: memberPermission,
         });
     } catch (error) {
         return createErrorResponse(error.toString(), 500);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,9 @@
 import NextAuth from "next-auth";
 import MicrosoftEntraID from "next-auth/providers/microsoft-entra-id";
+import {
+    MEMBER_PERMISSIONS,
+    type MemberPermission,
+} from "@/src/shared/types/api";
 
 const tenantId = process.env.AUTH_MICROSOFT_ENTRA_ID_TENANT_ID;
 
@@ -40,21 +44,29 @@ const extractStudentId = (email: string | null | undefined): string | null => {
 /** 部員確認API呼び出し（あだ名も同時に取得） */
 const verifyMember = async (
     identifier: string
-): Promise<{ isMember: boolean; name: string | null }> => {
+): Promise<{
+    isMember: boolean;
+    name: string | null;
+    permission: MemberPermission | null;
+}> => {
     try {
         const apiUrl = process.env.NEXT_PUBLIC_GAS_API_URL;
-        if (!apiUrl) return { isMember: false, name: null };
+        if (!apiUrl) return { isMember: false, name: null, permission: null };
 
         const res = await fetch(
             `${apiUrl}?path=verify-member&identifier=${encodeURIComponent(identifier)}`
         );
         const data = await res.json();
+        const permission = MEMBER_PERMISSIONS.includes(data.permission)
+            ? (data.permission as MemberPermission)
+            : null;
         return {
             isMember: data.success && data.isMember === true,
             name: data.name || null,
+            permission,
         };
     } catch {
-        return { isMember: false, name: null };
+        return { isMember: false, name: null, permission: null };
     }
 };
 
@@ -89,6 +101,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
             // jwtコールバックに引き渡すため一時的に格納
             (user as Record<string, unknown>).memberName = result.name;
+            (user as Record<string, unknown>).permission = result.permission;
             return true;
         },
         async jwt({ token, user, account }) {
@@ -98,6 +111,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                 token.memberName =
                     ((user as Record<string, unknown>).memberName as string) ||
                     null;
+                token.permission =
+                    ((user as Record<string, unknown>).permission as
+                        | MemberPermission
+                        | null) || undefined;
             }
             // 初回ログイン時にプロファイル画像を取得（一度だけ）
             if (account?.access_token && !token.profileImageFetched) {
@@ -115,6 +132,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             }
             if (token.memberName) {
                 session.memberName = token.memberName as string;
+            }
+            if (token.permission) {
+                session.permission = token.permission as MemberPermission;
             }
             if (token.profileImage) {
                 session.profileImage = token.profileImage as string;

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -8,6 +8,26 @@ export interface ApiResponse<T> {
     timestamp?: string;
 }
 
+export const MEMBER_PERMISSIONS = [
+    "OBOG",
+    "NORMAL",
+    "HEAD",
+    "SUB_HEAD",
+    "ACCOUNTANT",
+    "TMP_NORMAL",
+] as const;
+
+export type MemberPermission = (typeof MEMBER_PERMISSIONS)[number];
+
+export const MEMBER_PERMISSION_LABELS: Record<MemberPermission, string> = {
+    OBOG: "OB・OG",
+    NORMAL: "部員",
+    HEAD: "部長",
+    SUB_HEAD: "副部長",
+    ACCOUNTANT: "会計",
+    TMP_NORMAL: "仮入部",
+};
+
 // Items型（スプレッドシートのヘッダーに応じて調整してください）
 export interface Item {
     [key: string]: string | number | boolean | Date;

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,9 +1,11 @@
 import "next-auth";
+import type { MemberPermission } from "@/src/shared/types/api";
 
 declare module "next-auth" {
     interface Session {
         studentId?: string;
         memberName?: string;
+        permission?: MemberPermission;
         profileImage?: string;
     }
 }
@@ -12,6 +14,7 @@ declare module "next-auth/jwt" {
     interface JWT {
         studentId?: string;
         memberName?: string;
+        permission?: MemberPermission;
         profileImage?: string;
         profileImageFetched?: boolean;
     }


### PR DESCRIPTION
## Summary
- ログイン時に members シート H 列から自分の権限を取得し、session.permission として利用できるように変更
- 名簿一覧では Permission 列を非表示化
- 追加・編集モーダルでは Permission をセレクト入力に変更し、未入力時は TMP_NORMAL を既定に設定
- 権限表示ラベルを日本語化

## Verification
- npx tsc --noEmit
- npm run build

## Notes
- 権限の内部値は , , , , ,  のままです
- 表示ラベルのみ , , , ,  に変換しています