### PR TITLE
feat: スマホ向けPWA案内を追加

### DIFF
--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -20,6 +20,7 @@ import { ScheduleCard } from "@/features/schedule-card";
 import { DateDisplay } from "@/features/date-display";
 import { ProfileImageSaver } from "@/features/profile-image";
 import { NextMeetingCard } from "@/src/features/next-meeting";
+import { MobilePWAInstallBanner } from "@/src/features/pwa-install";
 import { auth } from "@/src/auth";
 
 const getScheduleAttendanceMode = (
@@ -129,6 +130,8 @@ export default async function HomePage() {
                         <span>{error}</span>
                     </div>
                 )}
+
+                <MobilePWAInstallBanner />
 
                 <div className="grid grid-cols-1 gap-5 lg:grid-cols-12">
                     <div className="card bg-base-100 shadow-xl border border-base-300 order-3 lg:order-3 lg:col-span-6">

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -2,15 +2,20 @@ import { Header } from "@/src/widgets/header";
 import { Sidebar } from "@/src/widgets/sidebar";
 import { Dock } from "@/src/widgets/dock";
 import { AccessLogger } from "@/src/features/access-log/AccessLogger";
+import { PWANotificationPrompt } from "@/src/features/pwa-install";
+import { auth } from "@/src/auth";
 
 export default async function AuthenticatedLayout({
     children,
 }: {
     children: React.ReactNode;
 }) {
+    const session = await auth();
+
     return (
         <>
             <AccessLogger />
+            <PWANotificationPrompt userEmail={session?.user?.email || null} />
 
             {/* Drawer - 大画面のみ表示 */}
             <Sidebar>{children}</Sidebar>

--- a/src/features/push-notification/lib/push-subscription.ts
+++ b/src/features/push-notification/lib/push-subscription.ts
@@ -1,0 +1,186 @@
+"use client";
+
+export type SubscriptionState =
+    | "loading"
+    | "unsupported"
+    | "denied"
+    | "subscribed"
+    | "unsubscribed";
+
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || "";
+
+export const isPushNotificationSupported = () =>
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window;
+
+export const urlBase64ToUint8Array = (base64String: string): ArrayBuffer => {
+    const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding)
+        .replace(/-/g, "+")
+        .replace(/_/g, "/");
+    const rawData = window.atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+    for (let i = 0; i < rawData.length; ++i) {
+        outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray.buffer as ArrayBuffer;
+};
+
+export async function getServiceWorkerRegistration(
+    maxRetries = 3,
+    retryDelay = 1000
+): Promise<ServiceWorkerRegistration | null> {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+            const existingRegistration =
+                await navigator.serviceWorker.getRegistration("/");
+            if (existingRegistration?.active) {
+                return existingRegistration;
+            }
+
+            const timeoutPromise = new Promise<null>((resolve) => {
+                setTimeout(() => resolve(null), 5000);
+            });
+
+            const registration = await Promise.race([
+                navigator.serviceWorker.ready,
+                timeoutPromise,
+            ]);
+
+            if (registration) {
+                return registration;
+            }
+
+            if (attempt < maxRetries - 1) {
+                await new Promise((resolve) => setTimeout(resolve, retryDelay));
+            }
+        } catch (error) {
+            console.error(
+                `Service Worker registration attempt ${attempt + 1} failed:`,
+                error
+            );
+            if (attempt < maxRetries - 1) {
+                await new Promise((resolve) => setTimeout(resolve, retryDelay));
+            }
+        }
+    }
+    return null;
+}
+
+export async function getPushSubscriptionState(): Promise<SubscriptionState> {
+    if (!isPushNotificationSupported()) {
+        return "unsupported";
+    }
+
+    if (Notification.permission === "denied") {
+        return "denied";
+    }
+
+    try {
+        const registration = await getServiceWorkerRegistration();
+
+        if (!registration) {
+            return "unsubscribed";
+        }
+
+        const subscription = await registration.pushManager.getSubscription();
+        return subscription ? "subscribed" : "unsubscribed";
+    } catch (error) {
+        console.error("Error checking subscription:", error);
+        return "unsubscribed";
+    }
+}
+
+const waitForServiceWorkerActivation = async (
+    worker: ServiceWorker | null
+) => {
+    if (!worker) return;
+    if (worker.state === "activated") return;
+
+    await new Promise<void>((resolve) => {
+        worker.addEventListener("statechange", function handler() {
+            if (this.state === "activated") {
+                this.removeEventListener("statechange", handler);
+                resolve();
+            }
+        });
+    });
+};
+
+export async function subscribeToPushNotifications(userEmail: string) {
+    if (!isPushNotificationSupported()) {
+        throw new Error("このブラウザはプッシュ通知に対応していません");
+    }
+
+    const permission = await Notification.requestPermission();
+    if (permission !== "granted") {
+        return {
+            subscribed: false,
+            denied: Notification.permission === "denied",
+        };
+    }
+
+    let registration = await getServiceWorkerRegistration(5, 2000);
+
+    if (!registration) {
+        const newRegistration = await navigator.serviceWorker.register(
+            "/sw.js"
+        );
+        await waitForServiceWorkerActivation(
+            newRegistration.installing || newRegistration.waiting
+        );
+        registration = await getServiceWorkerRegistration(3, 1000);
+    }
+
+    if (!registration) {
+        throw new Error("Service Workerを利用できません");
+    }
+
+    const existingSubscription =
+        await registration.pushManager.getSubscription();
+    if (existingSubscription) {
+        await existingSubscription.unsubscribe();
+    }
+
+    const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+    });
+
+    const response = await fetch("/api/push-subscribe", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            subscription: subscription.toJSON(),
+            studentId: userEmail.split("@")[0],
+        }),
+    });
+
+    if (!response.ok) {
+        throw new Error("通知設定の保存に失敗しました");
+    }
+
+    return { subscribed: true, denied: false };
+}
+
+export async function unsubscribeFromPushNotifications() {
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+
+    if (!subscription) return;
+
+    await subscription.unsubscribe();
+
+    await fetch("/api/push-subscribe", {
+        method: "DELETE",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            endpoint: subscription.endpoint,
+        }),
+    });
+}

--- a/src/features/push-notification/ui/PushNotificationToggle.tsx
+++ b/src/features/push-notification/ui/PushNotificationToggle.tsx
@@ -1,78 +1,14 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-
-type SubscriptionState =
-    | "loading"
-    | "unsupported"
-    | "denied"
-    | "subscribed"
-    | "unsubscribed";
-
-const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || "";
-
-/**
- * Base64 URL形式の文字列をUint8Arrayに変換
- */
-function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
-    const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
-    const base64 = (base64String + padding)
-        .replace(/-/g, "+")
-        .replace(/_/g, "/");
-    const rawData = window.atob(base64);
-    const outputArray = new Uint8Array(rawData.length);
-    for (let i = 0; i < rawData.length; ++i) {
-        outputArray[i] = rawData.charCodeAt(i);
-    }
-    return outputArray.buffer as ArrayBuffer;
-}
-
-/**
- * Service Workerの登録を取得（リトライ機能付き）
- */
-async function getServiceWorkerRegistration(
-    maxRetries = 3,
-    retryDelay = 1000
-): Promise<ServiceWorkerRegistration | null> {
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-        try {
-            // まず既存の登録を確認
-            const existingRegistration =
-                await navigator.serviceWorker.getRegistration("/");
-            if (existingRegistration?.active) {
-                return existingRegistration;
-            }
-
-            // readyを待機（タイムアウト付き）
-            const timeoutPromise = new Promise<null>((resolve) => {
-                setTimeout(() => resolve(null), 5000);
-            });
-
-            const registration = await Promise.race([
-                navigator.serviceWorker.ready,
-                timeoutPromise,
-            ]);
-
-            if (registration) {
-                return registration;
-            }
-
-            // リトライ前に待機
-            if (attempt < maxRetries - 1) {
-                await new Promise((resolve) => setTimeout(resolve, retryDelay));
-            }
-        } catch (error) {
-            console.error(
-                `Service Worker registration attempt ${attempt + 1} failed:`,
-                error
-            );
-            if (attempt < maxRetries - 1) {
-                await new Promise((resolve) => setTimeout(resolve, retryDelay));
-            }
-        }
-    }
-    return null;
-}
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBell } from "@fortawesome/free-regular-svg-icons";
+import {
+    getPushSubscriptionState,
+    subscribeToPushNotifications,
+    unsubscribeFromPushNotifications,
+    type SubscriptionState,
+} from "@/src/features/push-notification/lib/push-subscription";
 
 interface PushNotificationToggleProps {
     userEmail: string | null;
@@ -88,35 +24,8 @@ export default function PushNotificationToggle({
     const [isProcessing, setIsProcessing] = useState(false);
 
     const checkSubscription = useCallback(async () => {
-        // ブラウザサポートチェック
-        if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
-            setState("unsupported");
-            return;
-        }
-
-        // 通知許可状態チェック
-        const permission = Notification.permission;
-        if (permission === "denied") {
-            setState("denied");
-            return;
-        }
-
-        try {
-            const registration = await getServiceWorkerRegistration();
-
-            if (!registration) {
-                // Service Workerが利用できない場合もunsubscribedとして扱う
-                setState("unsubscribed");
-                return;
-            }
-
-            const subscription =
-                await registration.pushManager.getSubscription();
-            setState(subscription ? "subscribed" : "unsubscribed");
-        } catch (error) {
-            console.error("Error checking subscription:", error);
-            setState("unsubscribed");
-        }
+        const nextState = await getPushSubscriptionState();
+        setState(nextState);
     }, []);
 
     useEffect(() => {
@@ -131,121 +40,11 @@ export default function PushNotificationToggle({
 
         setIsProcessing(true);
         try {
-            // 通知許可をリクエスト
-            const permission = await Notification.requestPermission();
-            if (permission !== "granted") {
-                // ブラウザで完全にブロックされている場合のみdenied
-                // キャンセルや後での場合はunsubscribedのまま（再度オンにできる）
-                if (Notification.permission === "denied") {
-                    setState("denied");
-                }
-                // それ以外（default）はunsubscribedのまま
-                return;
-            }
-
-            // Service Workerの登録を取得（リトライ付き）
-            const registration = await getServiceWorkerRegistration(5, 2000);
-
-            if (!registration) {
-                // Service Workerが取得できない場合、再登録を試みる
-                try {
-                    const newRegistration =
-                        await navigator.serviceWorker.register("/sw.js");
-
-                    // Service Workerがactiveになるまで待機
-                    if (newRegistration.installing) {
-                        await new Promise<void>((resolve) => {
-                            newRegistration.installing!.addEventListener(
-                                "statechange",
-                                function handler() {
-                                    if (this.state === "activated") {
-                                        this.removeEventListener(
-                                            "statechange",
-                                            handler
-                                        );
-                                        resolve();
-                                    }
-                                }
-                            );
-                        });
-                    } else if (newRegistration.waiting) {
-                        await new Promise<void>((resolve) => {
-                            newRegistration.waiting!.addEventListener(
-                                "statechange",
-                                function handler() {
-                                    if (this.state === "activated") {
-                                        this.removeEventListener(
-                                            "statechange",
-                                            handler
-                                        );
-                                        resolve();
-                                    }
-                                }
-                            );
-                        });
-                    }
-
-                    // 再度取得を試みる
-                    const retryRegistration =
-                        await getServiceWorkerRegistration(3, 1000);
-                    if (!retryRegistration) {
-                        throw new Error("Service Worker activation failed");
-                    }
-                } catch (regError) {
-                    console.error(
-                        "Service Worker re-registration failed:",
-                        regError
-                    );
-                    const errorMessage =
-                        regError instanceof Error
-                            ? regError.message
-                            : "Unknown error";
-                    alert(
-                        `Service Workerの登録に失敗しました: ${errorMessage}\nブラウザの設定でService Workerを有効にしてください。`
-                    );
-                    return;
-                }
-            }
-
-            // 最終的な登録を取得
-            const finalRegistration =
-                registration || (await getServiceWorkerRegistration(1, 0));
-            if (!finalRegistration) {
-                throw new Error("Service Worker not available");
-            }
-
-            // 既存のサブスクリプションがあれば解除
-            const existingSubscription =
-                await finalRegistration.pushManager.getSubscription();
-            if (existingSubscription) {
-                await existingSubscription.unsubscribe();
-            }
-
-            // 新しいサブスクリプションを作成
-            const subscription = await finalRegistration.pushManager.subscribe({
-                userVisibleOnly: true,
-                applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
-            });
-
-            // 学籍番号を抽出（メールアドレスの@より前の部分）
-            const studentId = userEmail.split("@")[0];
-
-            // サーバーに登録
-            const response = await fetch("/api/push-subscribe", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    subscription: subscription.toJSON(),
-                    studentId,
-                }),
-            });
-
-            if (response.ok) {
+            const result = await subscribeToPushNotifications(userEmail);
+            if (result.subscribed) {
                 setState("subscribed");
-            } else {
-                throw new Error("Failed to save subscription");
+            } else if (result.denied) {
+                setState("denied");
             }
         } catch (error) {
             console.error("Error subscribing:", error);
@@ -262,25 +61,7 @@ export default function PushNotificationToggle({
 
         setIsProcessing(true);
         try {
-            const registration = await navigator.serviceWorker.ready;
-            const subscription =
-                await registration.pushManager.getSubscription();
-
-            if (subscription) {
-                await subscription.unsubscribe();
-
-                // サーバーから削除
-                await fetch("/api/push-subscribe", {
-                    method: "DELETE",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({
-                        endpoint: subscription.endpoint,
-                    }),
-                });
-            }
-
+            await unsubscribeFromPushNotifications();
             setState("unsubscribed");
         } catch (error) {
             console.error("Error unsubscribing:", error);
@@ -306,20 +87,7 @@ export default function PushNotificationToggle({
     return (
         <div className="flex items-center justify-between p-4 bg-base-200 rounded-lg">
             <div className="flex items-center gap-3">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5 text-primary"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                >
-                    <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-                    />
-                </svg>
+                <FontAwesomeIcon icon={faBell} className="h-5 w-5 text-primary" />
                 <div>
                     <p className="font-medium text-sm">プッシュ通知</p>
                     <p className="text-xs text-base-content/60">

--- a/src/features/pwa-install/index.ts
+++ b/src/features/pwa-install/index.ts
@@ -1,0 +1,3 @@
+export { PWAInstallButton } from "./ui/PWAInstallButton";
+export { MobilePWAInstallBanner } from "./ui/MobilePWAInstallBanner";
+export { PWANotificationPrompt } from "./ui/PWANotificationPrompt";

--- a/src/features/pwa-install/ui/MobilePWAInstallBanner.tsx
+++ b/src/features/pwa-install/ui/MobilePWAInstallBanner.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    faDownload,
+    faMobileScreenButton,
+    faShareNodes,
+    faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+
+interface BeforeInstallPromptEvent extends Event {
+    prompt: () => Promise<void>;
+    userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+type Platform = "ios" | "android" | "other";
+
+const DISMISS_KEY = "nb-pwa-install-banner-dismissed-at";
+const DISMISS_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+const isStandaloneDisplay = () =>
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (navigator as Navigator & { standalone?: boolean }).standalone === true;
+
+const isMobileViewport = () =>
+    window.matchMedia("(max-width: 768px)").matches ||
+    window.matchMedia("(pointer: coarse)").matches;
+
+const getPlatform = (): Platform => {
+    const userAgent = navigator.userAgent.toLowerCase();
+    const isIOS =
+        /iphone|ipad|ipod/.test(userAgent) ||
+        (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+
+    if (isIOS) return "ios";
+    if (/android/.test(userAgent)) return "android";
+    return "other";
+};
+
+const isRecentlyDismissed = () => {
+    const dismissedAt = Number(localStorage.getItem(DISMISS_KEY) || "0");
+    if (!dismissedAt) return false;
+    return Date.now() - dismissedAt < DISMISS_INTERVAL_MS;
+};
+
+export function MobilePWAInstallBanner() {
+    const [deferredPrompt, setDeferredPrompt] =
+        useState<BeforeInstallPromptEvent | null>(null);
+    const [platform, setPlatform] = useState<Platform>("other");
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        const shouldShow =
+            isMobileViewport() &&
+            !isStandaloneDisplay() &&
+            !isRecentlyDismissed();
+
+        const timerId = window.setTimeout(() => {
+            setPlatform(getPlatform());
+            setIsVisible(shouldShow);
+        }, 0);
+
+        const handleBeforeInstallPrompt = (event: Event) => {
+            event.preventDefault();
+            setDeferredPrompt(event as BeforeInstallPromptEvent);
+            if (shouldShow) {
+                setIsVisible(true);
+            }
+        };
+
+        const handleAppInstalled = () => {
+            setIsVisible(false);
+            setDeferredPrompt(null);
+        };
+
+        window.addEventListener(
+            "beforeinstallprompt",
+            handleBeforeInstallPrompt
+        );
+        window.addEventListener("appinstalled", handleAppInstalled);
+
+        return () => {
+            window.clearTimeout(timerId);
+            window.removeEventListener(
+                "beforeinstallprompt",
+                handleBeforeInstallPrompt
+            );
+            window.removeEventListener("appinstalled", handleAppInstalled);
+        };
+    }, []);
+
+    const dismiss = () => {
+        localStorage.setItem(DISMISS_KEY, String(Date.now()));
+        setIsVisible(false);
+    };
+
+    const install = async () => {
+        if (!deferredPrompt) return;
+
+        await deferredPrompt.prompt();
+        const { outcome } = await deferredPrompt.userChoice;
+        if (outcome === "accepted") {
+            setDeferredPrompt(null);
+            setIsVisible(false);
+        }
+    };
+
+    if (!isVisible) return null;
+
+    const canPrompt = !!deferredPrompt;
+    const isIOS = platform === "ios";
+    const installInstruction =
+        platform === "android"
+            ? "右上のメニュー（︙）→ アプリをインストール"
+            : "ブラウザの共有・メニュー → ホーム画面に追加";
+
+    return (
+        <div className="mb-5 rounded-2xl border border-primary/20 bg-base-100 p-4 shadow-sm">
+            <div className="flex items-start gap-3">
+                <div className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary">
+                    <FontAwesomeIcon icon={faMobileScreenButton} />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-start gap-2">
+                        <div className="min-w-0 flex-1">
+                            <p className="font-semibold">
+                                ホーム画面に追加できます
+                            </p>
+                            <p className="mt-1 text-sm leading-relaxed text-base-content/70">
+                                アプリのように開けます。通知を使う場合もホーム画面からの起動が必要です。
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            className="btn btn-ghost btn-xs btn-circle"
+                            onClick={dismiss}
+                            aria-label="閉じる"
+                        >
+                            <FontAwesomeIcon icon={faXmark} />
+                        </button>
+                    </div>
+
+                    {canPrompt ? (
+                        <button
+                            type="button"
+                            className="btn btn-primary btn-sm mt-3 gap-2"
+                            onClick={install}
+                        >
+                            <FontAwesomeIcon icon={faDownload} />
+                            インストール
+                        </button>
+                    ) : (
+                        <div className="mt-3 rounded-xl bg-base-200 px-3 py-2 text-sm text-base-content/75">
+                            <div className="flex items-center gap-2 font-medium">
+                                <FontAwesomeIcon icon={faShareNodes} />
+                                {isIOS
+                                    ? "共有ボタン → ホーム画面に追加"
+                                    : installInstruction}
+                            </div>
+                            {isIOS && (
+                                <p className="mt-1 text-xs text-base-content/60">
+                                    表示されない場合はSafariで開いてください。
+                                </p>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/pwa-install/ui/PWANotificationPrompt.tsx
+++ b/src/features/pwa-install/ui/PWANotificationPrompt.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBell } from "@fortawesome/free-regular-svg-icons";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import {
+    getPushSubscriptionState,
+    isPushNotificationSupported,
+    subscribeToPushNotifications,
+} from "@/src/features/push-notification/lib/push-subscription";
+
+interface PWANotificationPromptProps {
+    userEmail: string | null;
+}
+
+const DISMISS_KEY = "nb-pwa-notification-prompt-dismissed-at";
+const DISMISS_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const isStandaloneDisplay = () =>
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (navigator as Navigator & { standalone?: boolean }).standalone === true;
+
+const isRecentlyDismissed = () => {
+    const dismissedAt = Number(localStorage.getItem(DISMISS_KEY) || "0");
+    if (!dismissedAt) return false;
+    return Date.now() - dismissedAt < DISMISS_INTERVAL_MS;
+};
+
+export function PWANotificationPrompt({
+    userEmail,
+}: PWANotificationPromptProps) {
+    const [isVisible, setIsVisible] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const checkPrompt = async () => {
+            if (!userEmail || !isStandaloneDisplay() || isRecentlyDismissed()) {
+                return;
+            }
+
+            if (
+                !isPushNotificationSupported() ||
+                Notification.permission !== "default"
+            ) {
+                return;
+            }
+
+            const state = await getPushSubscriptionState();
+            if (isMounted && state === "unsubscribed") {
+                setIsVisible(true);
+            }
+        };
+
+        void checkPrompt();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [userEmail]);
+
+    const dismiss = () => {
+        localStorage.setItem(DISMISS_KEY, String(Date.now()));
+        setIsVisible(false);
+    };
+
+    const enableNotifications = async () => {
+        if (!userEmail) return;
+
+        setIsSubmitting(true);
+        setMessage(null);
+
+        try {
+            const result = await subscribeToPushNotifications(userEmail);
+            if (result.subscribed) {
+                setIsVisible(false);
+                return;
+            }
+
+            setMessage(
+                result.denied
+                    ? "ブラウザで通知がブロックされています。設定から許可してください。"
+                    : "通知は有効になりませんでした。必要になったらお知らせページから設定できます。"
+            );
+        } catch (error) {
+            console.error("Error enabling notifications:", error);
+            setMessage("通知の設定に失敗しました。時間をおいて再度お試しください。");
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    if (!isVisible) return null;
+
+    return (
+        <dialog className="modal modal-open">
+            <div className="modal-box max-w-sm rounded-2xl">
+                <div className="mb-4 flex items-start gap-3">
+                    <div className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary">
+                        <FontAwesomeIcon icon={faBell} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                        <h2 className="text-lg font-bold">通知を有効にしますか</h2>
+                        <p className="mt-2 text-sm leading-relaxed text-base-content/70">
+                            予定の追加や変更を、この端末で受け取れるようにします。
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        className="btn btn-ghost btn-xs btn-circle"
+                        onClick={dismiss}
+                        aria-label="閉じる"
+                    >
+                        <FontAwesomeIcon icon={faXmark} />
+                    </button>
+                </div>
+
+                {message && (
+                    <div className="alert alert-warning mb-4 py-2 text-sm">
+                        <span>{message}</span>
+                    </div>
+                )}
+
+                <div className="modal-action">
+                    <button
+                        type="button"
+                        className="btn btn-ghost"
+                        onClick={dismiss}
+                        disabled={isSubmitting}
+                    >
+                        あとで
+                    </button>
+                    <button
+                        type="button"
+                        className="btn btn-primary"
+                        onClick={enableNotifications}
+                        disabled={isSubmitting}
+                    >
+                        {isSubmitting ? (
+                            <span className="loading loading-spinner loading-sm" />
+                        ) : (
+                            "有効にする"
+                        )}
+                    </button>
+                </div>
+            </div>
+            <form method="dialog" className="modal-backdrop">
+                <button type="button" onClick={dismiss}>
+                    閉じる
+                </button>
+            </form>
+        </dialog>
+    );
+}


### PR DESCRIPTION
## 概要
- スマホ未インストール時にPWAのホーム画面追加案内を表示
- iOSとAndroidで案内文を出し分け
- PWA起動時に未購読の場合だけ通知案内モーダルを表示
- 通知購読処理を共通化し、お知らせページのトグルと共有

## 確認
- npm run build
- npx eslint 対象ファイル
- git diff --check