### PR TITLE
スケジュールカードの余白を調整

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -1386,7 +1386,7 @@ export default function CalendarPage() {
                                                             schedule
                                                         )
                                                     }
-                                                    className="p-4 bg-base-100 rounded-xl border-l-4 shadow-sm hover:shadow-lg transition-all cursor-pointer hover:bg-base-200/50"
+                                                    className="p-5 bg-base-100 rounded-xl shadow-sm hover:shadow-lg transition-all cursor-pointer hover:bg-base-200/50"
                                                     style={{
                                                         borderLeftColor:
                                                             eventColor,

--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -50,7 +50,7 @@ export default function ScheduleCard({
             {!hideCard && (
                 <div
                     onClick={() => setIsModalOpen(true)}
-                    className="p-5 bg-base-100 rounded-xl border-l-4 shadow-sm hover:shadow-lg transition-all cursor-pointer hover:bg-base-200/50"
+                    className="p-5 bg-base-100 rounded-xl shadow-sm hover:shadow-lg transition-all cursor-pointer hover:bg-base-200/50"
                     style={{ borderLeftColor: color }}
                 >
                     <div className="flex flex-col lg:flex-row gap-4">


### PR DESCRIPTION
## Summary
- カレンダー内スケジュールカードの余白を調整
- 共通スケジュールカードの左ボーダーを外し、見た目を揃える

## Tests
- npm run build