### PR TITLE
出欠方式と名簿チェック機能を追加

### DIFF
--- a/app/(authenticated)/absence/AbsenceFormContent.tsx
+++ b/app/(authenticated)/absence/AbsenceFormContent.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { submitAbsence } from "@/src/shared/api/client";
 import { HelpButton } from "@/src/features/help";
+import { normalizeScheduleAttendanceMode } from "@/src/shared/types/api";
 
 interface AbsenceFormContentProps {
     studentId: string | null;
@@ -17,6 +18,11 @@ export function AbsenceFormContent({
 }: AbsenceFormContentProps) {
     const searchParams = useSearchParams();
     const eventId = searchParams.get("eventId") || "";
+    const attendanceMode = normalizeScheduleAttendanceMode(
+        searchParams.get("mode")
+    );
+    const isAttendanceEvent = attendanceMode === "ATTENDANCE";
+    const pageTitle = isAttendanceEvent ? "出席申告" : "欠席連絡";
 
     const [formData, setFormData] = useState({
         studentNumber: studentId || "",
@@ -47,18 +53,28 @@ export function AbsenceFormContent({
                 eventId,
                 studentNumber: formData.studentNumber,
                 name: formData.name,
-                type: formData.type,
-                reason: formData.reasonCategory,
-                reasonDetail: formData.reasonDetail || undefined,
-                timeStepOut: formData.timeStepOut || undefined,
-                timeReturn: formData.timeReturn || undefined,
-                timeLeavingEarly: formData.timeLeavingEarly || undefined,
+                type: isAttendanceEvent ? "出席" : formData.type,
+                reason: isAttendanceEvent ? "出席" : formData.reasonCategory,
+                reasonDetail: isAttendanceEvent
+                    ? undefined
+                    : formData.reasonDetail || undefined,
+                timeStepOut: isAttendanceEvent
+                    ? undefined
+                    : formData.timeStepOut || undefined,
+                timeReturn: isAttendanceEvent
+                    ? undefined
+                    : formData.timeReturn || undefined,
+                timeLeavingEarly: isAttendanceEvent
+                    ? undefined
+                    : formData.timeLeavingEarly || undefined,
             });
 
             if (result.success) {
                 setSubmitStatus({
                     type: "success",
-                    message: "欠席連絡を送信しました",
+                    message: isAttendanceEvent
+                        ? "出席申告を送信しました"
+                        : "欠席連絡を送信しました",
                 });
 
                 // 学籍番号とあだ名は維持し、それ以外をリセット
@@ -97,7 +113,7 @@ export function AbsenceFormContent({
                     className="font-bold"
                     style={{ fontSize: "clamp(1.5rem, 4vw, 1.875rem)" }}
                 >
-                    欠席連絡
+                    {pageTitle}
                 </h1>
                 <HelpButton sectionId="absence" />
             </div>
@@ -176,103 +192,124 @@ export function AbsenceFormContent({
                             />
                         </div>
 
-                        {/* 種別 */}
-                        <div className="form-control">
-                            <label className="label">
-                                <span
-                                    className="label-text font-semibold"
-                                    style={{
-                                        fontSize: "clamp(0.875rem, 2vw, 1rem)",
-                                    }}
-                                >
-                                    種別 <span className="text-error">*</span>
-                                </span>
-                            </label>
-                            <select
-                                className="select select-bordered w-full"
-                                value={formData.type}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        type: e.target.value,
-                                    })
-                                }
-                                required
-                            >
-                                <option value="">選択してください</option>
-                                <option value="欠席">欠席</option>
-                                <option value="遅刻">遅刻</option>
-                                <option value="中抜け">中抜け</option>
-                                <option value="早退">早退</option>
-                            </select>
-                        </div>
+                        {!isAttendanceEvent && (
+                            <>
+                                {/* 種別 */}
+                                <div className="form-control">
+                                    <label className="label">
+                                        <span
+                                            className="label-text font-semibold"
+                                            style={{
+                                                fontSize:
+                                                    "clamp(0.875rem, 2vw, 1rem)",
+                                            }}
+                                        >
+                                            種別{" "}
+                                            <span className="text-error">
+                                                *
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <select
+                                        className="select select-bordered w-full"
+                                        value={formData.type}
+                                        onChange={(e) =>
+                                            setFormData({
+                                                ...formData,
+                                                type: e.target.value,
+                                            })
+                                        }
+                                        required
+                                    >
+                                        <option value="">
+                                            選択してください
+                                        </option>
+                                        <option value="欠席">欠席</option>
+                                        <option value="遅刻">遅刻</option>
+                                        <option value="中抜け">中抜け</option>
+                                        <option value="早退">早退</option>
+                                    </select>
+                                </div>
 
-                        {/* 理由カテゴリ */}
-                        <div className="form-control">
-                            <label className="label">
-                                <span
-                                    className="label-text font-semibold"
-                                    style={{
-                                        fontSize: "clamp(0.875rem, 2vw, 1rem)",
-                                    }}
-                                >
-                                    理由 <span className="text-error">*</span>
-                                </span>
-                            </label>
-                            <select
-                                className="select select-bordered w-full"
-                                value={formData.reasonCategory}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        reasonCategory: e.target.value,
-                                    })
-                                }
-                                required
-                            >
-                                <option value="">選択してください</option>
-                                <option value="体調不良">体調不良</option>
-                                <option value="授業">授業</option>
-                                <option value="家庭の都合">家庭の都合</option>
-                                <option value="その他">その他</option>
-                            </select>
-                        </div>
+                                {/* 理由カテゴリ */}
+                                <div className="form-control">
+                                    <label className="label">
+                                        <span
+                                            className="label-text font-semibold"
+                                            style={{
+                                                fontSize:
+                                                    "clamp(0.875rem, 2vw, 1rem)",
+                                            }}
+                                        >
+                                            理由{" "}
+                                            <span className="text-error">
+                                                *
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <select
+                                        className="select select-bordered w-full"
+                                        value={formData.reasonCategory}
+                                        onChange={(e) =>
+                                            setFormData({
+                                                ...formData,
+                                                reasonCategory: e.target.value,
+                                            })
+                                        }
+                                        required
+                                    >
+                                        <option value="">
+                                            選択してください
+                                        </option>
+                                        <option value="体調不良">
+                                            体調不良
+                                        </option>
+                                        <option value="授業">授業</option>
+                                        <option value="家庭の都合">
+                                            家庭の都合
+                                        </option>
+                                        <option value="その他">その他</option>
+                                    </select>
+                                </div>
 
-                        {/* 詳細（任意） */}
-                        <div className="form-control">
-                            <label className="label">
-                                <span
-                                    className="label-text font-semibold"
-                                    style={{
-                                        fontSize: "clamp(0.875rem, 2vw, 1rem)",
-                                    }}
-                                >
-                                    詳細
-                                    <span className="text-base-content/50 font-normal ml-2">
-                                        任意
-                                    </span>
-                                </span>
-                            </label>
-                            <textarea
-                                placeholder="補足があれば入力してください"
-                                className="textarea textarea-bordered w-full h-24"
-                                value={formData.reasonDetail}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        reasonDetail: e.target.value,
-                                    })
-                                }
-                            />
-                            <label className="label">
-                                <span className="label-text-alt text-base-content/50">
-                                    詳細はスプレッドシートにのみ記録されます
-                                </span>
-                            </label>
-                        </div>
+                                {/* 詳細（任意） */}
+                                <div className="form-control">
+                                    <label className="label">
+                                        <span
+                                            className="label-text font-semibold"
+                                            style={{
+                                                fontSize:
+                                                    "clamp(0.875rem, 2vw, 1rem)",
+                                            }}
+                                        >
+                                            詳細
+                                            <span className="text-base-content/50 font-normal ml-2">
+                                                任意
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <textarea
+                                        placeholder="補足があれば入力してください"
+                                        className="textarea textarea-bordered w-full h-24"
+                                        value={formData.reasonDetail}
+                                        onChange={(e) =>
+                                            setFormData({
+                                                ...formData,
+                                                reasonDetail: e.target.value,
+                                            })
+                                        }
+                                    />
+                                    <label className="label">
+                                        <span className="label-text-alt text-base-content/50">
+                                            詳細はスプレッドシートにのみ記録されます
+                                        </span>
+                                    </label>
+                                </div>
+                            </>
+                        )}
 
                         {/* 中抜けの場合 */}
-                        {formData.type === "中抜け" && (
+                        {!isAttendanceEvent && formData.type === "中抜け" && (
                             <div className="space-y-4 p-4 bg-base-200/50 rounded-lg border border-base-300">
                                 <h3
                                     className="font-semibold"
@@ -322,7 +359,7 @@ export function AbsenceFormContent({
                         )}
 
                         {/* 早退の場合 */}
-                        {formData.type === "早退" && (
+                        {!isAttendanceEvent && formData.type === "早退" && (
                             <div className="space-y-4 p-4 bg-base-200/50 rounded-lg border border-base-300">
                                 <h3
                                     className="font-semibold"
@@ -363,7 +400,11 @@ export function AbsenceFormContent({
                                 }`}
                                 disabled={isSubmitting}
                             >
-                                {isSubmitting ? "送信中..." : "送信"}
+                                {isSubmitting
+                                    ? "送信中..."
+                                    : isAttendanceEvent
+                                      ? "出席申告を送信"
+                                      : "欠席連絡を送信"}
                             </button>
                             <a
                                 href="/home"

--- a/app/(authenticated)/absence/page.tsx
+++ b/app/(authenticated)/absence/page.tsx
@@ -5,7 +5,7 @@ import { AbsenceFormContent } from "./AbsenceFormContent";
 export default async function AbsencePage() {
     const session = await auth();
     const studentId = session?.studentId || null;
-    const memberName = session?.memberName || null;
+    const memberName = session?.displayName || session?.memberName || null;
 
     return (
         <Suspense

--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useRef, useState } from "react";
 import { ScheduleCard } from "@/features/schedule-card";
-import type { Absence } from "@/src/shared/types/api";
+import {
+    normalizeScheduleAttendanceMode,
+    SCHEDULE_ATTENDANCE_MODE_LABELS,
+} from "@/src/shared/types/api";
+import type {
+    Absence,
+    ScheduleAttendanceMode,
+} from "@/src/shared/types/api";
 import { HelpButton } from "@/src/features/help";
 import {
     getClientCacheEntry,
@@ -68,10 +75,18 @@ interface EventForm {
     endDate: string;
     isAllDay: boolean;
     color: EventColorId;
+    attendanceMode: ScheduleAttendanceMode;
 }
 
 const CALENDAR_REFRESH_INTERVAL = CACHE_TTL_MS.pageData;
 const CALENDAR_REFETCH_COOLDOWN = 60 * 1000;
+
+const getScheduleAttendanceMode = (
+    schedule: Schedule
+): ScheduleAttendanceMode =>
+    normalizeScheduleAttendanceMode(
+        schedule.ATTENDANCE_MODE ?? schedule.attendanceMode
+    );
 
 export default function CalendarPage() {
     const [schedules, setSchedules] = useState<Schedule[]>([]);
@@ -103,6 +118,7 @@ export default function CalendarPage() {
         endDate: "",
         isAllDay: false,
         color: "primary",
+        attendanceMode: "ABSENCE",
     });
     const [editForm, setEditForm] = useState<EventForm>({
         title: "",
@@ -118,6 +134,7 @@ export default function CalendarPage() {
         endDate: "",
         isAllDay: false,
         color: "primary",
+        attendanceMode: "ABSENCE",
     });
 
     useEffect(() => {
@@ -335,6 +352,7 @@ export default function CalendarPage() {
             endDate: "",
             isAllDay: false,
             color: "primary",
+            attendanceMode: "ABSENCE",
         });
         setEditForm({
             title: "",
@@ -350,6 +368,7 @@ export default function CalendarPage() {
             endDate: "",
             isAllDay: false,
             color: "primary",
+            attendanceMode: "ABSENCE",
         });
     };
 
@@ -375,6 +394,7 @@ export default function CalendarPage() {
             endDate: "",
             isAllDay: false,
             color: "primary",
+            attendanceMode: "ABSENCE",
         });
     };
 
@@ -403,6 +423,7 @@ export default function CalendarPage() {
                     endMonth: addForm.endMonth || undefined,
                     endDate: addForm.endDate || undefined,
                     color: addForm.color,
+                    attendanceMode: addForm.attendanceMode,
                 }),
             });
 
@@ -424,6 +445,7 @@ export default function CalendarPage() {
                     END_MM: data.data.endMonth || "",
                     END_DD: data.data.endDate || "",
                     COLOR: data.data.color || "primary",
+                    ATTENDANCE_MODE: data.data.attendanceMode || "ABSENCE",
                 };
                 setSchedules((prev) => {
                     const next = [...prev, newSchedule];
@@ -520,6 +542,7 @@ export default function CalendarPage() {
                     : "",
             isAllDay,
             color: (values[12] as EventColorId) || "primary",
+            attendanceMode: getScheduleAttendanceMode(selectedEvent),
         });
         setShowEditModal(true);
     };
@@ -542,6 +565,7 @@ export default function CalendarPage() {
             endDate: "",
             isAllDay: false,
             color: "primary",
+            attendanceMode: "ABSENCE",
         });
     };
 
@@ -625,6 +649,7 @@ export default function CalendarPage() {
                     endMonth: editForm.endMonth || undefined,
                     endDate: editForm.endDate || undefined,
                     color: editForm.color,
+                    attendanceMode: editForm.attendanceMode,
                 }),
             });
 
@@ -650,6 +675,8 @@ export default function CalendarPage() {
                                 END_MM: data.data.endMonth || "",
                                 END_DD: data.data.endDate || "",
                                 COLOR: data.data.color || "primary",
+                                ATTENDANCE_MODE:
+                                    data.data.attendanceMode || "ABSENCE",
                             };
                         }
                         return schedule;
@@ -1297,7 +1324,7 @@ export default function CalendarPage() {
             {/* イベント一覧モーダル */}
             {selectedDate && !selectedEvent && !showAddModal && (
                 <dialog className="modal modal-open modal-middle">
-                    <div className="modal-box max-w-2xl max-h-[calc(100vh-5rem)] flex flex-col">
+                    <div className="modal-box max-w-2xl max-h-[calc(100vh-5rem)] flex flex-col bg-base-200">
                         <button
                             onClick={closeModal}
                             className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
@@ -1319,7 +1346,7 @@ export default function CalendarPage() {
                                     この日の予定はありません
                                 </div>
                             ) : (
-                                <div className="space-y-3">
+                                <div className="overflow-hidden rounded-xl bg-base-100 ring-1 ring-base-300/70 divide-y divide-base-300/70">
                                     {selectedDate.events.map(
                                         (eventWithPos, index) => {
                                             const { schedule, position } =
@@ -1339,6 +1366,12 @@ export default function CalendarPage() {
                                             const where = String(
                                                 values[7] ?? ""
                                             );
+                                            const attendanceMode =
+                                                getScheduleAttendanceMode(
+                                                    schedule
+                                                );
+                                            const attendanceModeBadgeClass =
+                                                "border-base-content/35 bg-base-200/70 text-base-content/70";
                                             const endYear = values[9]
                                                 ? Number(values[9])
                                                 : 0;
@@ -1361,6 +1394,21 @@ export default function CalendarPage() {
                                                       rawTimeMM
                                                   ).padStart(2, "0")}`
                                                 : null;
+                                            const startDate = new Date(
+                                                startYear,
+                                                startMonth - 1,
+                                                startDay
+                                            );
+                                            const startDayOfWeek = [
+                                                "日",
+                                                "月",
+                                                "火",
+                                                "水",
+                                                "木",
+                                                "金",
+                                                "土",
+                                            ][startDate.getDay()];
+                                            const startDateLabel = `${startMonth}/${startDay}(${startDayOfWeek})`;
 
                                             // 複数日イベントの期間表示
                                             const isMultiDay =
@@ -1371,7 +1419,13 @@ export default function CalendarPage() {
                                                 endMonth &&
                                                 endDay
                                                     ? `${startYear}年 ${startMonth}月 ${startDay}日 〜 ${endYear}年 ${endMonth}月 ${endDay}日`
-                                                    : null;
+                                                    : startDateLabel;
+                                            const dateTimeLabel = [
+                                                dateRangeLabel,
+                                                timeLabel,
+                                            ]
+                                                .filter(Boolean)
+                                                .join(" ");
 
                                             // イベントの色を取得
                                             const eventColor = getColorHex(
@@ -1386,47 +1440,93 @@ export default function CalendarPage() {
                                                             schedule
                                                         )
                                                     }
-                                                    className="p-5 bg-base-100 rounded-xl shadow-sm hover:shadow-lg transition-all cursor-pointer hover:bg-base-200/50"
-                                                    style={{
-                                                        borderLeftColor:
-                                                            eventColor,
-                                                    }}
+                                                    className="group bg-base-100 px-4 py-4 transition-colors hover:bg-base-200/50 cursor-pointer sm:px-5"
                                                 >
-                                                    <div className="flex items-center gap-3">
+                                                    <div className="flex items-stretch gap-4">
                                                         <div
-                                                            className="w-3 h-3 rounded-full shrink-0"
+                                                            className="w-1 rounded-full"
                                                             style={{
                                                                 backgroundColor:
                                                                     eventColor,
                                                             }}
-                                                        ></div>
-                                                        <div className="flex-1">
-                                                            <div className="font-bold text-lg flex items-center gap-2">
+                                                        />
+                                                        <div className="min-w-0 flex-1">
+                                                            <div className="text-lg font-bold">
                                                                 {title}
-                                                                {timeLabel && (
-                                                                    <span className="text-sm font-normal text-base-content/70">
+                                                            </div>
+                                                            <div className="mt-0">
+                                                                <span
+                                                                    className={`badge badge-outline badge-sm ${attendanceModeBadgeClass}`}
+                                                                >
+                                                                    {
+                                                                        SCHEDULE_ATTENDANCE_MODE_LABELS[
+                                                                            attendanceMode
+                                                                        ]
+                                                                    }
+                                                                </span>
+                                                            </div>
+                                                            <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-base-content/80">
+                                                                <div className="flex items-center gap-1">
+                                                                    <svg
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                        className="h-4 w-4 text-primary"
+                                                                        fill="none"
+                                                                        viewBox="0 0 24 24"
+                                                                        stroke="currentColor"
+                                                                    >
+                                                                        <path
+                                                                            strokeLinecap="round"
+                                                                            strokeLinejoin="round"
+                                                                            strokeWidth={
+                                                                                2
+                                                                            }
+                                                                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                                                                        />
+                                                                    </svg>
+                                                                    <span className="font-medium">
                                                                         {
-                                                                            timeLabel
+                                                                            dateTimeLabel
                                                                         }
                                                                     </span>
+                                                                </div>
+                                                                {where && (
+                                                                    <div className="flex items-center gap-1">
+                                                                        <svg
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                            className="h-4 w-4 text-primary"
+                                                                            fill="none"
+                                                                            viewBox="0 0 24 24"
+                                                                            stroke="currentColor"
+                                                                        >
+                                                                            <path
+                                                                                strokeLinecap="round"
+                                                                                strokeLinejoin="round"
+                                                                                strokeWidth={
+                                                                                    2
+                                                                                }
+                                                                                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                                                                            />
+                                                                            <path
+                                                                                strokeLinecap="round"
+                                                                                strokeLinejoin="round"
+                                                                                strokeWidth={
+                                                                                    2
+                                                                                }
+                                                                                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                                                                            />
+                                                                        </svg>
+                                                                        <span className="font-medium">
+                                                                            {
+                                                                                where
+                                                                            }
+                                                                        </span>
+                                                                    </div>
                                                                 )}
                                                             </div>
-                                                            {dateRangeLabel && (
-                                                                <div className="text-sm text-base-content/70 mt-1">
-                                                                    {
-                                                                        dateRangeLabel
-                                                                    }
-                                                                </div>
-                                                            )}
-                                                            {where && (
-                                                                <div className="text-sm text-base-content/70 mt-1">
-                                                                    {where}
-                                                                </div>
-                                                            )}
                                                         </div>
                                                         <svg
                                                             xmlns="http://www.w3.org/2000/svg"
-                                                            className="h-5 w-5 text-base-content/50"
+                                                            className="mt-1 h-5 w-5 shrink-0 text-base-content/40 transition-transform group-hover:translate-x-0.5 group-hover:text-base-content/60"
                                                             fill="none"
                                                             viewBox="0 0 24 24"
                                                             stroke="currentColor"
@@ -1541,6 +1641,66 @@ export default function CalendarPage() {
                                     />
                                     <span className="label-text">終日</span>
                                 </label>
+                            </div>
+                            <div className="form-control">
+                                <label className="label">
+                                    <span className="label-text">
+                                        出欠方式
+                                    </span>
+                                </label>
+                                <div className="grid grid-cols-1 gap-2">
+                                    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-base-300 p-3">
+                                        <input
+                                            type="radio"
+                                            name="addAttendanceMode"
+                                            className="radio radio-primary mt-1"
+                                            checked={
+                                                addForm.attendanceMode ===
+                                                "ABSENCE"
+                                            }
+                                            onChange={() =>
+                                                setAddForm({
+                                                    ...addForm,
+                                                    attendanceMode: "ABSENCE",
+                                                })
+                                            }
+                                        />
+                                        <span>
+                                            <span className="block font-medium">
+                                                全員参加
+                                            </span>
+                                            <span className="text-sm text-base-content/70">
+                                                全員参加が原則。欠席者が連絡します。
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-base-300 p-3">
+                                        <input
+                                            type="radio"
+                                            name="addAttendanceMode"
+                                            className="radio radio-primary mt-1"
+                                            checked={
+                                                addForm.attendanceMode ===
+                                                "ATTENDANCE"
+                                            }
+                                            onChange={() =>
+                                                setAddForm({
+                                                    ...addForm,
+                                                    attendanceMode:
+                                                        "ATTENDANCE",
+                                                })
+                                            }
+                                        />
+                                        <span>
+                                            <span className="block font-medium">
+                                                希望者参加
+                                            </span>
+                                            <span className="text-sm text-base-content/70">
+                                                参加希望者が出席を申告します。
+                                            </span>
+                                        </span>
+                                    </label>
+                                </div>
                             </div>
                             {addForm.isAllDay ? (
                                 <>
@@ -1770,6 +1930,8 @@ export default function CalendarPage() {
                     const title = String(values[6] ?? "予定");
                     const where = String(values[7] ?? "");
                     const detail = String(values[8] ?? "");
+                    const attendanceMode =
+                        getScheduleAttendanceMode(selectedEvent);
 
                     const scheduleDate = new Date(year, month - 1, date);
                     const scheduleDayOfWeek = [
@@ -1808,6 +1970,7 @@ export default function CalendarPage() {
                             where={where}
                             detail={detail}
                             absences={eventAbsences}
+                            attendanceMode={attendanceMode}
                             dateLabel={dateLabel}
                             timeLabel={timeLabel}
                             defaultOpen={true}
@@ -1876,6 +2039,66 @@ export default function CalendarPage() {
                                     />
                                     <span className="label-text">終日</span>
                                 </label>
+                            </div>
+                            <div className="form-control">
+                                <label className="label">
+                                    <span className="label-text">
+                                        出欠方式
+                                    </span>
+                                </label>
+                                <div className="grid grid-cols-1 gap-2">
+                                    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-base-300 p-3">
+                                        <input
+                                            type="radio"
+                                            name="editAttendanceMode"
+                                            className="radio radio-primary mt-1"
+                                            checked={
+                                                editForm.attendanceMode ===
+                                                "ABSENCE"
+                                            }
+                                            onChange={() =>
+                                                setEditForm({
+                                                    ...editForm,
+                                                    attendanceMode: "ABSENCE",
+                                                })
+                                            }
+                                        />
+                                        <span>
+                                            <span className="block font-medium">
+                                                全員参加
+                                            </span>
+                                            <span className="text-sm text-base-content/70">
+                                                全員参加が原則。欠席者が連絡します。
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-base-300 p-3">
+                                        <input
+                                            type="radio"
+                                            name="editAttendanceMode"
+                                            className="radio radio-primary mt-1"
+                                            checked={
+                                                editForm.attendanceMode ===
+                                                "ATTENDANCE"
+                                            }
+                                            onChange={() =>
+                                                setEditForm({
+                                                    ...editForm,
+                                                    attendanceMode:
+                                                        "ATTENDANCE",
+                                                })
+                                            }
+                                        />
+                                        <span>
+                                            <span className="block font-medium">
+                                                希望者参加
+                                            </span>
+                                            <span className="text-sm text-base-content/70">
+                                                参加希望者が出席を申告します。
+                                            </span>
+                                        </span>
+                                    </label>
+                                </div>
                             </div>
                             <div className="form-control">
                                 <label className="label">

--- a/app/(authenticated)/home/loading.tsx
+++ b/app/(authenticated)/home/loading.tsx
@@ -1,15 +1,15 @@
 export default function HomeLoading() {
     return (
-        <div className="max-w-full p-4 sm:px-6 sm:py-5 lg:flex lg:h-screen lg:flex-col lg:overflow-hidden lg:px-8 lg:py-6">
+        <div className="max-w-full p-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">
             <div className="mb-5 flex items-center gap-3 max-lg:hidden shrink-0 lg:mb-6">
                 <div className="h-6 w-6 bg-base-300 rounded animate-pulse"></div>
                 <div className="h-7 w-48 bg-base-300 rounded-lg animate-pulse"></div>
             </div>
 
-            <div className="grid grid-cols-1 gap-5 lg:flex-1 lg:min-h-0 lg:grid-cols-12 lg:grid-rows-[auto_auto_minmax(0,1fr)]">
+            <div className="grid grid-cols-1 gap-5 lg:grid-cols-12">
                 {/* Schedule Card Skeleton */}
-                <div className="card bg-base-100 shadow-xl border border-base-300 order-3 h-[420px] lg:order-none lg:col-span-7 lg:row-start-3 lg:h-full lg:min-h-0">
-                    <div className="card-body flex flex-col overflow-hidden p-5 pb-4">
+                <div className="card bg-base-100 shadow-xl border border-base-300 order-3 lg:order-3 lg:col-span-6">
+                    <div className="card-body flex flex-col p-5 pb-4">
                         <div className="mb-3 flex h-8 items-center gap-2 shrink-0">
                             <div className="h-5 w-5 bg-base-300 rounded animate-pulse"></div>
                             <div className="h-5 w-40 bg-base-300 rounded animate-pulse"></div>
@@ -21,7 +21,7 @@ export default function HomeLoading() {
                 </div>
 
                 {/* Weather & Clock Card Skeleton */}
-                <div className="card bg-base-100 shadow-xl border border-base-300 order-1 lg:order-none lg:col-span-12 lg:row-start-1">
+                <div className="card bg-base-100 shadow-xl border border-base-300 order-1 lg:order-1 lg:col-span-12">
                     <div className="card-body p-4">
                         <div className="flex h-7 items-center gap-2 shrink-0">
                             <div className="h-5 w-5 bg-base-300 rounded animate-pulse"></div>
@@ -36,7 +36,7 @@ export default function HomeLoading() {
                 </div>
 
                 {/* Next Meeting Card Skeleton */}
-                <div className="card bg-base-100 shadow-xl border border-base-300 order-2 lg:order-none lg:col-span-12 lg:row-start-2">
+                <div className="card bg-base-100 shadow-xl border border-base-300 order-2 lg:order-2 lg:col-span-12">
                     <div className="card-body gap-4 p-5 pb-4">
                         <div className="flex items-center gap-2">
                             <div className="h-5 w-5 bg-base-300 rounded animate-pulse"></div>
@@ -59,7 +59,7 @@ export default function HomeLoading() {
                 </div>
 
                 {/* Absences Card Skeleton */}
-                <div className="card bg-base-100 shadow-xl border border-base-300 order-4 h-[420px] overflow-hidden lg:order-none lg:col-span-5 lg:row-start-3 lg:h-full lg:min-h-0">
+                <div className="card bg-base-100 shadow-xl border border-base-300 order-4 overflow-hidden lg:order-4 lg:col-span-6">
                     <div className="card-body flex flex-col p-5 pb-4">
                         <div className="mb-3 flex h-8 items-center gap-2">
                             <div className="h-5 w-5 bg-base-300 rounded animate-pulse"></div>

--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -7,7 +7,9 @@ import type {
     Absence,
     NextMeetingSettings,
     Schedule,
+    ScheduleAttendanceMode,
 } from "@/src/shared/types/api";
+import { normalizeScheduleAttendanceMode } from "@/src/shared/types/api";
 import { DigitalClock } from "@/features/digital-clock";
 import { WeatherWidget } from "@/features/weather";
 import { ScheduleCard } from "@/features/schedule-card";
@@ -15,6 +17,13 @@ import { DateDisplay } from "@/features/date-display";
 import { ProfileImageSaver } from "@/features/profile-image";
 import { NextMeetingCard } from "@/src/features/next-meeting";
 import { auth } from "@/src/auth";
+
+const getScheduleAttendanceMode = (
+    schedule: Schedule
+): ScheduleAttendanceMode =>
+    normalizeScheduleAttendanceMode(
+        schedule.ATTENDANCE_MODE ?? schedule.attendanceMode
+    );
 
 export default async function HomePage() {
     const session = await auth();
@@ -65,10 +74,12 @@ export default async function HomePage() {
         })
         .map((schedule) => String(Object.values(schedule)[0]));
 
-    // 本日の欠席者をフィルタリング（今日のイベントに紐づく欠席者のみ）
+    // 本日の欠席者をフィルタリング（出席申告は除外）
     const todayAbsences = absences.filter((absence) => {
-        const absenceEventId = String(Object.values(absence)[1]); // B列のEVENT_ID
-        return todayEventIds.includes(absenceEventId);
+        const values = Object.values(absence);
+        const absenceEventId = String(values[1]); // B列のEVENT_ID
+        const type = String(values[4] ?? ""); // E列の種別
+        return todayEventIds.includes(absenceEventId) && type !== "出席";
     });
 
     const upcomingSchedules = schedules
@@ -100,7 +111,7 @@ export default async function HomePage() {
     return (
         <>
             <ProfileImageSaver profileImage={session?.profileImage} />
-            <div className="max-w-full p-4 sm:px-6 sm:py-5 lg:flex lg:h-screen lg:flex-col lg:overflow-hidden lg:px-8 lg:py-6">
+            <div className="max-w-full p-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">
                 <div className="mb-5 flex items-center gap-3 max-lg:hidden shrink-0 lg:mb-6">
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -129,9 +140,9 @@ export default async function HomePage() {
                     </div>
                 )}
 
-                <div className="grid grid-cols-1 gap-5 lg:flex-1 lg:min-h-0 lg:grid-cols-12 lg:grid-rows-[auto_auto_minmax(0,1fr)]">
-                    <div className="card bg-base-100 shadow-xl border border-base-300 order-3 h-[420px] lg:order-none lg:col-span-7 lg:row-start-3 lg:h-full lg:min-h-0">
-                        <div className="card-body flex flex-col overflow-hidden p-5 pb-4">
+                <div className="grid grid-cols-1 gap-5 lg:grid-cols-12">
+                    <div className="card bg-base-100 shadow-xl border border-base-300 order-3 lg:order-3 lg:col-span-6">
+                        <div className="card-body flex flex-col p-5 pb-4">
                             <div className="mb-3 flex h-8 items-center gap-2 shrink-0">
                                 <svg
                                     xmlns="http://www.w3.org/2000/svg"
@@ -162,7 +173,7 @@ export default async function HomePage() {
                                 )}
                             </div>
                             {upcomingSchedules.length > 0 ? (
-                                <div className="flex-1 overflow-y-auto pr-2 space-y-4 min-h-0">
+                                <div className="overflow-hidden rounded-xl bg-base-100 ring-1 ring-base-300/70 divide-y divide-base-300/70">
                                     {upcomingSchedules.map(
                                         (schedule: Schedule, index: number) => {
                                             const values =
@@ -184,6 +195,10 @@ export default async function HomePage() {
                                             const detail = String(
                                                 values[8] ?? ""
                                             ); // I列 (DETAIL)
+                                            const attendanceMode =
+                                                getScheduleAttendanceMode(
+                                                    schedule
+                                                );
 
                                             // 日付文字列を作成
                                             const scheduleDate = new Date(
@@ -236,6 +251,16 @@ export default async function HomePage() {
                                                     where={where}
                                                     detail={detail}
                                                     absences={eventAbsences}
+                                                    attendanceMode={
+                                                        attendanceMode
+                                                    }
+                                                    currentStudentNumber={
+                                                        session?.studentId
+                                                    }
+                                                    currentDisplayName={
+                                                        session?.displayName ||
+                                                        session?.memberName
+                                                    }
                                                     dateLabel={dateLabel}
                                                     timeLabel={timeLabel}
                                                 />
@@ -274,7 +299,7 @@ export default async function HomePage() {
                         </div>
                     </div>
 
-                    <div className="card bg-base-100 shadow-xl border border-base-300 order-1 lg:order-none lg:col-span-12 lg:row-start-1">
+                    <div className="card bg-base-100 shadow-xl border border-base-300 order-1 lg:order-1 lg:col-span-12">
                         <div className="card-body p-4">
                             <div className="flex h-7 items-center gap-2 shrink-0">
                                 <svg
@@ -313,10 +338,10 @@ export default async function HomePage() {
                     <NextMeetingCard
                         initialMeeting={nextMeeting}
                         permission={session?.permission}
-                        className="order-2 lg:order-none lg:col-span-12 lg:row-start-2"
+                        className="order-2 lg:order-2 lg:col-span-12"
                     />
 
-                    <div className="card bg-base-100 shadow-xl border border-base-300 order-4 h-[420px] overflow-hidden lg:order-none lg:col-span-5 lg:row-start-3 lg:h-full lg:min-h-0">
+                    <div className="card bg-base-100 shadow-xl border border-base-300 order-4 overflow-hidden lg:order-4 lg:col-span-6">
                         <div className="card-body flex flex-col p-5 pb-4">
                             <div className="mb-3 flex h-8 items-center gap-2">
                                 <svg

--- a/app/(authenticated)/members/page.tsx
+++ b/app/(authenticated)/members/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     MEMBER_PERMISSION_LABELS,
     MEMBER_PERMISSIONS,
@@ -216,6 +216,8 @@ export default function MembersPage() {
     const [error, setError] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+    const [isCheckedListModalOpen, setIsCheckedListModalOpen] =
+        useState(false);
     const [editingMember, setEditingMember] = useState<MemberRow | null>(null);
     const [deletingMember, setDeletingMember] = useState<MemberRow | null>(
         null
@@ -224,8 +226,14 @@ export default function MembersPage() {
     const [editValues, setEditValues] = useState<string[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [modalError, setModalError] = useState<string | null>(null);
+    const [lineNameCopyStatus, setLineNameCopyStatus] = useState<
+        "idle" | "copied" | "failed"
+    >("idle");
     const [checkedMemberRows, setCheckedMemberRows] = useState<Set<number>>(
         () => new Set()
+    );
+    const lineNameCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+        null
     );
 
     const applyMembersData = useCallback((data: MembersData) => {
@@ -286,8 +294,22 @@ export default function MembersPage() {
         void fetchMembers();
     }, [fetchMembers]);
 
+    useEffect(
+        () => () => {
+            if (lineNameCopyTimerRef.current) {
+                clearTimeout(lineNameCopyTimerRef.current);
+            }
+        },
+        []
+    );
+
     const studentNumberColumnIndex = useMemo(
         () => headers.findIndex(isStudentNumberHeader),
+        [headers]
+    );
+
+    const lineNameColumnIndex = useMemo(
+        () => headers.findIndex(isLineNameHeader),
         [headers]
     );
 
@@ -335,12 +357,35 @@ export default function MembersPage() {
         });
     }, [members, query, selectedAdmissionYear, studentNumberColumnIndex]);
 
+    const checkedMembers = useMemo(
+        () =>
+            members.filter((member) =>
+                checkedMemberRows.has(member.rowNumber)
+            ),
+        [checkedMemberRows, members]
+    );
+
+    const checkedLineNames = useMemo(() => {
+        if (lineNameColumnIndex < 0) return [];
+
+        return checkedMembers
+            .map((member) => stringifyCell(member.values[lineNameColumnIndex]))
+            .map((lineName) => lineName.trim())
+            .filter((lineName) => lineName !== "")
+            .map((lineName) =>
+                lineName.startsWith("@") ? lineName : `@${lineName}`
+            );
+    }, [checkedMembers, lineNameColumnIndex]);
+
     const hasActiveFilters =
-        query.trim() !== "" || selectedAdmissionYear !== "all";
+        query.trim() !== "" ||
+        selectedAdmissionYear !== "all" ||
+        checkedMemberRows.size > 0;
 
     const clearFilters = () => {
         setQuery("");
         setSelectedAdmissionYear("all");
+        setCheckedMemberRows(new Set());
     };
 
     const toggleMemberCheck = (rowNumber: number, checked: boolean) => {
@@ -400,6 +445,31 @@ export default function MembersPage() {
         setIsCreateModalOpen(false);
         setCreateValues([]);
         setModalError(null);
+    };
+
+    const closeCheckedListModal = () => {
+        setIsCheckedListModalOpen(false);
+        setLineNameCopyStatus("idle");
+    };
+
+    const copyCheckedLineNames = async () => {
+        if (checkedLineNames.length === 0) return;
+
+        if (lineNameCopyTimerRef.current) {
+            clearTimeout(lineNameCopyTimerRef.current);
+        }
+
+        try {
+            await navigator.clipboard.writeText(checkedLineNames.join(" "));
+            setLineNameCopyStatus("copied");
+        } catch {
+            setLineNameCopyStatus("failed");
+        }
+
+        lineNameCopyTimerRef.current = setTimeout(() => {
+            setLineNameCopyStatus("idle");
+            lineNameCopyTimerRef.current = null;
+        }, 1000);
     };
 
     const openEditModal = (member: MemberRow) => {
@@ -561,28 +631,57 @@ export default function MembersPage() {
                             <h1 className="text-2xl font-bold">部員名簿</h1>
                         </div>
                     </div>
-                    <button
-                        type="button"
-                        className="btn btn-primary btn-sm gap-2"
-                        onClick={openCreateModal}
-                        disabled={isLoading || headers.length === 0}
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            className="size-4"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
+                    <div className="flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            className="btn btn-outline btn-sm gap-2"
+                            onClick={() => setIsCheckedListModalOpen(true)}
+                            disabled={isLoading || checkedMembers.length === 0}
                         >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M12 4.5v15m7.5-7.5h-15"
-                            />
-                        </svg>
-                        追加
-                    </button>
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="size-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                                />
+                            </svg>
+                            チェック済み
+                            {checkedMembers.length > 0 && (
+                                <span className="badge badge-primary badge-sm">
+                                    {checkedMembers.length}
+                                </span>
+                            )}
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-primary btn-sm gap-2"
+                            onClick={openCreateModal}
+                            disabled={isLoading || headers.length === 0}
+                        >
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="size-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M12 4.5v15m7.5-7.5h-15"
+                                />
+                            </svg>
+                            追加
+                        </button>
+                    </div>
                 </div>
 
                 {error && (
@@ -907,7 +1006,135 @@ export default function MembersPage() {
                             type="button"
                             onClick={() => closeCreateModal()}
                         >
-                            close
+                            閉じる
+                        </button>
+                    </form>
+                </dialog>
+            )}
+
+            {isCheckedListModalOpen && (
+                <dialog
+                    className="modal modal-open"
+                    onClose={closeCheckedListModal}
+                >
+                    <div className="modal-box max-w-2xl p-0 overflow-hidden">
+                        <div className="bg-base-200 px-6 py-5">
+                            <h2 className="font-bold text-lg">
+                                チェック済み部員
+                            </h2>
+                            <p className="mt-1 text-sm text-base-content/70">
+                                {checkedMembers.length}名
+                            </p>
+                        </div>
+
+                        <div className="max-h-[62vh] overflow-y-auto p-4 sm:p-6">
+                            {checkedMembers.length > 0 ? (
+                                <div className="overflow-x-auto rounded-lg border border-base-300">
+                                    <table className="table table-zebra table-sm w-full">
+                                        <thead>
+                                            <tr>
+                                                {visibleColumnIndices.map(
+                                                    (index) => (
+                                                        <th
+                                                            key={`${headers[index]}-${index}-checked`}
+                                                            className="whitespace-nowrap bg-base-200"
+                                                        >
+                                                            {getHeaderLabel(
+                                                                headers[index]
+                                                            )}
+                                                        </th>
+                                                    )
+                                                )}
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {checkedMembers.map((member) => (
+                                                <tr key={member.rowNumber}>
+                                                    {visibleColumnIndices.map(
+                                                        (index) => {
+                                                            const header =
+                                                                headers[index];
+                                                            const value =
+                                                                getDisplayCellValue(
+                                                                    member,
+                                                                    header,
+                                                                    index
+                                                                );
+
+                                                            return (
+                                                                <td
+                                                                    key={`${member.rowNumber}-${header}-${index}-checked`}
+                                                                >
+                                                                    <span
+                                                                        className={`block truncate ${
+                                                                            isStudentNumberHeader(
+                                                                                header
+                                                                            )
+                                                                                ? "font-mono text-sm"
+                                                                                : ""
+                                                                        }`}
+                                                                    >
+                                                                        {isBooleanCell(
+                                                                            value
+                                                                        )
+                                                                            ? getBooleanStatusLabel(
+                                                                                  getBooleanCellValue(
+                                                                                      value
+                                                                                  )
+                                                                              )
+                                                                            : stringifyCell(
+                                                                                  value
+                                                                              )}
+                                                                    </span>
+                                                                </td>
+                                                            );
+                                                        }
+                                                    )}
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            ) : (
+                                <div className="py-8 text-center text-base-content/60">
+                                    チェック済みの部員はいません
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="modal-action bg-base-100 border-t border-base-300 m-0 px-6 py-4">
+                            <div className="flex justify-end gap-2">
+                                <button
+                                    type="button"
+                                    className="btn btn-outline"
+                                    onClick={() => void copyCheckedLineNames()}
+                                    disabled={checkedLineNames.length === 0}
+                                >
+                                    {lineNameCopyStatus === "copied"
+                                        ? "コピー済み"
+                                        : lineNameCopyStatus === "failed"
+                                          ? "失敗"
+                                          : "LINE名コピー"}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="btn btn-primary"
+                                    onClick={closeCheckedListModal}
+                                >
+                                    閉じる
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <form
+                        method="dialog"
+                        className="modal-backdrop"
+                    >
+                        <button
+                            type="button"
+                            onClick={closeCheckedListModal}
+                        >
+                            閉じる
                         </button>
                     </form>
                 </dialog>
@@ -1000,7 +1227,7 @@ export default function MembersPage() {
                             type="button"
                             onClick={() => closeEditModal()}
                         >
-                            close
+                            閉じる
                         </button>
                     </form>
                 </dialog>
@@ -1054,7 +1281,7 @@ export default function MembersPage() {
                             type="button"
                             onClick={() => closeDeleteModal()}
                         >
-                            close
+                            閉じる
                         </button>
                     </form>
                 </dialog>

--- a/app/api/absence/route.ts
+++ b/app/api/absence/route.ts
@@ -44,9 +44,21 @@ export async function POST(request: NextRequest) {
 
     try {
         const body = await request.json();
+        const sessionDisplayName =
+            session.displayName ||
+            session.memberName ||
+            session.nickname ||
+            session.user.name ||
+            session.studentId;
+        const submitBody = {
+            ...body,
+            studentNumber: body.studentNumber || session.studentId,
+            name: body.name || sessionDisplayName,
+            reason: body.type === "出席" ? body.reason || "出席" : body.reason,
+        };
 
         // 入力バリデーション
-        const validationResult = absenceSubmitSchema.safeParse(body);
+        const validationResult = absenceSubmitSchema.safeParse(submitBody);
         if (!validationResult.success) {
             return NextResponse.json(
                 {

--- a/gas/main.js
+++ b/gas/main.js
@@ -319,6 +319,7 @@ const getFormData = (e) => {
 
 /** 種別に応じたEmbed色を返す */
 const getAbsenceColor = (type) => {
+    if (type === "出席") return 0x57f287;
     if (type === "欠席") return 0xed4245;
     if (type === "遅刻") return 0xfee75c;
     if (type === "早退") return 0xf0b232;
@@ -350,6 +351,7 @@ const formatTypeWithTime = (type, opts = {}) => {
  */
 const buildAbsenceEmbed = (params) => {
     const typeDisplay = formatTypeWithTime(params.type, params);
+    const isAttendance = params.type === "出席";
     const fields = [
         { name: "氏名", value: params.name || "不明", inline: true },
         { name: "種別", value: typeDisplay, inline: true },
@@ -367,7 +369,7 @@ const buildAbsenceEmbed = (params) => {
     }
 
     const embed = {
-        title: "欠席連絡",
+        title: isAttendance ? "出席申告" : "欠席連絡",
         color: getAbsenceColor(params.type),
         fields,
     };
@@ -1180,8 +1182,27 @@ const handleDeleteItem = (postData) => {
 // ============================================
 // API: スケジュール一覧取得
 // シート名: schedules
-// 列構成: A:EVENT_ID, B:YYYY, C:MM, D:DD, E:TIME_HH, F:TIME_MM, G:TITLE, H:WHERE, I:DETAIL, J:END_YYYY, K:END_MM, L:END_DD, M:COLOR, N:CREATED_BY, O:CREATED_AT, P:UPDATED_BY, Q:UPDATED_AT
+// 列構成: A:EVENT_ID, B:YYYY, C:MM, D:DD, E:TIME_HH, F:TIME_MM, G:TITLE, H:WHERE, I:DETAIL, J:END_YYYY, K:END_MM, L:END_DD, M:COLOR, N:CREATED_BY, O:CREATED_AT, P:UPDATED_BY, Q:UPDATED_AT, R:ATTENDANCE_MODE
 // ============================================
+
+const SCHEDULE_ATTENDANCE_MODE_COLUMN = 18;
+
+const normalizeScheduleAttendanceMode = (mode) =>
+    String(mode || "").trim().toUpperCase() === "ATTENDANCE"
+        ? "ATTENDANCE"
+        : "ABSENCE";
+
+const ensureScheduleAttendanceModeHeader = (sheet) => {
+    const header = String(
+        sheet.getRange(1, SCHEDULE_ATTENDANCE_MODE_COLUMN).getValue() || ""
+    ).trim();
+
+    if (!header) {
+        sheet
+            .getRange(1, SCHEDULE_ATTENDANCE_MODE_COLUMN)
+            .setValue("ATTENDANCE_MODE");
+    }
+};
 
 /**
  * スケジュール一覧を取得
@@ -1197,6 +1218,8 @@ const handleGetSchedules = (e) => {
             return createErrorResponse("Sheet 'schedules' not found", 404);
         }
 
+        ensureScheduleAttendanceModeHeader(sheet);
+
         const lastRow = sheet.getLastRow();
         if (lastRow < 2) {
             return createResponse({
@@ -1206,12 +1229,12 @@ const handleGetSchedules = (e) => {
             });
         }
 
-        // A2:M（2行目以降、13列）のデータを取得（終了日とカラーを含む）
-        const range = sheet.getRange(2, 1, lastRow - 1, 13);
+        // A2:R（2行目以降、18列）のデータを取得（終了日、カラー、出欠方式を含む）
+        const range = sheet.getRange(2, 1, lastRow - 1, 18);
         const values = range.getValues();
 
-        // ヘッダー行（A1:M1）を取得
-        const headers = sheet.getRange(1, 1, 1, 13).getValues()[0];
+        // ヘッダー行（A1:R1）を取得
+        const headers = sheet.getRange(1, 1, 1, 18).getValues()[0];
 
         // ヘッダーをキーとしたオブジェクト配列に変換
         const schedules = values.map((row) => {
@@ -1819,6 +1842,7 @@ const handlePostSchedule = (postData) => {
             endMonth,
             endDate,
             color,
+            attendanceMode,
             createdBy,
         } = postData;
 
@@ -1836,6 +1860,8 @@ const handlePostSchedule = (postData) => {
         if (!sheet) {
             return createErrorResponse("Sheet 'schedules' not found", 404);
         }
+
+        ensureScheduleAttendanceModeHeader(sheet);
 
         // EVENT_IDを自動生成（E-XX形式、行番号-1で0埋め2桁）
         const lastRow = sheet.getLastRow();
@@ -1868,6 +1894,9 @@ const handlePostSchedule = (postData) => {
             color || "primary",
             createdBy || "",
             createdAt,
+            "",
+            "",
+            normalizeScheduleAttendanceMode(attendanceMode),
         ];
 
         sheet.appendRow(rowData);
@@ -1893,6 +1922,7 @@ const handlePostSchedule = (postData) => {
                 endMonth: endMonth || null,
                 endDate: endDate || null,
                 color: color || "primary",
+                attendanceMode: normalizeScheduleAttendanceMode(attendanceMode),
                 createdBy: createdBy || "",
                 createdAt,
             },
@@ -1930,7 +1960,13 @@ const handlePostAbsence = (postData) => {
         } = postData;
 
         // 必須フィールドの検証
-        if (!eventId || !studentNumber || !name || !type || !reason) {
+        if (
+            !eventId ||
+            !studentNumber ||
+            !name ||
+            !type ||
+            (type !== "出席" && !reason)
+        ) {
             return createErrorResponse("Missing required fields", 400);
         }
 
@@ -1956,7 +1992,7 @@ const handlePostAbsence = (postData) => {
             studentNumber,
             name,
             type,
-            reason,
+            type === "出席" ? "" : reason,
             reasonDetail || "",
             timeLeavingEarly || "",
             timeStepOut || "",
@@ -1973,7 +2009,7 @@ const handlePostAbsence = (postData) => {
             const embed = buildAbsenceEmbed({
                 name,
                 type,
-                reason,
+                reason: type === "出席" ? "" : reason,
                 reasonDetail,
                 timestamp,
                 timeLeavingEarly,
@@ -1989,7 +2025,10 @@ const handlePostAbsence = (postData) => {
 
         if (domain && studentNumber) {
             const email = `${studentNumber}@${domain}`;
-            const subject = "欠席連絡フォーム送信完了通知";
+            const isAttendance = type === "出席";
+            const subject = isAttendance
+                ? "出席申告フォーム送信完了通知"
+                : "欠席連絡フォーム送信完了通知";
 
             let bodyText = `${name} さん\n\n`;
             bodyText += `以下の内容でフォームが送信されました．\n\n`;
@@ -2002,14 +2041,16 @@ const handlePostAbsence = (postData) => {
                 bodyText += `(${timeStepOut || ""} ~ ${timeReturn || ""})`;
             }
 
-            bodyText += `\n理由: ${reason}\n`;
+            if (!isAttendance) {
+                bodyText += `\n理由: ${reason}\n`;
+            }
             if (reasonDetail) {
                 bodyText += `詳細: ${reasonDetail}\n`;
             }
             bodyText += `\n送信日時: ${timestamp}\n`;
 
             MailApp.sendEmail(email, subject, bodyText, {
-                name: "欠席連絡システム",
+                name: isAttendance ? "出席申告システム" : "欠席連絡システム",
             });
         }
 
@@ -2057,6 +2098,7 @@ const handleUpdateSchedule = (postData) => {
             endMonth,
             endDate,
             color,
+            attendanceMode,
             updatedBy,
         } = postData;
 
@@ -2074,6 +2116,8 @@ const handleUpdateSchedule = (postData) => {
         if (!sheet) {
             return createErrorResponse("Sheet 'schedules' not found", 404);
         }
+
+        ensureScheduleAttendanceModeHeader(sheet);
 
         const lastRow = sheet.getLastRow();
         if (lastRow < 2) {
@@ -2124,6 +2168,9 @@ const handleUpdateSchedule = (postData) => {
         ];
 
         sheet.getRange(targetRow, 2, 1, 12).setValues([updateData]);
+        sheet
+            .getRange(targetRow, SCHEDULE_ATTENDANCE_MODE_COLUMN)
+            .setValue(normalizeScheduleAttendanceMode(attendanceMode));
 
         // P列（UPDATED_BY）とQ列（UPDATED_AT）を更新
         if (updatedBy) {
@@ -2153,6 +2200,7 @@ const handleUpdateSchedule = (postData) => {
                 endMonth: endMonth || null,
                 endDate: endDate || null,
                 color: color || "primary",
+                attendanceMode: normalizeScheduleAttendanceMode(attendanceMode),
                 updatedBy: updatedBy || "",
                 updatedAt,
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "1.8.5",
+    "version": "1.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "1.8.5",
+            "version": "1.9.0",
             "dependencies": {
                 "@ducanh2912/next-pwa": "^10.2.9",
                 "@types/google-apps-script": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "1.8.5",
+    "version": "1.9.0",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",

--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useState } from "react";
-import type { Absence } from "@/src/shared/types/api";
+import { FormEvent, useEffect, useState } from "react";
+import {
+    normalizeScheduleAttendanceMode,
+    SCHEDULE_ATTENDANCE_MODE_LABELS,
+} from "@/src/shared/types/api";
+import type {
+    Absence,
+    ScheduleAttendanceMode,
+} from "@/src/shared/types/api";
 
 interface ScheduleCardProps {
     eventId: string;
@@ -9,6 +16,9 @@ interface ScheduleCardProps {
     where?: string;
     detail?: string;
     absences: Absence[];
+    attendanceMode?: ScheduleAttendanceMode;
+    currentStudentNumber?: string | null;
+    currentDisplayName?: string | null;
     dateLabel?: string;
     timeLabel?: string;
     defaultOpen?: boolean;
@@ -24,6 +34,9 @@ export default function ScheduleCard({
     where,
     detail,
     absences,
+    attendanceMode = "ABSENCE",
+    currentStudentNumber,
+    currentDisplayName,
     dateLabel,
     timeLabel,
     defaultOpen = false,
@@ -33,16 +46,190 @@ export default function ScheduleCard({
     color = "#2a83a2",
 }: ScheduleCardProps) {
     const [isModalOpen, setIsModalOpen] = useState(defaultOpen);
+    const [isAttendanceConfirmOpen, setIsAttendanceConfirmOpen] =
+        useState(false);
+    const [isAbsenceFormOpen, setIsAbsenceFormOpen] = useState(false);
+    const [isAttendanceSubmitting, setIsAttendanceSubmitting] = useState(false);
+    const [isAbsenceSubmitting, setIsAbsenceSubmitting] = useState(false);
+    const [attendanceSubmitMessage, setAttendanceSubmitMessage] = useState<
+        string | null
+    >(null);
+    const [absenceSubmitMessage, setAbsenceSubmitMessage] = useState<
+        string | null
+    >(null);
+    const [attendanceNote, setAttendanceNote] = useState("");
+    const [profile, setProfile] = useState({
+        studentNumber: currentStudentNumber || "",
+        name: currentDisplayName || "",
+    });
+    const [absenceForm, setAbsenceForm] = useState({
+        type: "",
+        reasonCategory: "",
+        reasonDetail: "",
+        timeStepOut: "",
+        timeReturn: "",
+        timeLeavingEarly: "",
+    });
+    const normalizedAttendanceMode =
+        normalizeScheduleAttendanceMode(attendanceMode);
+    const isAttendanceEvent = normalizedAttendanceMode === "ATTENDANCE";
+    const responseSectionTitle = isAttendanceEvent ? "出席申告" : "欠席申請";
+    const emptyResponseText = isAttendanceEvent
+        ? "出席申告者はいません"
+        : "欠席者はいません";
+    const actionLabel = isAttendanceEvent ? "出席申告" : "欠席連絡";
+    const attendanceModeBadgeClass =
+        "border-base-content/35 bg-base-200/70 text-base-content/70";
+    const attendanceDateTimeLabel = [dateLabel, timeLabel]
+        .filter(Boolean)
+        .join(" ");
+
+    useEffect(() => {
+        if (currentStudentNumber || currentDisplayName) {
+            setProfile({
+                studentNumber: currentStudentNumber || "",
+                name: currentDisplayName || "",
+            });
+            return;
+        }
+
+        const loadSession = async () => {
+            try {
+                const response = await fetch("/api/auth/session");
+                if (!response.ok) return;
+                const session = await response.json();
+                setProfile({
+                    studentNumber: session?.studentId || "",
+                    name:
+                        session?.displayName ||
+                        session?.memberName ||
+                        session?.user?.name ||
+                        "",
+                });
+            } catch {
+                // セッション取得に失敗しても、送信API側で補完する
+            }
+        };
+
+        void loadSession();
+    }, [currentDisplayName, currentStudentNumber]);
 
     const handleClose = () => {
         setIsModalOpen(false);
+        setIsAttendanceConfirmOpen(false);
+        setIsAbsenceFormOpen(false);
+        setAttendanceSubmitMessage(null);
+        setAbsenceSubmitMessage(null);
+        setAttendanceNote("");
         onClose?.();
     };
 
-    // 詳細を10文字までに切り詰める関数
-    const truncateDetail = (text: string, maxLength: number = 10) => {
-        if (text.length <= maxLength) return text;
-        return text.substring(0, maxLength) + "...";
+    const closeAttendanceConfirm = () => {
+        if (isAttendanceSubmitting) return;
+        setIsAttendanceConfirmOpen(false);
+        setAttendanceSubmitMessage(null);
+        setAttendanceNote("");
+    };
+
+    const closeAbsenceForm = () => {
+        if (isAbsenceSubmitting) return;
+        setIsAbsenceFormOpen(false);
+        setAbsenceSubmitMessage(null);
+        setAbsenceForm({
+            type: "",
+            reasonCategory: "",
+            reasonDetail: "",
+            timeStepOut: "",
+            timeReturn: "",
+            timeLeavingEarly: "",
+        });
+    };
+
+    const submitAttendance = async () => {
+        setIsAttendanceSubmitting(true);
+        setAttendanceSubmitMessage(null);
+
+        try {
+            const response = await fetch("/api/absence", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    eventId,
+                    type: "出席",
+                    reasonDetail: attendanceNote.trim() || undefined,
+                }),
+            });
+            const result = await response.json();
+
+            if (!response.ok || result?.success !== true) {
+                throw new Error(result?.error || "出席申告に失敗しました");
+            }
+
+            setAttendanceSubmitMessage("出席申告を送信しました");
+            setIsAttendanceConfirmOpen(false);
+            setAttendanceNote("");
+        } catch (error) {
+            setAttendanceSubmitMessage(
+                error instanceof Error
+                    ? error.message
+                    : "出席申告に失敗しました"
+            );
+        } finally {
+            setIsAttendanceSubmitting(false);
+        }
+    };
+
+    const submitAbsence = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setIsAbsenceSubmitting(true);
+        setAbsenceSubmitMessage(null);
+
+        try {
+            const response = await fetch("/api/absence", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    eventId,
+                    studentNumber: profile.studentNumber,
+                    name: profile.name,
+                    type: absenceForm.type,
+                    reason: absenceForm.reasonCategory,
+                    reasonDetail: absenceForm.reasonDetail || undefined,
+                    timeStepOut: absenceForm.timeStepOut || undefined,
+                    timeReturn: absenceForm.timeReturn || undefined,
+                    timeLeavingEarly:
+                        absenceForm.timeLeavingEarly || undefined,
+                }),
+            });
+            const result = await response.json();
+
+            if (!response.ok || result?.success !== true) {
+                throw new Error(result?.error || "欠席連絡に失敗しました");
+            }
+
+            setAbsenceSubmitMessage("欠席連絡を送信しました");
+            setIsAbsenceFormOpen(false);
+            setAbsenceForm({
+                type: "",
+                reasonCategory: "",
+                reasonDetail: "",
+                timeStepOut: "",
+                timeReturn: "",
+                timeLeavingEarly: "",
+            });
+        } catch (error) {
+            setAbsenceSubmitMessage(
+                error instanceof Error
+                    ? error.message
+                    : "欠席連絡に失敗しました"
+            );
+        } finally {
+            setIsAbsenceSubmitting(false);
+        }
     };
 
     return (
@@ -50,57 +237,64 @@ export default function ScheduleCard({
             {!hideCard && (
                 <div
                     onClick={() => setIsModalOpen(true)}
-                    className="p-5 bg-base-100 rounded-xl shadow-sm hover:shadow-lg transition-all cursor-pointer hover:bg-base-200/50"
-                    style={{ borderLeftColor: color }}
+                    className="group bg-base-100 p-5 transition-colors cursor-pointer hover:bg-base-200/50"
                 >
-                    <div className="flex flex-col lg:flex-row gap-4">
+                    <div className="flex items-stretch gap-4">
+                        <div
+                            className="w-1 rounded-full"
+                            style={{ backgroundColor: color }}
+                        />
                         <div className="flex items-start gap-3 flex-1">
                             <div className="flex-1">
                                 <div
-                                    className="font-bold mb-2 flex items-center gap-2"
+                                    className="font-bold"
                                     style={{
                                         fontSize: "clamp(1rem, 2.5vw, 1.25rem)",
                                     }}
                                 >
                                     {title}
-                                    {timeLabel && (
-                                        <span
-                                            className="font-normal text-base-content/70"
-                                            style={{
-                                                fontSize:
-                                                    "clamp(1.25rem, 3vw, 1.5rem)",
-                                            }}
-                                        >
-                                            {timeLabel}
-                                        </span>
-                                    )}
                                 </div>
-                                {(where || dateLabel) && (
+                                <div className="mt-0">
+                                    <span
+                                        className={`badge badge-outline badge-sm ${attendanceModeBadgeClass}`}
+                                    >
+                                        {
+                                            SCHEDULE_ATTENDANCE_MODE_LABELS[
+                                                normalizedAttendanceMode
+                                            ]
+                                        }
+                                    </span>
+                                </div>
+                                {(where || dateLabel || timeLabel) && (
                                     <div
-                                        className="flex items-center gap-4 text-base-content/80"
+                                        className="mt-2 flex items-center gap-4 text-base-content/80"
                                         style={{
                                             fontSize:
                                                 "clamp(0.75rem, 1.5vw, 1rem)",
                                         }}
                                     >
-                                        {dateLabel && (
+                                        {(dateLabel || timeLabel) && (
                                             <div className="flex items-center gap-1">
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    className="h-4 w-4 text-primary"
-                                                    fill="none"
-                                                    viewBox="0 0 24 24"
-                                                    stroke="currentColor"
-                                                >
-                                                    <path
-                                                        strokeLinecap="round"
-                                                        strokeLinejoin="round"
-                                                        strokeWidth={2}
-                                                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                                                    />
-                                                </svg>
+                                                {dateLabel && (
+                                                    <svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        className="h-4 w-4 text-primary"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                        stroke="currentColor"
+                                                    >
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            strokeWidth={2}
+                                                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                                                        />
+                                                    </svg>
+                                                )}
                                                 <span className="font-medium">
-                                                    {dateLabel}
+                                                    {[dateLabel, timeLabel]
+                                                        .filter(Boolean)
+                                                        .join(" ")}
                                                 </span>
                                             </div>
                                         )}
@@ -135,16 +329,6 @@ export default function ScheduleCard({
                                 )}
                             </div>
                         </div>
-                        {detail && (
-                            <div
-                                className="max-lg:hidden lg:w-1/3 text-base-content/80 leading-relaxed lg:border-l lg:border-base-300 lg:pl-4"
-                                style={{
-                                    fontSize: "clamp(0.75rem, 1.5vw, 1rem)",
-                                }}
-                            >
-                                {truncateDetail(detail)}
-                            </div>
-                        )}
                     </div>
                 </div>
             )}
@@ -152,7 +336,13 @@ export default function ScheduleCard({
             {/* Modal */}
             {isModalOpen && (
                 <dialog className="modal modal-open">
-                    <div className="modal-box max-w-2xl bg-base-100">
+                    <div
+                        className={`modal-box bg-base-100 ${
+                            isAttendanceConfirmOpen
+                                ? "w-[min(calc(100vw-2rem),34rem)] max-w-none"
+                                : "max-w-2xl"
+                        }`}
+                    >
                         <button
                             onClick={handleClose}
                             className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
@@ -163,8 +353,14 @@ export default function ScheduleCard({
                             className="font-bold mb-4 flex items-center gap-3"
                             style={{ fontSize: "clamp(1.25rem, 3vw, 1.5rem)" }}
                         >
-                            {title}
-                            {timeLabel && (
+                            {isAttendanceConfirmOpen
+                                ? "出席申告"
+                                : isAbsenceFormOpen
+                                  ? "欠席連絡"
+                                  : title}
+                            {!isAttendanceConfirmOpen &&
+                                !isAbsenceFormOpen &&
+                                timeLabel && (
                                 <span
                                     className="font-normal text-base-content/70"
                                     style={{
@@ -176,159 +372,509 @@ export default function ScheduleCard({
                                 </span>
                             )}
                         </h3>
-                        {(where || dateLabel) && (
-                            <div
-                                className="flex items-center gap-4 text-base-content/80 mb-4"
-                                style={{
-                                    fontSize: "clamp(0.875rem, 2vw, 1.125rem)",
-                                }}
-                            >
-                                {dateLabel && (
-                                    <div className="flex items-center gap-2">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            className="h-5 w-5 text-primary"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke="currentColor"
-                                        >
-                                            <path
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                                strokeWidth={2}
-                                                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                                            />
-                                        </svg>
-                                        <span className="font-medium">
-                                            {dateLabel}
-                                        </span>
-                                    </div>
-                                )}
-                                {where && (
-                                    <div className="flex items-center gap-2">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            className="h-5 w-5 text-primary"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke="currentColor"
-                                        >
-                                            <path
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                                strokeWidth={2}
-                                                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                                            />
-                                            <path
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                                strokeWidth={2}
-                                                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                                            />
-                                        </svg>
-                                        <span className="font-medium">
-                                            {where}
-                                        </span>
-                                    </div>
-                                )}
-                            </div>
-                        )}
-                        {detail && (
-                            <div className="py-4">
-                                <h4
-                                    className="font-semibold mb-2"
-                                    style={{
-                                        fontSize:
-                                            "clamp(1rem, 2.5vw, 1.125rem)",
-                                    }}
-                                >
-                                    詳細
-                                </h4>
-                                <p
-                                    className="text-base-content/80 leading-relaxed whitespace-pre-wrap break-words"
-                                    style={{
-                                        fontSize: "clamp(0.875rem, 2vw, 1rem)",
-                                    }}
-                                >
-                                    {detail}
-                                </p>
-                            </div>
-                        )}
-
-                        {/* 欠席者セクション */}
-                        <div className="py-4 border-t border-base-300">
-                            <h4
-                                className="font-semibold mb-2"
-                                style={{
-                                    fontSize: "clamp(1rem, 2.5vw, 1.125rem)",
-                                }}
-                            >
-                                欠席申請
-                            </h4>
-                            {absences.length > 0 ? (
-                                <div className="space-y-2">
-                                    {absences.map((absence, index) => {
-                                        // absence_data シートの列構成:
-                                        // A:タイムスタンプ, B:EVENT_ID, C:学籍番号, D:氏名, E:種別, F:理由, G:早退時間, H:抜ける時間, I:戻る時間
-                                        const values = Object.values(absence);
-                                        const name = String(values[3] || ""); // D列（氏名）
-                                        const type = String(values[4] || ""); // E列（種別）
-
-                                        return (
-                                            <div
-                                                key={index}
-                                                className="p-3 bg-base-200/50 rounded-lg border border-base-300"
-                                            >
-                                                <div
-                                                    className="font-medium text-base-content"
-                                                    style={{
-                                                        fontSize:
-                                                            "clamp(0.875rem, 2vw, 1rem)",
-                                                    }}
-                                                >
-                                                    {name}{" "}
-                                                    <span className="badge badge-primary badge-sm ml-2">
-                                                        {type}
-                                                    </span>
-                                                </div>
-                                            </div>
-                                        );
-                                    })}
+                        {isAttendanceConfirmOpen ? (
+                            <>
+                                <div className="mb-5">
+                                    <p className="text-base font-medium">
+                                        {title}に出席します。
+                                    </p>
+                                    {attendanceDateTimeLabel && (
+                                        <p className="mt-1 text-sm text-base-content/70">
+                                            {attendanceDateTimeLabel}
+                                        </p>
+                                    )}
                                 </div>
-                            ) : (
-                                <p
-                                    className="text-base-content/60"
-                                    style={{
-                                        fontSize: "clamp(0.875rem, 2vw, 1rem)",
-                                    }}
-                                >
-                                    欠席者はいません
-                                </p>
-                            )}
-                        </div>
-
-                        <div className="modal-action">
-                            {onEdit && (
-                                <button
-                                    onClick={onEdit}
-                                    className="btn btn-outline btn-primary"
-                                >
-                                    編集
-                                </button>
-                            )}
-                            <a
-                                href={`/absence?eventId=${eventId}`}
-                                className="btn btn-primary"
+                                <div className="space-y-2">
+                                    <span className="label-text">
+                                        備考（任意）
+                                    </span>
+                                    <textarea
+                                        className="textarea textarea-bordered min-h-24 w-full"
+                                        value={attendanceNote}
+                                        onChange={(event) =>
+                                            setAttendanceNote(
+                                                event.target.value
+                                            )
+                                        }
+                                        placeholder="補足があれば入力してください"
+                                        maxLength={500}
+                                        disabled={isAttendanceSubmitting}
+                                    />
+                                </div>
+                                {attendanceSubmitMessage && (
+                                    <div className="alert alert-error mt-4">
+                                        <span>{attendanceSubmitMessage}</span>
+                                    </div>
+                                )}
+                                <div className="modal-action">
+                                    <button
+                                        type="button"
+                                        className="btn btn-ghost"
+                                        onClick={closeAttendanceConfirm}
+                                        disabled={isAttendanceSubmitting}
+                                    >
+                                        キャンセル
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="btn btn-primary"
+                                        onClick={() => void submitAttendance()}
+                                        disabled={isAttendanceSubmitting}
+                                    >
+                                        {isAttendanceSubmitting && (
+                                            <span className="loading loading-spinner loading-sm" />
+                                        )}
+                                        送信
+                                    </button>
+                                </div>
+                            </>
+                        ) : isAbsenceFormOpen ? (
+                            <form
+                                onSubmit={(event) => void submitAbsence(event)}
+                                className="space-y-5"
                             >
-                                欠席連絡
-                            </a>
-                        </div>
+                                <div className="grid gap-4 sm:grid-cols-2">
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text font-semibold">
+                                                学籍番号
+                                                <span className="text-error">
+                                                    *
+                                                </span>
+                                            </span>
+                                        </label>
+                                        <input
+                                            type="text"
+                                            className="input input-bordered w-full"
+                                            value={profile.studentNumber}
+                                            onChange={(event) =>
+                                                setProfile({
+                                                    ...profile,
+                                                    studentNumber:
+                                                        event.target.value,
+                                                })
+                                            }
+                                            required
+                                            disabled={isAbsenceSubmitting}
+                                        />
+                                    </div>
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text font-semibold">
+                                                氏名 または あだ名
+                                                <span className="text-error">
+                                                    *
+                                                </span>
+                                            </span>
+                                        </label>
+                                        <input
+                                            type="text"
+                                            className="input input-bordered w-full"
+                                            value={profile.name}
+                                            onChange={(event) =>
+                                                setProfile({
+                                                    ...profile,
+                                                    name: event.target.value,
+                                                })
+                                            }
+                                            required
+                                            disabled={isAbsenceSubmitting}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="grid gap-4 sm:grid-cols-2">
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text font-semibold">
+                                                種別
+                                                <span className="text-error">
+                                                    *
+                                                </span>
+                                            </span>
+                                        </label>
+                                        <select
+                                            className="select select-bordered w-full"
+                                            value={absenceForm.type}
+                                            onChange={(event) =>
+                                                setAbsenceForm({
+                                                    ...absenceForm,
+                                                    type: event.target.value,
+                                                })
+                                            }
+                                            required
+                                            disabled={isAbsenceSubmitting}
+                                        >
+                                            <option value="">
+                                                選択してください
+                                            </option>
+                                            <option value="欠席">欠席</option>
+                                            <option value="遅刻">遅刻</option>
+                                            <option value="中抜け">
+                                                中抜け
+                                            </option>
+                                            <option value="早退">早退</option>
+                                        </select>
+                                    </div>
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text font-semibold">
+                                                理由
+                                                <span className="text-error">
+                                                    *
+                                                </span>
+                                            </span>
+                                        </label>
+                                        <select
+                                            className="select select-bordered w-full"
+                                            value={absenceForm.reasonCategory}
+                                            onChange={(event) =>
+                                                setAbsenceForm({
+                                                    ...absenceForm,
+                                                    reasonCategory:
+                                                        event.target.value,
+                                                })
+                                            }
+                                            required
+                                            disabled={isAbsenceSubmitting}
+                                        >
+                                            <option value="">
+                                                選択してください
+                                            </option>
+                                            <option value="体調不良">
+                                                体調不良
+                                            </option>
+                                            <option value="授業">授業</option>
+                                            <option value="家庭の都合">
+                                                家庭の都合
+                                            </option>
+                                            <option value="その他">
+                                                その他
+                                            </option>
+                                        </select>
+                                    </div>
+                                </div>
+
+                                <div className="form-control">
+                                    <label className="label">
+                                        <span className="label-text font-semibold">
+                                            詳細
+                                            <span className="text-base-content/50 font-normal ml-2">
+                                                任意
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <textarea
+                                        className="textarea textarea-bordered h-24 w-full"
+                                        value={absenceForm.reasonDetail}
+                                        onChange={(event) =>
+                                            setAbsenceForm({
+                                                ...absenceForm,
+                                                reasonDetail:
+                                                    event.target.value,
+                                            })
+                                        }
+                                        placeholder="補足があれば入力してください"
+                                        maxLength={500}
+                                        disabled={isAbsenceSubmitting}
+                                    />
+                                </div>
+
+                                {absenceForm.type === "中抜け" && (
+                                    <div className="grid gap-4 rounded-lg border border-base-300 bg-base-200/50 p-4 sm:grid-cols-2">
+                                        <div className="form-control">
+                                            <label className="label">
+                                                <span className="label-text">
+                                                    抜ける時間
+                                                </span>
+                                            </label>
+                                            <input
+                                                type="time"
+                                                className="input input-bordered w-full"
+                                                value={
+                                                    absenceForm.timeStepOut
+                                                }
+                                                onChange={(event) =>
+                                                    setAbsenceForm({
+                                                        ...absenceForm,
+                                                        timeStepOut:
+                                                            event.target.value,
+                                                    })
+                                                }
+                                                disabled={isAbsenceSubmitting}
+                                            />
+                                        </div>
+                                        <div className="form-control">
+                                            <label className="label">
+                                                <span className="label-text">
+                                                    活動に戻る時間
+                                                </span>
+                                            </label>
+                                            <input
+                                                type="time"
+                                                className="input input-bordered w-full"
+                                                value={absenceForm.timeReturn}
+                                                onChange={(event) =>
+                                                    setAbsenceForm({
+                                                        ...absenceForm,
+                                                        timeReturn:
+                                                            event.target.value,
+                                                    })
+                                                }
+                                                disabled={isAbsenceSubmitting}
+                                            />
+                                        </div>
+                                    </div>
+                                )}
+
+                                {absenceForm.type === "早退" && (
+                                    <div className="rounded-lg border border-base-300 bg-base-200/50 p-4">
+                                        <div className="form-control">
+                                            <label className="label">
+                                                <span className="label-text">
+                                                    早退する時間
+                                                </span>
+                                            </label>
+                                            <input
+                                                type="time"
+                                                className="input input-bordered w-full"
+                                                value={
+                                                    absenceForm.timeLeavingEarly
+                                                }
+                                                onChange={(event) =>
+                                                    setAbsenceForm({
+                                                        ...absenceForm,
+                                                        timeLeavingEarly:
+                                                            event.target.value,
+                                                    })
+                                                }
+                                                disabled={isAbsenceSubmitting}
+                                            />
+                                        </div>
+                                    </div>
+                                )}
+
+                                {absenceSubmitMessage && (
+                                    <div className="alert alert-error">
+                                        <span>{absenceSubmitMessage}</span>
+                                    </div>
+                                )}
+
+                                <div className="modal-action">
+                                    <button
+                                        type="button"
+                                        className="btn btn-ghost"
+                                        onClick={closeAbsenceForm}
+                                        disabled={isAbsenceSubmitting}
+                                    >
+                                        キャンセル
+                                    </button>
+                                    <button
+                                        type="submit"
+                                        className="btn btn-primary"
+                                        disabled={isAbsenceSubmitting}
+                                    >
+                                        {isAbsenceSubmitting && (
+                                            <span className="loading loading-spinner loading-sm" />
+                                        )}
+                                        送信
+                                    </button>
+                                </div>
+                            </form>
+                        ) : (
+                            <>
+                                {(where || dateLabel) && (
+                                    <div
+                                        className="flex items-center gap-4 text-base-content/80 mb-4"
+                                        style={{
+                                            fontSize:
+                                                "clamp(0.875rem, 2vw, 1.125rem)",
+                                        }}
+                                    >
+                                        {dateLabel && (
+                                            <div className="flex items-center gap-2">
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    className="h-5 w-5 text-primary"
+                                                    fill="none"
+                                                    viewBox="0 0 24 24"
+                                                    stroke="currentColor"
+                                                >
+                                                    <path
+                                                        strokeLinecap="round"
+                                                        strokeLinejoin="round"
+                                                        strokeWidth={2}
+                                                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                                                    />
+                                                </svg>
+                                                <span className="font-medium">
+                                                    {dateLabel}
+                                                </span>
+                                            </div>
+                                        )}
+                                        {where && (
+                                            <div className="flex items-center gap-2">
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    className="h-5 w-5 text-primary"
+                                                    fill="none"
+                                                    viewBox="0 0 24 24"
+                                                    stroke="currentColor"
+                                                >
+                                                    <path
+                                                        strokeLinecap="round"
+                                                        strokeLinejoin="round"
+                                                        strokeWidth={2}
+                                                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                                                    />
+                                                    <path
+                                                        strokeLinecap="round"
+                                                        strokeLinejoin="round"
+                                                        strokeWidth={2}
+                                                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                                                    />
+                                                </svg>
+                                                <span className="font-medium">
+                                                    {where}
+                                                </span>
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                                {detail && (
+                                    <div className="py-4">
+                                        <h4
+                                            className="font-semibold mb-2"
+                                            style={{
+                                                fontSize:
+                                                    "clamp(1rem, 2.5vw, 1.125rem)",
+                                            }}
+                                        >
+                                            詳細
+                                        </h4>
+                                        <p
+                                            className="text-base-content/80 leading-relaxed whitespace-pre-wrap break-words"
+                                            style={{
+                                                fontSize:
+                                                    "clamp(0.875rem, 2vw, 1rem)",
+                                            }}
+                                        >
+                                            {detail}
+                                        </p>
+                                    </div>
+                                )}
+
+                                <div className="py-4 border-t border-base-300">
+                                    <h4
+                                        className="font-semibold mb-2"
+                                        style={{
+                                            fontSize:
+                                                "clamp(1rem, 2.5vw, 1.125rem)",
+                                        }}
+                                    >
+                                        {responseSectionTitle}
+                                    </h4>
+                                    {absences.length > 0 ? (
+                                        <div className="space-y-2">
+                                            {absences.map((absence, index) => {
+                                                const values =
+                                                    Object.values(absence);
+                                                const name = String(
+                                                    values[3] || ""
+                                                );
+                                                const type = String(
+                                                    values[4] || ""
+                                                );
+
+                                                return (
+                                                    <div
+                                                        key={index}
+                                                        className="p-3 bg-base-200/50 rounded-lg border border-base-300"
+                                                    >
+                                                        <div
+                                                            className="font-medium text-base-content"
+                                                            style={{
+                                                                fontSize:
+                                                                    "clamp(0.875rem, 2vw, 1rem)",
+                                                            }}
+                                                        >
+                                                            {name}{" "}
+                                                            <span className="badge badge-primary badge-sm ml-2">
+                                                                {type}
+                                                            </span>
+                                                        </div>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    ) : (
+                                        <p
+                                            className="text-base-content/60"
+                                            style={{
+                                                fontSize:
+                                                    "clamp(0.875rem, 2vw, 1rem)",
+                                            }}
+                                        >
+                                            {emptyResponseText}
+                                        </p>
+                                    )}
+                                </div>
+
+                                <div className="modal-action">
+                                    {onEdit && (
+                                        <button
+                                            onClick={onEdit}
+                                            className="btn btn-outline btn-primary"
+                                        >
+                                            編集
+                                        </button>
+                                    )}
+                                    {isAttendanceEvent ? (
+                                        <button
+                                            type="button"
+                                            className="btn btn-primary"
+                                            onClick={() => {
+                                                setAttendanceSubmitMessage(
+                                                    null
+                                                );
+                                                setIsAttendanceConfirmOpen(
+                                                    true
+                                                );
+                                            }}
+                                        >
+                                            {actionLabel}
+                                        </button>
+                                    ) : (
+                                        <button
+                                            type="button"
+                                            className="btn btn-primary"
+                                            onClick={() => {
+                                                setAbsenceSubmitMessage(null);
+                                                setIsAbsenceFormOpen(true);
+                                            }}
+                                        >
+                                            {actionLabel}
+                                        </button>
+                                    )}
+                                </div>
+                                {attendanceSubmitMessage && (
+                                    <div className="alert alert-success mt-4">
+                                        <span>{attendanceSubmitMessage}</span>
+                                    </div>
+                                )}
+                                {absenceSubmitMessage && (
+                                    <div className="alert alert-success mt-4">
+                                        <span>{absenceSubmitMessage}</span>
+                                    </div>
+                                )}
+                            </>
+                        )}
                     </div>
                     <form
                         method="dialog"
                         className="modal-backdrop"
                     >
-                        <button onClick={handleClose}>close</button>
+                        <button onClick={handleClose}>閉じる</button>
                     </form>
                 </dialog>
             )}

--- a/src/shared/lib/validation.ts
+++ b/src/shared/lib/validation.ts
@@ -3,28 +3,45 @@ import { z } from "zod";
 /**
  * 欠席連絡送信データのバリデーションスキーマ
  */
-export const absenceSubmitSchema = z.object({
-    eventId: z
-        .string()
-        .min(1, "イベントIDは必須です")
-        .max(100, "イベントIDが長すぎます"),
-    studentNumber: z
-        .string()
-        .min(1, "学籍番号は必須です")
-        .max(20, "学籍番号が長すぎます")
-        .regex(/^[A-Za-z0-9-]+$/, "学籍番号の形式が不正です"),
-    name: z.string().min(1, "名前は必須です").max(50, "名前が長すぎます"),
-    type: z.enum(["欠席", "遅刻", "中抜け", "早退"], {
-        error: "無効な欠席種別です",
-    }),
-    reason: z.enum(["体調不良", "授業", "家庭の都合", "その他"], {
-        error: "無効な理由カテゴリです",
-    }),
-    reasonDetail: z.string().max(500, "詳細が長すぎます").optional(),
-    timeStepOut: z.string().max(10).optional(),
-    timeReturn: z.string().max(10).optional(),
-    timeLeavingEarly: z.string().max(10).optional(),
-});
+export const absenceSubmitSchema = z
+    .object({
+        eventId: z
+            .string()
+            .min(1, "イベントIDは必須です")
+            .max(100, "イベントIDが長すぎます"),
+        studentNumber: z
+            .string()
+            .min(1, "学籍番号は必須です")
+            .max(20, "学籍番号が長すぎます")
+            .regex(/^[A-Za-z0-9-]+$/, "学籍番号の形式が不正です"),
+        name: z
+            .string()
+            .min(1, "名前は必須です")
+            .max(50, "名前が長すぎます"),
+        type: z.enum(["欠席", "遅刻", "中抜け", "早退", "出席"], {
+            error: "無効な欠席種別です",
+        }),
+        reason: z
+            .enum(["体調不良", "授業", "家庭の都合", "その他", "出席"], {
+                error: "無効な理由カテゴリです",
+            })
+            .optional(),
+        reasonDetail: z.string().max(500, "詳細が長すぎます").optional(),
+        timeStepOut: z.string().max(10).optional(),
+        timeReturn: z.string().max(10).optional(),
+        timeLeavingEarly: z.string().max(10).optional(),
+    })
+    .superRefine((data, ctx) => {
+        if (data.type === "出席") return;
+
+        if (!data.reason) {
+            ctx.addIssue({
+                code: "custom",
+                path: ["reason"],
+                message: "理由は必須です",
+            });
+        }
+    });
 
 export type AbsenceSubmitData = z.infer<typeof absenceSubmitSchema>;
 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -64,6 +64,31 @@ export const NEXT_MEETING_MODE_LABELS: Record<NextMeetingMode, string> = {
     DISCORD: "Discord",
 };
 
+export const SCHEDULE_ATTENDANCE_MODES = ["ABSENCE", "ATTENDANCE"] as const;
+
+export type ScheduleAttendanceMode =
+    (typeof SCHEDULE_ATTENDANCE_MODES)[number];
+
+export const SCHEDULE_ATTENDANCE_MODE_LABELS: Record<
+    ScheduleAttendanceMode,
+    string
+> = {
+    ABSENCE: "全員参加",
+    ATTENDANCE: "希望者参加",
+};
+
+export const normalizeScheduleAttendanceMode = (
+    value: unknown
+): ScheduleAttendanceMode => {
+    const normalized = String(value ?? "")
+        .trim()
+        .toUpperCase()
+        .replaceAll("-", "_")
+        .replace(/\s+/g, "_");
+
+    return normalized === "ATTENDANCE" ? "ATTENDANCE" : "ABSENCE";
+};
+
 export interface NextMeetingSettings {
     eventId?: string;
     date: string;


### PR DESCRIPTION
## 概要
- 名簿に一時チェックボックスとチェック済み部員一覧モーダルを追加
- LINEメンション用の名前コピーとチェッククリアを追加
- 予定に出欠方式（全員参加 / 希望者参加）を追加
- 希望者参加の出席申告と欠席連絡をモーダル送信に変更
- ダッシュボードとカレンダーの予定表示を調整
- バージョンを 1.9.0 に更新

## 確認
- npm run build