### PR TITLE
feat: スケジュールの経過状態を追加

### DIFF
--- a/cloudflare/nb-portal-api/migrations/0004_schedule_is_past.sql
+++ b/cloudflare/nb-portal-api/migrations/0004_schedule_is_past.sql
@@ -1,0 +1,6 @@
+ALTER TABLE schedules ADD COLUMN is_past INTEGER NOT NULL DEFAULT 0;
+
+UPDATE schedules
+SET is_past = CASE WHEN date < date('now', '+9 hours') THEN 1 ELSE 0 END;
+
+CREATE INDEX idx_schedules_is_past ON schedules(is_past);

--- a/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
+++ b/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
@@ -115,6 +115,14 @@ const buildTime = (hour, minute) => {
 	return `${(h || "0").padStart(2, "0")}:${(m || "0").padStart(2, "0")}`;
 };
 
+const buildTodayJst = () =>
+	new Intl.DateTimeFormat("en-CA", {
+		timeZone: "Asia/Tokyo",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(new Date());
+
 const statements = [
 	"PRAGMA foreign_keys = OFF;",
 	"DELETE FROM push_subscriptions;",
@@ -122,6 +130,8 @@ const statements = [
 	"DELETE FROM schedules;",
 	"DELETE FROM members;",
 ];
+
+const todayJst = buildTodayJst();
 
 for (const member of readCsv(files.members)) {
 	const studentNumber = member.StudentNumber;
@@ -149,9 +159,9 @@ for (const schedule of readCsv(files.schedules)) {
 	const eventId = schedule.EVENT_ID;
 	if (!eventId) continue;
 
-	statements.push(`INSERT INTO schedules (
+statements.push(`INSERT INTO schedules (
   id, title, date, start_time, end_time, location, description, attendance_mode,
-  created_by, created_at, updated_by, updated_at
+  is_past, created_by, created_at, updated_by, updated_at
 ) VALUES (
   ${sqlString(eventId)},
   ${sqlString(schedule.TITLE)},
@@ -161,6 +171,7 @@ for (const schedule of readCsv(files.schedules)) {
   ${sqlNullableString(schedule.WHERE)},
   ${sqlNullableString(schedule.DETAIL)},
   ${sqlString(schedule.ATTENDANCE_MODE || "ABSENCE")},
+  ${buildDate(schedule.YYYY, schedule.MM, schedule.DD) < todayJst ? "1" : "0"},
   ${sqlNullableString(schedule.CREATED_BY)},
   ${sqlString(parseSpreadsheetDateTime(schedule.CREATED_AT) || new Date().toISOString())},
   ${sqlNullableString(schedule.UPDATED_BY)},

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -48,6 +48,7 @@ type ScheduleRow = {
 	location: string | null;
 	description: string | null;
 	attendance_mode: string;
+	is_past: number;
 	created_by: string | null;
 	created_at: string;
 	updated_by: string | null;
@@ -177,6 +178,29 @@ const buildTime = (hour: unknown, minute: unknown) => {
 	return `${h.padStart(2, "0")}:${(m || "0").padStart(2, "0")}`;
 };
 
+const getJstDateParts = (date = new Date()) => {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone: "Asia/Tokyo",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		hourCycle: "h23",
+	}).formatToParts(date);
+	const value = (type: Intl.DateTimeFormatPartTypes) =>
+		parts.find((part) => part.type === type)?.value || "";
+
+	return {
+		date: `${value("year")}-${value("month")}-${value("day")}`,
+		dateLabel: `${value("year")}/${value("month")}/${value("day")}`,
+		hour: value("hour"),
+		minute: value("minute"),
+	};
+};
+
+const toScheduleIsPast = (date: string) => (date < getJstDateParts().date ? 1 : 0);
+
 const toMemberResponse = (row: MemberRow, rowNumber: number) => ({
 	rowNumber,
 	values: [
@@ -217,6 +241,7 @@ const toScheduleResponse = (row: ScheduleRow) => {
 		ATTENDANCE_MODE: row.attendance_mode || "ABSENCE",
 		END_TIME_HH: endTime.hour,
 		END_TIME_MM: endTime.minute,
+		IS_PAST: row.is_past === 1,
 	};
 };
 
@@ -391,7 +416,7 @@ const verifyMember = async (url: URL, env: Env) => {
 const getSchedules = async (env: Env) => {
 	const rows = await env.DB.prepare(
 		`SELECT id, title, date, start_time, end_time, location, description,
-			attendance_mode, created_by, created_at, updated_by, updated_at
+			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		FROM schedules
 		ORDER BY date, start_time, id`
 	).all<ScheduleRow>();
@@ -412,9 +437,9 @@ const createSchedule = async (request: Request, env: Env) => {
 	await env.DB.prepare(
 		`INSERT INTO schedules (
 			id, title, date, start_time, end_time, location, description,
-			attendance_mode, created_by, created_at, updated_by, updated_at
+			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`
 	)
 		.bind(
 			eventId,
@@ -425,6 +450,7 @@ const createSchedule = async (request: Request, env: Env) => {
 			String(body.where ?? "").trim(),
 			String(body.detail ?? "").trim(),
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
+			toScheduleIsPast(date),
 			String(body.createdBy ?? "").trim(),
 			String(body.createdBy ?? "").trim()
 		)
@@ -458,7 +484,7 @@ const updateSchedule = async (request: Request, env: Env) => {
 	await env.DB.prepare(
 		`UPDATE schedules SET
 			title = ?, date = ?, start_time = ?, end_time = ?, location = ?,
-			description = ?, attendance_mode = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP
+			description = ?, attendance_mode = ?, is_past = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?`
 	)
 		.bind(
@@ -469,6 +495,7 @@ const updateSchedule = async (request: Request, env: Env) => {
 			String(body.where ?? "").trim(),
 			String(body.detail ?? "").trim(),
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
+			toScheduleIsPast(date),
 			String(body.updatedBy ?? "").trim(),
 			eventId
 		)
@@ -659,7 +686,7 @@ const getDashboardData = async (env: Env) => {
 		env.DB.prepare("SELECT * FROM absences ORDER BY submitted_at").all<AbsenceRow>(),
 		env.DB.prepare(
 			`SELECT id, title, date, start_time, end_time, location, description,
-				attendance_mode, created_by, created_at, updated_by, updated_at
+				attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 			FROM schedules
 			ORDER BY date, start_time, id`
 		).all<ScheduleRow>(),
@@ -826,27 +853,6 @@ const saveAccessLogs = async (request: Request, env: Env) => {
 		await env.DB.batch(statements);
 	}
 	return ok(null, { count: statements.length });
-};
-
-const getJstDateParts = (date = new Date()) => {
-	const parts = new Intl.DateTimeFormat("en-CA", {
-		timeZone: "Asia/Tokyo",
-		year: "numeric",
-		month: "2-digit",
-		day: "2-digit",
-		hour: "2-digit",
-		minute: "2-digit",
-		hourCycle: "h23",
-	}).formatToParts(date);
-	const value = (type: Intl.DateTimeFormatPartTypes) =>
-		parts.find((part) => part.type === type)?.value || "";
-
-	return {
-		date: `${value("year")}-${value("month")}-${value("day")}`,
-		dateLabel: `${value("year")}/${value("month")}/${value("day")}`,
-		hour: value("hour"),
-		minute: value("minute"),
-	};
 };
 
 const formatDateTime = (value: string | null) => {
@@ -1165,7 +1171,27 @@ const markCronExecutionFailed = async (
 		.run();
 };
 
+const updateSchedulePastState = async (env: RuntimeEnv) => {
+	const today = getJstDateParts().date;
+	await env.DB.prepare(
+		`UPDATE schedules
+		SET is_past = CASE WHEN date < ? THEN 1 ELSE 0 END,
+			updated_at = CASE
+				WHEN is_past != CASE WHEN date < ? THEN 1 ELSE 0 END
+				THEN CURRENT_TIMESTAMP
+				ELSE updated_at
+			END`
+	)
+		.bind(today, today)
+		.run();
+};
+
 const runScheduledTasks = async (controller: ScheduledController, env: RuntimeEnv) => {
+	if (controller.cron === "0 15 * * *") {
+		await updateSchedulePastState(env);
+		return;
+	}
+
 	if (controller.cron === "0 22 * * *") {
 		await Promise.all([
 			sendTodayAbsences(env),

--- a/cloudflare/nb-portal-api/wrangler.jsonc
+++ b/cloudflare/nb-portal-api/wrangler.jsonc
@@ -31,6 +31,7 @@
 			"name": "nb-portal-api-production",
 			"triggers": {
 				"crons": [
+					"0 15 * * *",
 					"0 22 * * *",
 					"0 9 * * *"
 				]

--- a/docs/cloudflare-d1-migration-design.md
+++ b/docs/cloudflare-d1-migration-design.md
@@ -147,6 +147,7 @@ CREATE TABLE schedules (
   location TEXT,
   description TEXT,
   attendance_mode TEXT NOT NULL DEFAULT 'ABSENCE',
+  is_past INTEGER NOT NULL DEFAULT 0,
   created_by TEXT,
   updated_by TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -288,6 +289,8 @@ Initial setup order:
 - Scheduled absence and next meeting notifications run on Cloudflare Cron
   Triggers. Completed cron executions are recorded in `cron_executions` to avoid
   duplicate Discord notifications.
+- Schedule past state is stored in `schedules.is_past` and refreshed every day
+  at 00:00 JST.
 - `items` stays intentionally disabled in the D1 API until the new item model is
   designed.
 
@@ -295,6 +298,7 @@ Initial setup order:
 
 Cloudflare Cron uses UTC:
 
+- `0 15 * * *`: 00:00 JST schedule past-state refresh.
 - `0 22 * * *`: 07:00 JST daily absence summary and morning next meeting check.
 - `0 9 * * *`: 18:00 JST Discord next meeting reminder.
 

--- a/docs/daily-absence-notification.md
+++ b/docs/daily-absence-notification.md
@@ -7,10 +7,21 @@ GAS の時間主導型トリガーは使わない。Cloudflare Worker `nb-portal
 
 本番環境の cron:
 
+- `0 15 * * *`: 00:00 JST
 - `0 22 * * *`: 07:00 JST
 - `0 9 * * *`: 18:00 JST
 
 Cloudflare の cron は UTC 指定のため、JST から 9 時間引いた時刻で設定する。
+
+## 00:00 JST の処理
+
+`schedules` の `is_past` を更新する。
+
+- `date < 今日(JST)`: `is_past = 1`
+- `date >= 今日(JST)`: `is_past = 0`
+
+予定作成・更新時にも同じ判定を行うため、cron 実行前でも API レスポンスの
+`IS_PAST` は現在日付に基づいた値になる。
 
 ## 07:00 JST の処理
 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -113,6 +113,7 @@ export interface Item {
 // Schedules型（スプレッドシートのヘッダーに応じて調整してください）
 export interface Schedule {
     [key: string]: string | number | boolean | Date;
+    IS_PAST: boolean;
 }
 
 // Absences型（スプレッドシートのヘッダーに応じて調整してください）


### PR DESCRIPTION
## 概要
- schedules に is_past カラムを追加
- 00:00 JST の Cloudflare Cron で当日を過ぎた予定を判定
- 予定作成・更新時にも is_past を設定
- API レスポンスに IS_PAST を追加
- CSV import SQL 生成時にも is_past を含める
- 運用ドキュメントを更新

## 既存スケジュールについて
- /Users/uyuyu/Downloads/nb-portal_csv_from_spreadsheet/NB_Portal - schedules.csv はヘッダのみで、投入可能な予定レコードは 0 件
- 本番 D1 の schedules も 0 件であることを確認済み

## 適用済み
- D1 dev/prod に 0004_schedule_is_past.sql を適用
- Worker dev/prod を deploy
- 本番 Worker cron: 0 15 * * *, 0 22 * * *, 0 9 * * *

## 検証
- npm test（cloudflare/nb-portal-api）
- npm run build
- 本番 Worker /health で database connected を確認