### PR TITLE
表示名とホームウィジェットの見た目を調整

### DIFF
--- a/app/(authenticated)/more/MoreClient.tsx
+++ b/app/(authenticated)/more/MoreClient.tsx
@@ -12,9 +12,12 @@ interface User {
 
 interface MoreClientProps {
     user: User | undefined;
+    displayName?: string | null;
 }
 
-export default function MoreClient({ user }: MoreClientProps) {
+export default function MoreClient({ user, displayName }: MoreClientProps) {
+    const resolvedDisplayName = displayName || user?.name || null;
+
     return (
         <div className="p-4 lg:p-6 w-full">
             <div className="max-w-4xl mx-auto space-y-8">
@@ -146,12 +149,12 @@ export default function MoreClient({ user }: MoreClientProps) {
                             </h2>
                             <div className="flex items-center gap-4 mt-2">
                                 <ProfileAvatar
-                                    name={user.name}
+                                    name={resolvedDisplayName}
                                     size="md"
                                 />
                                 <div className="flex-1 min-w-0">
                                     <p className="font-medium text-base truncate">
-                                        {user.name}
+                                        {resolvedDisplayName}
                                     </p>
                                     <p className="text-sm text-base-content/60 truncate">
                                         {user.email}

--- a/app/(authenticated)/more/page.tsx
+++ b/app/(authenticated)/more/page.tsx
@@ -4,5 +4,16 @@ import MoreClient from "./MoreClient";
 export default async function MorePage() {
     const session = await auth();
 
-    return <MoreClient user={session?.user} />;
+    return (
+        <MoreClient
+            user={session?.user}
+            displayName={
+                session?.displayName ||
+                session?.memberName ||
+                session?.user?.name ||
+                session?.studentId ||
+                null
+            }
+        />
+    );
 }

--- a/src/features/digital-clock/ui/DigitalClock.tsx
+++ b/src/features/digital-clock/ui/DigitalClock.tsx
@@ -45,10 +45,10 @@ export default function DigitalClock({ memberName }: DigitalClockProps) {
     const greeting = getGreeting(Number(hours));
 
     return (
-        <div className="flex flex-col items-center gap-1">
+        <div className="flex flex-col items-center">
             <p
                 suppressHydrationWarning
-                className="text-sm text-base-content/60"
+                className="text-xs text-base-content/60"
             >
                 {greeting}
                 {memberName && `、${memberName}さん`}
@@ -56,13 +56,13 @@ export default function DigitalClock({ memberName }: DigitalClockProps) {
             <div className="flex items-baseline justify-center">
                 <span
                     suppressHydrationWarning
-                    className="text-5xl font-bold tabular-nums"
+                    className="text-4xl font-bold tabular-nums"
                 >
                     {hours}:{minutes}
                 </span>
                 <span
                     suppressHydrationWarning
-                    className="text-2xl font-bold tabular-nums text-base-content/60"
+                    className="text-xl font-bold tabular-nums text-base-content/60"
                 >
                     :{seconds}
                 </span>

--- a/src/features/weather/ui/WeatherWidget.tsx
+++ b/src/features/weather/ui/WeatherWidget.tsx
@@ -293,25 +293,21 @@ export default function WeatherWidget() {
     }
 
     return (
-        <div className="flex flex-wrap items-center justify-center gap-3 text-base-content/70">
+        <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm text-base-content/70">
             <div className="flex items-center gap-1.5">
-                <div className="w-6 h-6">
+                <div className="h-5 w-5">
                     <WeatherIcon code={weather.weatherCode} />
                 </div>
                 <span className="font-semibold text-base-content">
                     {getWeatherDescription(weather.weatherCode)}
                 </span>
             </div>
-            <span className="font-bold text-lg tabular-nums text-base-content">
+            <span className="font-bold tabular-nums text-base-content">
                 {weather.temperature}
-                <span className="text-sm text-base-content/60">°C</span>
+                <span className="text-xs text-base-content/60">°C</span>
             </span>
-            <span className="text-sm tabular-nums">
-                湿度 {weather.humidity}%
-            </span>
-            <span className="text-sm tabular-nums">
-                風速 {weather.windSpeed}m/s
-            </span>
+            <span className="tabular-nums">湿度 {weather.humidity}%</span>
+            <span className="tabular-nums">風速 {weather.windSpeed}m/s</span>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- more画面のプロフィール表示でセッションの表示名を優先
- デジタル時計の表示サイズを調整
- 天気ウィジェットをコンパクトに調整

## Tests
- npm run build