### PR TITLE
予定の終了時刻入力に対応

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -67,6 +67,8 @@ interface EventForm {
     detail: string;
     timeHH: string;
     timeMM: string;
+    endTimeHH: string;
+    endTimeMM: string;
     year: string;
     month: string;
     date: string;
@@ -110,6 +112,8 @@ export default function CalendarPage() {
         detail: "",
         timeHH: "",
         timeMM: "",
+        endTimeHH: "",
+        endTimeMM: "",
         year: "",
         month: "",
         date: "",
@@ -126,6 +130,8 @@ export default function CalendarPage() {
         detail: "",
         timeHH: "",
         timeMM: "",
+        endTimeHH: "",
+        endTimeMM: "",
         year: "",
         month: "",
         date: "",
@@ -344,6 +350,8 @@ export default function CalendarPage() {
             detail: "",
             timeHH: "",
             timeMM: "",
+            endTimeHH: "",
+            endTimeMM: "",
             year: "",
             month: "",
             date: "",
@@ -360,6 +368,8 @@ export default function CalendarPage() {
             detail: "",
             timeHH: "",
             timeMM: "",
+            endTimeHH: "",
+            endTimeMM: "",
             year: "",
             month: "",
             date: "",
@@ -386,6 +396,8 @@ export default function CalendarPage() {
             detail: "",
             timeHH: "",
             timeMM: "",
+            endTimeHH: "",
+            endTimeMM: "",
             year: "",
             month: "",
             date: "",
@@ -416,6 +428,8 @@ export default function CalendarPage() {
                     date: selectedDate.date.getDate(),
                     timeHH: addForm.timeHH || undefined,
                     timeMM: addForm.timeMM || undefined,
+                    endTimeHH: addForm.endTimeHH || undefined,
+                    endTimeMM: addForm.endTimeMM || undefined,
                     title: addForm.title.trim(),
                     where: addForm.where.trim(),
                     detail: addForm.detail.trim(),
@@ -446,6 +460,8 @@ export default function CalendarPage() {
                     END_DD: data.data.endDate || "",
                     COLOR: data.data.color || "primary",
                     ATTENDANCE_MODE: data.data.attendanceMode || "ABSENCE",
+                    END_TIME_HH: data.data.endTimeHH || "",
+                    END_TIME_MM: data.data.endTimeMM || "",
                 };
                 setSchedules((prev) => {
                     const next = [...prev, newSchedule];
@@ -489,6 +505,8 @@ export default function CalendarPage() {
         const values = Object.values(selectedEvent);
         const rawTimeHH = values[4];
         const rawTimeMM = values[5];
+        const rawEndTimeHH = values[18];
+        const rawEndTimeMM = values[19];
         // 終了日はインデックス9, 10, 11（END_YYYY, END_MM, END_DD）
         const rawEndYear = values[9];
         const rawEndMonth = values[10];
@@ -518,6 +536,18 @@ export default function CalendarPage() {
                 rawTimeMM !== null &&
                 rawTimeMM !== undefined
                     ? String(rawTimeMM)
+                    : "",
+            endTimeHH:
+                rawEndTimeHH !== "" &&
+                rawEndTimeHH !== null &&
+                rawEndTimeHH !== undefined
+                    ? String(rawEndTimeHH)
+                    : "",
+            endTimeMM:
+                rawEndTimeMM !== "" &&
+                rawEndTimeMM !== null &&
+                rawEndTimeMM !== undefined
+                    ? String(rawEndTimeMM)
                     : "",
             year: String(values[1] ?? ""),
             month: String(values[2] ?? ""),
@@ -557,6 +587,8 @@ export default function CalendarPage() {
             detail: "",
             timeHH: "",
             timeMM: "",
+            endTimeHH: "",
+            endTimeMM: "",
             year: "",
             month: "",
             date: "",
@@ -642,6 +674,8 @@ export default function CalendarPage() {
                     date: Number(editForm.date),
                     timeHH: editForm.timeHH || undefined,
                     timeMM: editForm.timeMM || undefined,
+                    endTimeHH: editForm.endTimeHH || undefined,
+                    endTimeMM: editForm.endTimeMM || undefined,
                     title: editForm.title.trim(),
                     where: editForm.where.trim(),
                     detail: editForm.detail.trim(),
@@ -671,6 +705,8 @@ export default function CalendarPage() {
                                 DETAIL: data.data.detail,
                                 TIME_HH: data.data.timeHH || "",
                                 TIME_MM: data.data.timeMM || "",
+                                END_TIME_HH: data.data.endTimeHH || "",
+                                END_TIME_MM: data.data.endTimeMM || "",
                                 END_YYYY: data.data.endYear || "",
                                 END_MM: data.data.endMonth || "",
                                 END_DD: data.data.endDate || "",
@@ -810,6 +846,8 @@ export default function CalendarPage() {
         const values = Object.values(schedule);
         const rawTimeHH = values[4];
         const rawTimeMM = values[5];
+        const rawEndTimeHH = values[18];
+        const rawEndTimeMM = values[19];
         const hasTime =
             rawTimeHH !== "" &&
             rawTimeHH !== null &&
@@ -817,11 +855,24 @@ export default function CalendarPage() {
             rawTimeMM !== "" &&
             rawTimeMM !== null &&
             rawTimeMM !== undefined;
-        return hasTime
-            ? `${String(rawTimeHH).padStart(2, "0")}:${String(
-                  rawTimeMM
-              ).padStart(2, "0")}`
-            : null;
+        if (!hasTime) return null;
+
+        const startTime = `${String(rawTimeHH).padStart(2, "0")}:${String(
+            rawTimeMM
+        ).padStart(2, "0")}`;
+        const hasEndTime =
+            rawEndTimeHH !== "" &&
+            rawEndTimeHH !== null &&
+            rawEndTimeHH !== undefined &&
+            rawEndTimeMM !== "" &&
+            rawEndTimeMM !== null &&
+            rawEndTimeMM !== undefined;
+        if (!hasEndTime) return startTime;
+
+        const endTime = `${String(rawEndTimeHH).padStart(2, "0")}:${String(
+            rawEndTimeMM
+        ).padStart(2, "0")}`;
+        return `${startTime}-${endTime}`;
     };
 
     if (isLoading) {
@@ -1360,6 +1411,8 @@ export default function CalendarPage() {
                                             const startDay = Number(values[3]);
                                             const rawTimeHH = values[4];
                                             const rawTimeMM = values[5];
+                                            const rawEndTimeHH = values[18];
+                                            const rawEndTimeMM = values[19];
                                             const title = String(
                                                 values[6] ?? "予定"
                                             );
@@ -1394,6 +1447,22 @@ export default function CalendarPage() {
                                                       rawTimeMM
                                                   ).padStart(2, "0")}`
                                                 : null;
+                                            const hasEndTime =
+                                                rawEndTimeHH !== "" &&
+                                                rawEndTimeHH !== null &&
+                                                rawEndTimeHH !== undefined &&
+                                                rawEndTimeMM !== "" &&
+                                                rawEndTimeMM !== null &&
+                                                rawEndTimeMM !== undefined;
+                                            const endTimeLabel = hasEndTime
+                                                ? `${String(rawEndTimeHH).padStart(2, "0")}:${String(
+                                                      rawEndTimeMM
+                                                  ).padStart(2, "0")}`
+                                                : null;
+                                            const timeRangeLabel =
+                                                timeLabel && endTimeLabel
+                                                    ? `${timeLabel}-${endTimeLabel}`
+                                                    : timeLabel;
                                             const startDate = new Date(
                                                 startYear,
                                                 startMonth - 1,
@@ -1422,7 +1491,7 @@ export default function CalendarPage() {
                                                     : startDateLabel;
                                             const dateTimeLabel = [
                                                 dateRangeLabel,
-                                                timeLabel,
+                                                timeRangeLabel,
                                             ]
                                                 .filter(Boolean)
                                                 .join(" ");
@@ -1636,6 +1705,12 @@ export default function CalendarPage() {
                                                 timeMM: e.target.checked
                                                     ? ""
                                                     : addForm.timeMM,
+                                                endTimeHH: e.target.checked
+                                                    ? ""
+                                                    : addForm.endTimeHH,
+                                                endTimeMM: e.target.checked
+                                                    ? ""
+                                                    : addForm.endTimeMM,
                                             })
                                         }
                                     />
@@ -1784,40 +1859,86 @@ export default function CalendarPage() {
                                     </div>
                                 </>
                             ) : (
-                                <div className="form-control">
-                                    <label className="label">
-                                        <span className="label-text">時刻</span>
-                                    </label>
-                                    <div className="flex items-center gap-2">
-                                        <input
-                                            type="number"
-                                            placeholder="時"
-                                            min="0"
-                                            max="23"
-                                            className="input input-bordered w-20"
-                                            value={addForm.timeHH}
-                                            onChange={(e) =>
-                                                setAddForm({
-                                                    ...addForm,
-                                                    timeHH: e.target.value,
-                                                })
-                                            }
-                                        />
-                                        <span>:</span>
-                                        <input
-                                            type="number"
-                                            placeholder="分"
-                                            min="0"
-                                            max="59"
-                                            className="input input-bordered w-20"
-                                            value={addForm.timeMM}
-                                            onChange={(e) =>
-                                                setAddForm({
-                                                    ...addForm,
-                                                    timeMM: e.target.value,
-                                                })
-                                            }
-                                        />
+                                <div className="grid gap-4 sm:grid-cols-2">
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text">
+                                                開始時刻
+                                            </span>
+                                        </label>
+                                        <div className="flex items-center gap-2">
+                                            <input
+                                                type="number"
+                                                placeholder="時"
+                                                min="0"
+                                                max="23"
+                                                className="input input-bordered w-20"
+                                                value={addForm.timeHH}
+                                                onChange={(e) =>
+                                                    setAddForm({
+                                                        ...addForm,
+                                                        timeHH:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                            <span>:</span>
+                                            <input
+                                                type="number"
+                                                placeholder="分"
+                                                min="0"
+                                                max="59"
+                                                className="input input-bordered w-20"
+                                                value={addForm.timeMM}
+                                                onChange={(e) =>
+                                                    setAddForm({
+                                                        ...addForm,
+                                                        timeMM:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text">
+                                                終了時刻
+                                            </span>
+                                        </label>
+                                        <div className="flex items-center gap-2">
+                                            <input
+                                                type="number"
+                                                placeholder="時"
+                                                min="0"
+                                                max="23"
+                                                className="input input-bordered w-20"
+                                                value={addForm.endTimeHH}
+                                                onChange={(e) =>
+                                                    setAddForm({
+                                                        ...addForm,
+                                                        endTimeHH:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                            <span>:</span>
+                                            <input
+                                                type="number"
+                                                placeholder="分"
+                                                min="0"
+                                                max="59"
+                                                className="input input-bordered w-20"
+                                                value={addForm.endTimeMM}
+                                                onChange={(e) =>
+                                                    setAddForm({
+                                                        ...addForm,
+                                                        endTimeMM:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                        </div>
                                     </div>
                                 </div>
                             )}
@@ -1927,6 +2048,8 @@ export default function CalendarPage() {
                     const date = Number(values[3]);
                     const rawTimeHH = values[4];
                     const rawTimeMM = values[5];
+                    const rawEndTimeHH = values[18];
+                    const rawEndTimeMM = values[19];
                     const title = String(values[6] ?? "予定");
                     const where = String(values[7] ?? "");
                     const detail = String(values[8] ?? "");
@@ -1957,6 +2080,22 @@ export default function CalendarPage() {
                               rawTimeMM
                           ).padStart(2, "0")}`
                         : undefined;
+                    const hasEndTime =
+                        rawEndTimeHH !== "" &&
+                        rawEndTimeHH !== null &&
+                        rawEndTimeHH !== undefined &&
+                        rawEndTimeMM !== "" &&
+                        rawEndTimeMM !== null &&
+                        rawEndTimeMM !== undefined;
+                    const endTimeLabel = hasEndTime
+                        ? `${String(rawEndTimeHH).padStart(2, "0")}:${String(
+                              rawEndTimeMM
+                          ).padStart(2, "0")}`
+                        : undefined;
+                    const timeRangeLabel =
+                        timeLabel && endTimeLabel
+                            ? `${timeLabel}-${endTimeLabel}`
+                            : timeLabel;
 
                     const eventAbsences = absences.filter((absence) => {
                         const absenceValues = Object.values(absence);
@@ -1972,7 +2111,7 @@ export default function CalendarPage() {
                             absences={eventAbsences}
                             attendanceMode={attendanceMode}
                             dateLabel={dateLabel}
-                            timeLabel={timeLabel}
+                            timeLabel={timeRangeLabel}
                             defaultOpen={true}
                             onClose={closeEventModal}
                             onEdit={openEditModal}
@@ -2034,6 +2173,12 @@ export default function CalendarPage() {
                                                 timeMM: e.target.checked
                                                     ? ""
                                                     : editForm.timeMM,
+                                                endTimeHH: e.target.checked
+                                                    ? ""
+                                                    : editForm.endTimeHH,
+                                                endTimeMM: e.target.checked
+                                                    ? ""
+                                                    : editForm.endTimeMM,
                                             })
                                         }
                                     />
@@ -2220,40 +2365,86 @@ export default function CalendarPage() {
                                     </div>
                                 </div>
                             ) : (
-                                <div className="form-control">
-                                    <label className="label">
-                                        <span className="label-text">時刻</span>
-                                    </label>
-                                    <div className="flex items-center gap-2">
-                                        <input
-                                            type="number"
-                                            placeholder="時"
-                                            min="0"
-                                            max="23"
-                                            className="input input-bordered w-20"
-                                            value={editForm.timeHH}
-                                            onChange={(e) =>
-                                                setEditForm({
-                                                    ...editForm,
-                                                    timeHH: e.target.value,
-                                                })
-                                            }
-                                        />
-                                        <span>:</span>
-                                        <input
-                                            type="number"
-                                            placeholder="分"
-                                            min="0"
-                                            max="59"
-                                            className="input input-bordered w-20"
-                                            value={editForm.timeMM}
-                                            onChange={(e) =>
-                                                setEditForm({
-                                                    ...editForm,
-                                                    timeMM: e.target.value,
-                                                })
-                                            }
-                                        />
+                                <div className="grid gap-4 sm:grid-cols-2">
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text">
+                                                開始時刻
+                                            </span>
+                                        </label>
+                                        <div className="flex items-center gap-2">
+                                            <input
+                                                type="number"
+                                                placeholder="時"
+                                                min="0"
+                                                max="23"
+                                                className="input input-bordered w-20"
+                                                value={editForm.timeHH}
+                                                onChange={(e) =>
+                                                    setEditForm({
+                                                        ...editForm,
+                                                        timeHH:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                            <span>:</span>
+                                            <input
+                                                type="number"
+                                                placeholder="分"
+                                                min="0"
+                                                max="59"
+                                                className="input input-bordered w-20"
+                                                value={editForm.timeMM}
+                                                onChange={(e) =>
+                                                    setEditForm({
+                                                        ...editForm,
+                                                        timeMM:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="form-control">
+                                        <label className="label">
+                                            <span className="label-text">
+                                                終了時刻
+                                            </span>
+                                        </label>
+                                        <div className="flex items-center gap-2">
+                                            <input
+                                                type="number"
+                                                placeholder="時"
+                                                min="0"
+                                                max="23"
+                                                className="input input-bordered w-20"
+                                                value={editForm.endTimeHH}
+                                                onChange={(e) =>
+                                                    setEditForm({
+                                                        ...editForm,
+                                                        endTimeHH:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                            <span>:</span>
+                                            <input
+                                                type="number"
+                                                placeholder="分"
+                                                min="0"
+                                                max="59"
+                                                className="input input-bordered w-20"
+                                                value={editForm.endTimeMM}
+                                                onChange={(e) =>
+                                                    setEditForm({
+                                                        ...editForm,
+                                                        endTimeMM:
+                                                            e.target.value,
+                                                    })
+                                                }
+                                            />
+                                        </div>
                                     </div>
                                 </div>
                             )}

--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -186,6 +186,8 @@ export default async function HomePage() {
                                             const date = Number(values[3]); // D列 (DD)
                                             const rawTimeHH = values[4]; // E列 (TIME_HH)
                                             const rawTimeMM = values[5]; // F列 (TIME_MM)
+                                            const rawEndTimeHH = values[18]; // S列 (END_TIME_HH)
+                                            const rawEndTimeMM = values[19]; // T列 (END_TIME_MM)
                                             const title = String(
                                                 values[6] ?? "予定"
                                             ); // G列 (TITLE)
@@ -230,6 +232,22 @@ export default async function HomePage() {
                                                       rawTimeMM
                                                   ).padStart(2, "0")}`
                                                 : undefined;
+                                            const hasEndTime =
+                                                rawEndTimeHH !== "" &&
+                                                rawEndTimeHH !== null &&
+                                                rawEndTimeHH !== undefined &&
+                                                rawEndTimeMM !== "" &&
+                                                rawEndTimeMM !== null &&
+                                                rawEndTimeMM !== undefined;
+                                            const endTimeLabel = hasEndTime
+                                                ? `${String(rawEndTimeHH).padStart(2, "0")}:${String(
+                                                      rawEndTimeMM
+                                                  ).padStart(2, "0")}`
+                                                : undefined;
+                                            const timeRangeLabel =
+                                                timeLabel && endTimeLabel
+                                                    ? `${timeLabel}-${endTimeLabel}`
+                                                    : timeLabel;
 
                                             // このイベントの欠席者をフィルタリング
                                             // absence_data シートの列構成: A:タイムスタンプ, B:EVENT_ID, C:学籍番号, D:氏名...
@@ -262,7 +280,7 @@ export default async function HomePage() {
                                                         session?.memberName
                                                     }
                                                     dateLabel={dateLabel}
-                                                    timeLabel={timeLabel}
+                                                    timeLabel={timeRangeLabel}
                                                 />
                                             );
                                         }

--- a/gas/main.js
+++ b/gas/main.js
@@ -1182,10 +1182,13 @@ const handleDeleteItem = (postData) => {
 // ============================================
 // API: スケジュール一覧取得
 // シート名: schedules
-// 列構成: A:EVENT_ID, B:YYYY, C:MM, D:DD, E:TIME_HH, F:TIME_MM, G:TITLE, H:WHERE, I:DETAIL, J:END_YYYY, K:END_MM, L:END_DD, M:COLOR, N:CREATED_BY, O:CREATED_AT, P:UPDATED_BY, Q:UPDATED_AT, R:ATTENDANCE_MODE
+// 列構成: A:EVENT_ID, B:YYYY, C:MM, D:DD, E:TIME_HH, F:TIME_MM, G:TITLE, H:WHERE, I:DETAIL, J:END_YYYY, K:END_MM, L:END_DD, M:COLOR, N:CREATED_BY, O:CREATED_AT, P:UPDATED_BY, Q:UPDATED_AT, R:ATTENDANCE_MODE, S:END_TIME_HH, T:END_TIME_MM
 // ============================================
 
 const SCHEDULE_ATTENDANCE_MODE_COLUMN = 18;
+const SCHEDULE_END_TIME_HH_COLUMN = 19;
+const SCHEDULE_END_TIME_MM_COLUMN = 20;
+const SCHEDULE_COLUMN_COUNT = 20;
 
 const normalizeScheduleAttendanceMode = (mode) =>
     String(mode || "").trim().toUpperCase() === "ATTENDANCE"
@@ -1193,15 +1196,18 @@ const normalizeScheduleAttendanceMode = (mode) =>
         : "ABSENCE";
 
 const ensureScheduleAttendanceModeHeader = (sheet) => {
-    const header = String(
-        sheet.getRange(1, SCHEDULE_ATTENDANCE_MODE_COLUMN).getValue() || ""
-    ).trim();
+    const headers = [
+        [SCHEDULE_ATTENDANCE_MODE_COLUMN, "ATTENDANCE_MODE"],
+        [SCHEDULE_END_TIME_HH_COLUMN, "END_TIME_HH"],
+        [SCHEDULE_END_TIME_MM_COLUMN, "END_TIME_MM"],
+    ];
 
-    if (!header) {
-        sheet
-            .getRange(1, SCHEDULE_ATTENDANCE_MODE_COLUMN)
-            .setValue("ATTENDANCE_MODE");
-    }
+    headers.forEach(([column, value]) => {
+        const header = String(sheet.getRange(1, column).getValue() || "").trim();
+        if (!header) {
+            sheet.getRange(1, column).setValue(value);
+        }
+    });
 };
 
 /**
@@ -1229,12 +1235,14 @@ const handleGetSchedules = (e) => {
             });
         }
 
-        // A2:R（2行目以降、18列）のデータを取得（終了日、カラー、出欠方式を含む）
-        const range = sheet.getRange(2, 1, lastRow - 1, 18);
+        // A2:T（2行目以降、20列）のデータを取得（終了日、カラー、出欠方式、終了時刻を含む）
+        const range = sheet.getRange(2, 1, lastRow - 1, SCHEDULE_COLUMN_COUNT);
         const values = range.getValues();
 
-        // ヘッダー行（A1:R1）を取得
-        const headers = sheet.getRange(1, 1, 1, 18).getValues()[0];
+        // ヘッダー行（A1:T1）を取得
+        const headers = sheet
+            .getRange(1, 1, 1, SCHEDULE_COLUMN_COUNT)
+            .getValues()[0];
 
         // ヘッダーをキーとしたオブジェクト配列に変換
         const schedules = values.map((row) => {
@@ -1835,6 +1843,8 @@ const handlePostSchedule = (postData) => {
             date,
             timeHH,
             timeMM,
+            endTimeHH,
+            endTimeMM,
             title,
             where,
             detail,
@@ -1897,6 +1907,12 @@ const handlePostSchedule = (postData) => {
             "",
             "",
             normalizeScheduleAttendanceMode(attendanceMode),
+            endTimeHH !== undefined && endTimeHH !== ""
+                ? Number(endTimeHH)
+                : "",
+            endTimeMM !== undefined && endTimeMM !== ""
+                ? Number(endTimeMM)
+                : "",
         ];
 
         sheet.appendRow(rowData);
@@ -1915,6 +1931,8 @@ const handlePostSchedule = (postData) => {
                 date: Number(date),
                 timeHH: timeHH || null,
                 timeMM: timeMM || null,
+                endTimeHH: endTimeHH || null,
+                endTimeMM: endTimeMM || null,
                 title,
                 where: where || "",
                 detail: detail || "",
@@ -2091,6 +2109,8 @@ const handleUpdateSchedule = (postData) => {
             date,
             timeHH,
             timeMM,
+            endTimeHH,
+            endTimeMM,
             title,
             where,
             detail,
@@ -2171,6 +2191,18 @@ const handleUpdateSchedule = (postData) => {
         sheet
             .getRange(targetRow, SCHEDULE_ATTENDANCE_MODE_COLUMN)
             .setValue(normalizeScheduleAttendanceMode(attendanceMode));
+        sheet
+            .getRange(targetRow, SCHEDULE_END_TIME_HH_COLUMN, 1, 2)
+            .setValues([
+                [
+                    endTimeHH !== undefined && endTimeHH !== ""
+                        ? Number(endTimeHH)
+                        : "",
+                    endTimeMM !== undefined && endTimeMM !== ""
+                        ? Number(endTimeMM)
+                        : "",
+                ],
+            ]);
 
         // P列（UPDATED_BY）とQ列（UPDATED_AT）を更新
         if (updatedBy) {
@@ -2193,6 +2225,8 @@ const handleUpdateSchedule = (postData) => {
                 date: Number(date),
                 timeHH: timeHH || null,
                 timeMM: timeMM || null,
+                endTimeHH: endTimeHH || null,
+                endTimeMM: endTimeMM || null,
                 title,
                 where: where || "",
                 detail: detail || "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "dependencies": {
                 "@ducanh2912/next-pwa": "^10.2.9",
                 "@types/google-apps-script": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",

--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -358,19 +358,6 @@ export default function ScheduleCard({
                                 : isAbsenceFormOpen
                                   ? "欠席連絡"
                                   : title}
-                            {!isAttendanceConfirmOpen &&
-                                !isAbsenceFormOpen &&
-                                timeLabel && (
-                                <span
-                                    className="font-normal text-base-content/70"
-                                    style={{
-                                        fontSize:
-                                            "clamp(1rem, 2.5vw, 1.125rem)",
-                                    }}
-                                >
-                                    {timeLabel}
-                                </span>
-                            )}
                         </h3>
                         {isAttendanceConfirmOpen ? (
                             <>
@@ -683,7 +670,7 @@ export default function ScheduleCard({
                             </form>
                         ) : (
                             <>
-                                {(where || dateLabel) && (
+                                {(where || dateLabel || timeLabel) && (
                                     <div
                                         className="flex items-center gap-4 text-base-content/80 mb-4"
                                         style={{
@@ -691,24 +678,28 @@ export default function ScheduleCard({
                                                 "clamp(0.875rem, 2vw, 1.125rem)",
                                         }}
                                     >
-                                        {dateLabel && (
+                                        {(dateLabel || timeLabel) && (
                                             <div className="flex items-center gap-2">
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    className="h-5 w-5 text-primary"
-                                                    fill="none"
-                                                    viewBox="0 0 24 24"
-                                                    stroke="currentColor"
-                                                >
-                                                    <path
-                                                        strokeLinecap="round"
-                                                        strokeLinejoin="round"
-                                                        strokeWidth={2}
-                                                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                                                    />
-                                                </svg>
+                                                {dateLabel && (
+                                                    <svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        className="h-5 w-5 text-primary"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                        stroke="currentColor"
+                                                    >
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            strokeWidth={2}
+                                                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                                                        />
+                                                    </svg>
+                                                )}
                                                 <span className="font-medium">
-                                                    {dateLabel}
+                                                    {[dateLabel, timeLabel]
+                                                        .filter(Boolean)
+                                                        .join(" ")}
                                                 </span>
                                             </div>
                                         )}


### PR DESCRIPTION
## 概要
- イベント登録・編集で開始時刻と終了時刻を入力できるように変更
- 予定表示で 11:00-12:00 のような時刻範囲を表示
- イベント個別モーダルでタイトル横に時刻を表示しないよう修正
- GAS の schedules に終了時刻列 END_TIME_HH / END_TIME_MM を追加
- バージョンを 1.10.0 に更新

## 確認
- npm run build
- clasp push --force 実行済み