### PR TITLE
fix: 次回部会をスケジュールに同期

### DIFF
--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -646,6 +646,50 @@ const getNextMeeting = async (env: Env) => {
 
 const updateNextMeeting = async (request: Request, env: Env) => {
 	const body = await getBody(request);
+	const existing = await env.DB.prepare(
+		"SELECT event_id FROM next_meeting_settings WHERE id = 1"
+	).first<{ event_id: string | null }>();
+	const date = String(body.date ?? "").trim();
+	const time = String(body.time ?? "").trim();
+	const mode = String(body.mode ?? "IN_PERSON").trim() || "IN_PERSON";
+	const updatedBy = String(body.updatedBy ?? "").trim();
+	const eventId =
+		String(body.eventId ?? "").trim() ||
+		existing?.event_id ||
+		`MEETING-${Date.now().toString(36).toUpperCase()}`;
+
+	if (!date) return error("Next meeting date is required", 400);
+	if (!time) return error("Next meeting time is required", 400);
+
+	await env.DB.prepare(
+		`INSERT INTO schedules (
+			id, title, date, start_time, end_time, location, description,
+			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+		)
+		VALUES (?, '部会', ?, ?, NULL, ?, '次回部会', 'ABSENCE', ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			title = excluded.title,
+			date = excluded.date,
+			start_time = excluded.start_time,
+			end_time = excluded.end_time,
+			location = excluded.location,
+			description = excluded.description,
+			attendance_mode = excluded.attendance_mode,
+			is_past = excluded.is_past,
+			updated_by = excluded.updated_by,
+			updated_at = CURRENT_TIMESTAMP`
+	)
+		.bind(
+			eventId,
+			date,
+			time,
+			mode === "DISCORD" ? "Discord" : "対面",
+			toScheduleIsPast(date),
+			updatedBy,
+			updatedBy
+		)
+		.run();
+
 	await env.DB.prepare(
 		`INSERT INTO next_meeting_settings (id, event_id, date, time, mode, updated_by, updated_at)
 		VALUES (1, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
@@ -658,11 +702,11 @@ const updateNextMeeting = async (request: Request, env: Env) => {
 			updated_at = CURRENT_TIMESTAMP`
 	)
 		.bind(
-			String(body.eventId ?? "").trim() || null,
-			String(body.date ?? "").trim(),
-			String(body.time ?? "").trim(),
-			String(body.mode ?? "IN_PERSON").trim(),
-			String(body.updatedBy ?? "").trim()
+			eventId,
+			date,
+			time,
+			mode,
+			updatedBy
 		)
 		.run();
 

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -4,7 +4,7 @@ import {
 	waitOnExecutionContext,
 	SELF,
 } from "cloudflare:test";
-import { describe, it, expect } from "vitest";
+import { beforeAll, describe, it, expect } from "vitest";
 import worker from "../src/index";
 
 // For now, you'll need to do something like this to get a correctly-typed
@@ -12,6 +12,37 @@ import worker from "../src/index";
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
 describe("Hello World worker", () => {
+	beforeAll(async () => {
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS schedules (
+				id TEXT PRIMARY KEY,
+				title TEXT NOT NULL,
+				date TEXT NOT NULL,
+				start_time TEXT,
+				end_time TEXT,
+				location TEXT,
+				description TEXT,
+				attendance_mode TEXT NOT NULL DEFAULT 'ABSENCE',
+				created_by TEXT,
+				updated_by TEXT,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				is_past INTEGER NOT NULL DEFAULT 0
+			)`
+		).run();
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS next_meeting_settings (
+				id INTEGER PRIMARY KEY CHECK (id = 1),
+				event_id TEXT,
+				date TEXT NOT NULL,
+				time TEXT NOT NULL,
+				mode TEXT NOT NULL,
+				updated_by TEXT,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`
+		).run();
+	});
+
 	it("responds with health status (unit style)", async () => {
 		const request = new IncomingRequest("http://example.com/health");
 		// Create an empty context to pass to `worker.fetch()`.
@@ -31,5 +62,52 @@ describe("Hello World worker", () => {
 	it("responds with health status (integration style)", async () => {
 		const response = await SELF.fetch("https://example.com/health");
 		expect(response.status).toBe(200);
+	});
+
+	it("creates a schedule when next meeting is updated", async () => {
+		const request = new IncomingRequest("http://example.com/next-meeting", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				date: "2099-01-23",
+				time: "18:00",
+				mode: "DISCORD",
+				updatedBy: "test",
+			}),
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+
+		const responseBody = (await response.json()) as {
+			success?: boolean;
+			data?: { eventId?: string };
+		};
+		expect(responseBody.success).toBe(true);
+		expect(responseBody.data?.eventId).toBeTruthy();
+
+		const schedulesResponse = await worker.fetch(
+			new IncomingRequest("http://example.com/schedules"),
+			env,
+			createExecutionContext()
+		);
+		const schedulesBody = (await schedulesResponse.json()) as {
+			success?: boolean;
+			data?: Array<Record<string, unknown>>;
+		};
+		const meetingSchedule = schedulesBody.data?.find(
+			(schedule) => schedule.EVENT_ID === responseBody.data?.eventId
+		);
+
+		expect(meetingSchedule).toMatchObject({
+			TITLE: "部会",
+			YYYY: "2099",
+			MM: "1",
+			DD: "23",
+			TIME_HH: "18",
+			TIME_MM: "0",
+			WHERE: "Discord",
+		});
 	});
 });


### PR DESCRIPTION
## 概要
- 次回部会保存時に schedules へ部会予定を作成/更新するよう修正
- 既存の next_meeting_settings.event_id があれば同じ schedule を更新
- event_id が無い場合は MEETING-* を生成して next_meeting_settings に保存
- 再発防止の Worker テストを追加

## 本番対応
- Worker production/dev は deploy 済み
- 既存の次回部会 2026-06-17 21:00 Discord を再保存し、schedules に MEETING-MQDMIV59 として作成済み

## 検証
- npm test（cloudflare/nb-portal-api）
- npm run build
- 本番 schedules API で部会予定が返ることを確認
- 本番 Worker /health で database connected を確認