### PR TITLE
タスク管理機能を追加

### DIFF
--- a/app/(authenticated)/more/MoreClient.tsx
+++ b/app/(authenticated)/more/MoreClient.tsx
@@ -8,6 +8,7 @@ import {
     faBookOpen,
     faCircleInfo,
     faCircleQuestion,
+    faListCheck,
     faRightFromBracket,
     faUser,
 } from "@fortawesome/free-solid-svg-icons";
@@ -65,6 +66,33 @@ export default function MoreClient({ user, displayName }: MoreClientProps) {
                                     className="text-lg"
                                 />
                                 ヘルプを見る
+                            </Link>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="card bg-base-200">
+                    <div className="card-body">
+                        <h2 className="card-title text-base">
+                            <FontAwesomeIcon
+                                icon={faListCheck}
+                                className="text-lg"
+                            />
+                            タスク管理
+                        </h2>
+                        <p className="text-sm text-base-content/60 mt-1">
+                            担当者と進捗状況をまとめて確認できます
+                        </p>
+                        <div className="card-actions mt-3">
+                            <Link
+                                href="/tasks"
+                                className="btn btn-primary btn-sm w-full gap-2"
+                            >
+                                <FontAwesomeIcon
+                                    icon={faListCheck}
+                                    className="text-lg"
+                                />
+                                タスクを開く
                             </Link>
                         </div>
                     </div>

--- a/app/(authenticated)/tasks/TasksClient.tsx
+++ b/app/(authenticated)/tasks/TasksClient.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    faCheck,
+    faCirclePlus,
+    faPen,
+    faTrash,
+    faUsers,
+} from "@fortawesome/free-solid-svg-icons";
+import type {
+    ApiResponse,
+    MembersData,
+    Task,
+    TaskStatus,
+} from "@/src/shared/types/api";
+import { TASK_STATUS_LABELS } from "@/src/shared/types/api";
+
+type MemberOption = {
+    studentNumber: string;
+    displayName: string;
+};
+
+type TaskFormState = {
+    id?: string;
+    title: string;
+    description: string;
+    status: TaskStatus;
+    dueDate: string;
+    assigneeStudentNumbers: string[];
+};
+
+const emptyForm: TaskFormState = {
+    title: "",
+    description: "",
+    status: "TODO",
+    dueDate: "",
+    assigneeStudentNumbers: [],
+};
+
+const statusBadgeClass: Record<TaskStatus, string> = {
+    TODO: "badge-ghost",
+    IN_PROGRESS: "badge-info",
+    DONE: "badge-success",
+};
+
+const statusOrder: TaskStatus[] = ["TODO", "IN_PROGRESS", "DONE"];
+
+const formatDate = (value?: string | null) => {
+    if (!value) return "期限なし";
+    const date = new Date(`${value}T00:00:00`);
+    if (Number.isNaN(date.getTime())) return value;
+    const weekday = ["日", "月", "火", "水", "木", "金", "土"][date.getDay()];
+    return `${date.getMonth() + 1}/${date.getDate()}(${weekday})`;
+};
+
+const resolveMembers = (data: MembersData | undefined): MemberOption[] => {
+    if (!data) return [];
+    return data.members
+        .map((member) => {
+            const studentNumber = String(member.values[0] ?? "").trim();
+            const name = String(member.values[1] ?? "").trim();
+            const nickname = String(member.values[2] ?? "").trim();
+            const displayName =
+                nickname && nickname !== "---" ? nickname : name || studentNumber;
+            return { studentNumber, displayName };
+        })
+        .filter((member) => member.studentNumber && member.displayName);
+};
+
+export default function TasksClient() {
+    const [tasks, setTasks] = useState<Task[]>([]);
+    const [members, setMembers] = useState<MemberOption[]>([]);
+    const [form, setForm] = useState<TaskFormState>(emptyForm);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+    const progress = useMemo(() => {
+        const total = tasks.length;
+        const done = tasks.filter((task) => task.status === "DONE").length;
+        return {
+            total,
+            done,
+            percent: total === 0 ? 0 : Math.round((done / total) * 100),
+        };
+    }, [tasks]);
+
+    const groupedTasks = useMemo(
+        () =>
+            statusOrder.map((status) => ({
+                status,
+                tasks: tasks.filter((task) => task.status === status),
+            })),
+        [tasks]
+    );
+
+    const loadData = async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const [tasksResponse, membersResponse] = await Promise.all([
+                fetch("/api/tasks", { cache: "no-store" }),
+                fetch("/api/backend?path=members", { cache: "no-store" }),
+            ]);
+            const tasksData = (await tasksResponse.json()) as ApiResponse<Task[]>;
+            const membersData =
+                (await membersResponse.json()) as ApiResponse<MembersData>;
+
+            if (!tasksData.success) {
+                throw new Error(tasksData.error || "タスクの取得に失敗しました");
+            }
+            if (!membersData.success) {
+                throw new Error(membersData.error || "名簿の取得に失敗しました");
+            }
+
+            setTasks(tasksData.data || []);
+            setMembers(resolveMembers(membersData.data));
+        } catch (caught) {
+            setError(
+                caught instanceof Error
+                    ? caught.message
+                    : "データの取得に失敗しました"
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void loadData();
+    }, []);
+
+    const resetForm = () => {
+        setForm(emptyForm);
+        setSuccessMessage(null);
+    };
+
+    const toggleAssignee = (studentNumber: string) => {
+        setForm((current) => {
+            const exists = current.assigneeStudentNumbers.includes(studentNumber);
+            return {
+                ...current,
+                assigneeStudentNumbers: exists
+                    ? current.assigneeStudentNumbers.filter(
+                          (value) => value !== studentNumber
+                      )
+                    : [...current.assigneeStudentNumbers, studentNumber],
+            };
+        });
+    };
+
+    const submitTask = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setError(null);
+        setSuccessMessage(null);
+        setIsSubmitting(true);
+
+        try {
+            const response = await fetch("/api/tasks", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(form),
+            });
+            const data = (await response.json()) as ApiResponse<Task[]>;
+            if (!response.ok || !data.success) {
+                throw new Error(data.error || "タスクの保存に失敗しました");
+            }
+
+            setTasks(data.data || []);
+            setSuccessMessage(form.id ? "タスクを更新しました" : "タスクを追加しました");
+            resetForm();
+        } catch (caught) {
+            setError(
+                caught instanceof Error
+                    ? caught.message
+                    : "タスクの保存に失敗しました"
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const editTask = (task: Task) => {
+        setForm({
+            id: task.id,
+            title: task.title,
+            description: task.description,
+            status: task.status,
+            dueDate: task.dueDate || "",
+            assigneeStudentNumbers: task.assignees.map(
+                (assignee) => assignee.studentNumber
+            ),
+        });
+        setSuccessMessage(null);
+        setError(null);
+    };
+
+    const updateTaskStatus = async (task: Task, status: TaskStatus) => {
+        setError(null);
+        const response = await fetch("/api/tasks", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                id: task.id,
+                title: task.title,
+                description: task.description,
+                status,
+                dueDate: task.dueDate || "",
+                assigneeStudentNumbers: task.assignees.map(
+                    (assignee) => assignee.studentNumber
+                ),
+            }),
+        });
+        const data = (await response.json()) as ApiResponse<Task[]>;
+        if (data.success) {
+            setTasks(data.data || []);
+        } else {
+            setError(data.error || "ステータス更新に失敗しました");
+        }
+    };
+
+    const deleteTask = async (taskId: string) => {
+        if (!window.confirm("このタスクを削除しますか？")) return;
+        setError(null);
+        const response = await fetch("/api/tasks", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ id: taskId }),
+        });
+        const data = (await response.json()) as ApiResponse<null>;
+        if (data.success) {
+            setTasks((current) => current.filter((task) => task.id !== taskId));
+        } else {
+            setError(data.error || "タスク削除に失敗しました");
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <span className="loading loading-spinner loading-lg text-primary" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(320px,420px)_1fr]">
+            <section className="card bg-base-100 shadow-xl border border-base-300">
+                <form className="card-body gap-4" onSubmit={submitTask}>
+                    <div className="flex items-center gap-2">
+                        <FontAwesomeIcon
+                            icon={faCirclePlus}
+                            className="text-lg text-primary"
+                        />
+                        <h2 className="card-title text-base">
+                            {form.id ? "タスクを編集" : "タスクを追加"}
+                        </h2>
+                    </div>
+
+                    <label className="form-control">
+                        <span className="label-text text-sm">タイトル</span>
+                        <input
+                            className="input input-bordered w-full"
+                            value={form.title}
+                            onChange={(event) =>
+                                setForm((current) => ({
+                                    ...current,
+                                    title: event.target.value,
+                                }))
+                            }
+                            required
+                            maxLength={100}
+                        />
+                    </label>
+
+                    <label className="form-control">
+                        <span className="label-text text-sm">説明</span>
+                        <textarea
+                            className="textarea textarea-bordered min-h-24 w-full"
+                            value={form.description}
+                            onChange={(event) =>
+                                setForm((current) => ({
+                                    ...current,
+                                    description: event.target.value,
+                                }))
+                            }
+                            maxLength={1000}
+                        />
+                    </label>
+
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        <label className="form-control">
+                            <span className="label-text text-sm">状態</span>
+                            <select
+                                className="select select-bordered w-full"
+                                value={form.status}
+                                onChange={(event) =>
+                                    setForm((current) => ({
+                                        ...current,
+                                        status: event.target.value as TaskStatus,
+                                    }))
+                                }
+                            >
+                                {statusOrder.map((status) => (
+                                    <option key={status} value={status}>
+                                        {TASK_STATUS_LABELS[status]}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <label className="form-control">
+                            <span className="label-text text-sm">期限</span>
+                            <input
+                                type="date"
+                                className="input input-bordered w-full"
+                                value={form.dueDate}
+                                onChange={(event) =>
+                                    setForm((current) => ({
+                                        ...current,
+                                        dueDate: event.target.value,
+                                    }))
+                                }
+                            />
+                        </label>
+                    </div>
+
+                    <div className="rounded-lg border border-base-300 p-3">
+                        <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+                            <FontAwesomeIcon icon={faUsers} />
+                            担当者
+                        </div>
+                        <div className="max-h-56 overflow-y-auto pr-1 grid grid-cols-1 gap-2">
+                            {members.map((member) => (
+                                <label
+                                    key={member.studentNumber}
+                                    className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 hover:bg-base-200"
+                                >
+                                    <input
+                                        type="checkbox"
+                                        className="checkbox checkbox-primary checkbox-sm"
+                                        checked={form.assigneeStudentNumbers.includes(
+                                            member.studentNumber
+                                        )}
+                                        onChange={() =>
+                                            toggleAssignee(member.studentNumber)
+                                        }
+                                    />
+                                    <span className="min-w-0 truncate text-sm">
+                                        {member.displayName}
+                                    </span>
+                                    <span className="ml-auto shrink-0 font-mono text-xs text-base-content/50">
+                                        {member.studentNumber}
+                                    </span>
+                                </label>
+                            ))}
+                        </div>
+                    </div>
+
+                    {error && <div className="alert alert-error">{error}</div>}
+                    {successMessage && (
+                        <div className="alert alert-success">{successMessage}</div>
+                    )}
+
+                    <div className="card-actions justify-end">
+                        {form.id && (
+                            <button
+                                type="button"
+                                className="btn btn-ghost"
+                                onClick={resetForm}
+                                disabled={isSubmitting}
+                            >
+                                クリア
+                            </button>
+                        )}
+                        <button
+                            type="submit"
+                            className="btn btn-primary gap-2"
+                            disabled={isSubmitting}
+                        >
+                            {isSubmitting ? (
+                                <span className="loading loading-spinner loading-sm" />
+                            ) : (
+                                <FontAwesomeIcon icon={faCheck} />
+                            )}
+                            保存
+                        </button>
+                    </div>
+                </form>
+            </section>
+
+            <section className="card bg-base-100 shadow-xl border border-base-300">
+                <div className="card-body gap-5">
+                    <div className="flex flex-wrap items-center gap-3">
+                        <h2 className="card-title text-base">進捗状況</h2>
+                        <span className="badge badge-primary badge-outline">
+                            {progress.done}/{progress.total} 完了
+                        </span>
+                    </div>
+                    <progress
+                        className="progress progress-primary w-full"
+                        value={progress.percent}
+                        max={100}
+                    />
+
+                    {tasks.length === 0 ? (
+                        <div className="rounded-lg border border-dashed border-base-300 py-12 text-center text-base-content/60">
+                            タスクはまだありません
+                        </div>
+                    ) : (
+                        <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+                            {groupedTasks.map((group) => (
+                                <div key={group.status} className="space-y-3">
+                                    <div className="flex items-center gap-2">
+                                        <span
+                                            className={`badge ${statusBadgeClass[group.status]}`}
+                                        >
+                                            {TASK_STATUS_LABELS[group.status]}
+                                        </span>
+                                        <span className="text-sm text-base-content/50">
+                                            {group.tasks.length}
+                                        </span>
+                                    </div>
+                                    <div className="space-y-3">
+                                        {group.tasks.map((task) => (
+                                            <article
+                                                key={task.id}
+                                                className="rounded-lg border border-base-300 bg-base-200/40 p-4"
+                                            >
+                                                <div className="flex items-start gap-3">
+                                                    <div className="min-w-0 flex-1">
+                                                        <h3 className="font-semibold leading-snug">
+                                                            {task.title}
+                                                        </h3>
+                                                        {task.description && (
+                                                            <p className="mt-2 whitespace-pre-wrap text-sm text-base-content/70">
+                                                                {task.description}
+                                                            </p>
+                                                        )}
+                                                    </div>
+                                                    <div className="flex shrink-0 gap-1">
+                                                        <button
+                                                            type="button"
+                                                            className="btn btn-ghost btn-xs"
+                                                            onClick={() =>
+                                                                editTask(task)
+                                                            }
+                                                            aria-label="編集"
+                                                        >
+                                                            <FontAwesomeIcon
+                                                                icon={faPen}
+                                                            />
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            className="btn btn-ghost btn-xs text-error"
+                                                            onClick={() =>
+                                                                void deleteTask(
+                                                                    task.id
+                                                                )
+                                                            }
+                                                            aria-label="削除"
+                                                        >
+                                                            <FontAwesomeIcon
+                                                                icon={faTrash}
+                                                            />
+                                                        </button>
+                                                    </div>
+                                                </div>
+
+                                                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-base-content/60">
+                                                    <span>
+                                                        期限:{" "}
+                                                        {formatDate(task.dueDate)}
+                                                    </span>
+                                                    {task.assignees.map(
+                                                        (assignee) => (
+                                                            <span
+                                                                key={
+                                                                    assignee.studentNumber
+                                                                }
+                                                                className="badge badge-outline badge-sm"
+                                                            >
+                                                                {
+                                                                    assignee.displayName
+                                                                }
+                                                            </span>
+                                                        )
+                                                    )}
+                                                </div>
+
+                                                <div className="mt-3 grid grid-cols-3 gap-1">
+                                                    {statusOrder.map((status) => (
+                                                        <button
+                                                            key={status}
+                                                            type="button"
+                                                            className={`btn btn-xs ${
+                                                                task.status ===
+                                                                status
+                                                                    ? "btn-primary"
+                                                                    : "btn-ghost"
+                                                            }`}
+                                                            onClick={() =>
+                                                                void updateTaskStatus(
+                                                                    task,
+                                                                    status
+                                                                )
+                                                            }
+                                                        >
+                                                            {
+                                                                TASK_STATUS_LABELS[
+                                                                    status
+                                                                ]
+                                                            }
+                                                        </button>
+                                                    ))}
+                                                </div>
+                                            </article>
+                                        ))}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/app/(authenticated)/tasks/loading.tsx
+++ b/app/(authenticated)/tasks/loading.tsx
@@ -1,0 +1,34 @@
+export default function TasksLoading() {
+    return (
+        <div className="p-4 lg:p-6 w-full">
+            <div className="max-w-7xl mx-auto space-y-6">
+                <div className="flex items-center gap-3">
+                    <div className="h-6 w-6 bg-base-300 rounded animate-pulse" />
+                    <div className="h-8 w-32 bg-base-300 rounded-lg animate-pulse" />
+                </div>
+                <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(320px,420px)_1fr]">
+                    <div className="card bg-base-100 shadow-xl border border-base-300">
+                        <div className="card-body space-y-4">
+                            <div className="skeleton h-6 w-32" />
+                            <div className="skeleton h-12 w-full" />
+                            <div className="skeleton h-24 w-full" />
+                            <div className="skeleton h-12 w-full" />
+                            <div className="skeleton h-10 w-28" />
+                        </div>
+                    </div>
+                    <div className="card bg-base-100 shadow-xl border border-base-300">
+                        <div className="card-body space-y-4">
+                            <div className="skeleton h-6 w-36" />
+                            {[...Array(4)].map((_, index) => (
+                                <div
+                                    key={index}
+                                    className="skeleton h-24 w-full"
+                                />
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/(authenticated)/tasks/page.tsx
+++ b/app/(authenticated)/tasks/page.tsx
@@ -1,0 +1,25 @@
+import { faListCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import TasksClient from "./TasksClient";
+
+export default function TasksPage() {
+    return (
+        <div className="p-4 lg:p-6 w-full">
+            <div className="max-w-7xl mx-auto space-y-6">
+                <div className="flex items-center gap-3">
+                    <FontAwesomeIcon
+                        icon={faListCheck}
+                        className="text-2xl text-primary"
+                    />
+                    <h1
+                        className="font-bold"
+                        style={{ fontSize: "clamp(1.25rem, 3vw, 1.5rem)" }}
+                    >
+                        タスク管理
+                    </h1>
+                </div>
+                <TasksClient />
+            </div>
+        </div>
+    );
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,169 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { auth } from "@/src/auth";
+import { CACHE_TAGS } from "@/src/shared/lib/cache-policy";
+import { getBackendApiHeaders, getBackendApiUrl } from "@/src/shared/lib/server-env";
+import { validateWriteRequest } from "@/src/shared/lib/csrf";
+import {
+    formatValidationErrors,
+    taskDeleteSchema,
+    taskUpsertSchema,
+} from "@/src/shared/lib/validation";
+
+const BACKEND_API_URL = getBackendApiUrl();
+
+const extractStudentId = (email: string | null | undefined): string => {
+    if (!email) return "";
+    return email.split("@")[0].substring(0, 7).toLowerCase();
+};
+
+const requireAuth = async () => {
+    const session = await auth();
+    if (!session?.user) {
+        return {
+            session: null,
+            response: NextResponse.json(
+                { success: false, error: "Unauthorized" },
+                { status: 401 }
+            ),
+        };
+    }
+
+    return { session, response: null };
+};
+
+const getBackendUrl = (path: string) => {
+    if (!BACKEND_API_URL) return null;
+    const url = new URL(BACKEND_API_URL);
+    url.searchParams.append("path", path);
+    return url;
+};
+
+export async function GET() {
+    const { response } = await requireAuth();
+    if (response) return response;
+
+    const url = getBackendUrl("tasks");
+    if (!url) {
+        return NextResponse.json(
+            { success: false, error: "Backend API URL is not configured" },
+            { status: 500 }
+        );
+    }
+
+    const backendResponse = await fetch(url.toString(), {
+        method: "GET",
+        cache: "no-store",
+        headers: getBackendApiHeaders(),
+    });
+
+    return NextResponse.json(await backendResponse.json(), {
+        status: backendResponse.ok ? 200 : backendResponse.status,
+    });
+}
+
+export async function POST(request: NextRequest) {
+    const writeRequestError = validateWriteRequest(request);
+    if (writeRequestError) return writeRequestError;
+
+    const { session, response } = await requireAuth();
+    if (response) return response;
+
+    const url = getBackendUrl("tasks");
+    if (!url) {
+        return NextResponse.json(
+            { success: false, error: "Backend API URL is not configured" },
+            { status: 500 }
+        );
+    }
+
+    const body = await request.json();
+    const validation = taskUpsertSchema.safeParse(body);
+    if (!validation.success) {
+        return NextResponse.json(
+            {
+                success: false,
+                error: "バリデーションエラー",
+                details: formatValidationErrors(validation.error),
+            },
+            { status: 400 }
+        );
+    }
+
+    const actor =
+        session?.studentId ||
+        extractStudentId(session?.user?.email) ||
+        session?.displayName ||
+        session?.memberName ||
+        "unknown";
+
+    const backendResponse = await fetch(url.toString(), {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            ...getBackendApiHeaders(),
+        },
+        body: JSON.stringify({
+            ...validation.data,
+            dueDate: validation.data.dueDate || undefined,
+            createdBy: actor,
+            updatedBy: actor,
+        }),
+    });
+
+    const data = await backendResponse.json();
+    if (data?.success === true) {
+        revalidateTag(CACHE_TAGS.tasks, "max");
+    }
+
+    return NextResponse.json(data, {
+        status: backendResponse.ok ? 200 : backendResponse.status,
+    });
+}
+
+export async function DELETE(request: NextRequest) {
+    const writeRequestError = validateWriteRequest(request);
+    if (writeRequestError) return writeRequestError;
+
+    const { response } = await requireAuth();
+    if (response) return response;
+
+    const url = getBackendUrl("tasks/delete");
+    if (!url) {
+        return NextResponse.json(
+            { success: false, error: "Backend API URL is not configured" },
+            { status: 500 }
+        );
+    }
+
+    const body = await request.json();
+    const validation = taskDeleteSchema.safeParse(body);
+    if (!validation.success) {
+        return NextResponse.json(
+            {
+                success: false,
+                error: "バリデーションエラー",
+                details: formatValidationErrors(validation.error),
+            },
+            { status: 400 }
+        );
+    }
+
+    const backendResponse = await fetch(url.toString(), {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            ...getBackendApiHeaders(),
+        },
+        body: JSON.stringify(validation.data),
+    });
+
+    const data = await backendResponse.json();
+    if (data?.success === true) {
+        revalidateTag(CACHE_TAGS.tasks, "max");
+    }
+
+    return NextResponse.json(data, {
+        status: backendResponse.ok ? 200 : backendResponse.status,
+    });
+}

--- a/cloudflare/nb-portal-api/migrations/0005_tasks.sql
+++ b/cloudflare/nb-portal-api/migrations/0005_tasks.sql
@@ -1,0 +1,22 @@
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'TODO' CHECK (status IN ('TODO', 'IN_PROGRESS', 'DONE')),
+  due_date TEXT,
+  created_by TEXT,
+  updated_by TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE task_assignees (
+  task_id TEXT NOT NULL,
+  student_number TEXT NOT NULL,
+  assigned_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (task_id, student_number)
+);
+
+CREATE INDEX idx_tasks_status ON tasks(status);
+CREATE INDEX idx_tasks_due_date ON tasks(due_date);
+CREATE INDEX idx_task_assignees_student_number ON task_assignees(student_number);

--- a/cloudflare/nb-portal-api/package-lock.json
+++ b/cloudflare/nb-portal-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nb-portal-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nb-portal-api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.4",
         "@types/node": "^25.9.3",

--- a/cloudflare/nb-portal-api/package.json
+++ b/cloudflare/nb-portal-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nb-portal-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -110,6 +110,27 @@ type NotificationRow = {
 	updated_by_name: string | null;
 };
 
+type TaskStatus = "TODO" | "IN_PROGRESS" | "DONE";
+
+type TaskRow = {
+	id: string;
+	title: string;
+	description: string | null;
+	status: TaskStatus;
+	due_date: string | null;
+	created_by: string | null;
+	updated_by: string | null;
+	created_at: string;
+	updated_at: string;
+};
+
+type TaskAssigneeRow = {
+	task_id: string;
+	student_number: string;
+	name: string | null;
+	nickname: string | null;
+};
+
 const memberHeaders = [
 	"StudentNumber",
 	"Name",
@@ -256,6 +277,30 @@ const toAbsenceResponse = (row: AbsenceRow) => ({
 	TimeLeavingEarly: row.time_leaving_early || "",
 	TimeStepOut: row.time_step_out || "",
 	TimeReturn: row.time_return || "",
+});
+
+const toTaskResponse = (row: TaskRow, assignees: TaskAssigneeRow[]) => ({
+	id: row.id,
+	title: row.title,
+	description: row.description || "",
+	status: row.status,
+	dueDate: row.due_date,
+	createdBy: row.created_by,
+	updatedBy: row.updated_by,
+	createdAt: row.created_at,
+	updatedAt: row.updated_at,
+	assignees: assignees
+		.filter((assignee) => assignee.task_id === row.id)
+		.map((assignee) => {
+			const nickname = assignee.nickname || "";
+			const name = assignee.name || assignee.student_number;
+			return {
+				studentNumber: assignee.student_number,
+				name,
+				nickname: nickname || null,
+				displayName: nickname && nickname !== "---" ? nickname : name,
+			};
+		}),
 });
 
 const getBody = async (request: Request) => {
@@ -812,6 +857,117 @@ const getNotifications = async (url: URL, env: Env) => {
 	return ok(notifications.slice(0, limit), { count: notifications.length });
 };
 
+const getTasks = async (env: Env) => {
+	const [tasks, assignees] = await Promise.all([
+		env.DB.prepare(
+			`SELECT id, title, description, status, due_date, created_by, updated_by, created_at, updated_at
+			FROM tasks
+			ORDER BY
+				CASE status WHEN 'TODO' THEN 1 WHEN 'IN_PROGRESS' THEN 2 ELSE 3 END,
+				COALESCE(due_date, '9999-12-31'),
+				created_at DESC`
+		).all<TaskRow>(),
+		env.DB.prepare(
+			`SELECT ta.task_id, ta.student_number, m.name, m.nickname
+			FROM task_assignees ta
+			LEFT JOIN members m ON lower(m.student_number) = lower(ta.student_number)
+			ORDER BY ta.assigned_at`
+		).all<TaskAssigneeRow>(),
+	]);
+
+	const assigneeRows = assignees.results || [];
+	return ok((tasks.results || []).map((task) => toTaskResponse(task, assigneeRows)), {
+		count: tasks.results?.length || 0,
+	});
+};
+
+const normalizeTaskStatus = (value: unknown): TaskStatus => {
+	const normalized = String(value ?? "TODO").trim().toUpperCase();
+	if (normalized === "IN_PROGRESS" || normalized === "DONE") return normalized;
+	return "TODO";
+};
+
+const replaceTaskAssignees = async (
+	env: Env,
+	taskId: string,
+	assigneeStudentNumbers: unknown
+) => {
+	const uniqueStudentNumbers = Array.from(
+		new Set(
+			(Array.isArray(assigneeStudentNumbers) ? assigneeStudentNumbers : [])
+				.map((value) => normalizeStudentId(value))
+				.filter(Boolean)
+		)
+	);
+
+	const statements = [
+		env.DB.prepare("DELETE FROM task_assignees WHERE task_id = ?").bind(taskId),
+		...uniqueStudentNumbers.map((studentNumber) =>
+			env.DB.prepare(
+				`INSERT INTO task_assignees (task_id, student_number, assigned_at)
+				VALUES (?, ?, CURRENT_TIMESTAMP)`
+			)
+				.bind(taskId, studentNumber)
+		),
+	];
+
+	await env.DB.batch(statements);
+};
+
+const upsertTask = async (request: Request, env: Env) => {
+	const body = await getBody(request);
+	const taskId =
+		String(body.id ?? "").trim() ||
+		`TASK-${Date.now().toString(36).toUpperCase()}`;
+	const title = String(body.title ?? "").trim();
+	if (!title) return error("Task title is required", 400);
+
+	const dueDate = String(body.dueDate ?? "").trim() || null;
+	const actor = String(body.updatedBy ?? body.createdBy ?? "").trim();
+
+	await env.DB.prepare(
+		`INSERT INTO tasks (
+			id, title, description, status, due_date, created_by, updated_by, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			title = excluded.title,
+			description = excluded.description,
+			status = excluded.status,
+			due_date = excluded.due_date,
+			updated_by = excluded.updated_by,
+			updated_at = CURRENT_TIMESTAMP`
+	)
+		.bind(
+			taskId,
+			title,
+			String(body.description ?? "").trim(),
+			normalizeTaskStatus(body.status),
+			dueDate,
+			actor,
+			actor
+		)
+		.run();
+
+	await replaceTaskAssignees(env, taskId, body.assigneeStudentNumbers);
+
+	const tasks = await getTasks(env);
+	return tasks;
+};
+
+const deleteTask = async (request: Request, env: Env) => {
+	const body = await getBody(request);
+	const taskId = String(body.id ?? "").trim();
+	if (!taskId) return error("Task id is required", 400);
+
+	await env.DB.batch([
+		env.DB.prepare("DELETE FROM task_assignees WHERE task_id = ?").bind(taskId),
+		env.DB.prepare("DELETE FROM tasks WHERE id = ?").bind(taskId),
+	]);
+
+	return ok(null, { message: "Task deleted" });
+};
+
 const savePushSubscription = async (request: Request, env: Env) => {
 	const body = await getBody(request);
 	const subscription = body.subscription as
@@ -1321,6 +1477,8 @@ const routeGet = (url: URL, env: Env) => {
 			return getDashboardData(env);
 		case "notifications":
 			return getNotifications(url, env);
+		case "tasks":
+			return getTasks(env);
 		case "push-subscriptions":
 			return getPushSubscriptions(env);
 		case "items":
@@ -1353,6 +1511,11 @@ const routePost = (request: Request, url: URL, env: Env) => {
 			return deleteAbsence(request, env);
 		case "next-meeting":
 			return updateNextMeeting(request, env);
+		case "tasks":
+		case "tasks/update":
+			return upsertTask(request, env);
+		case "tasks/delete":
+			return deleteTask(request, env);
 		case "push-subscribe":
 			return savePushSubscription(request, env);
 		case "push-unsubscribe":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",

--- a/src/shared/lib/cache-policy.ts
+++ b/src/shared/lib/cache-policy.ts
@@ -5,6 +5,7 @@ export const CACHE_TAGS = {
     absences: "absences",
     notifications: "notifications",
     nextMeeting: "next-meeting",
+    tasks: "tasks",
 } as const;
 
 export const CACHE_SECONDS = {
@@ -23,5 +24,6 @@ export const CLIENT_CACHE_KEYS = {
     items: "nb-portal-items-cache",
     members: "nb-portal-members-cache-v2",
     notifications: "nb-portal-notifications-cache",
+    tasks: "nb-portal-tasks-cache",
     meetingMemoDraft: "nb-portal-meeting-memo-draft",
 } as const;

--- a/src/shared/lib/validation.ts
+++ b/src/shared/lib/validation.ts
@@ -73,6 +73,7 @@ export const backendApiPathSchema = z.enum([
     "absences",
     "event-absences",
     "next-meeting",
+    "tasks",
     "dashboard-data",
     "health",
     "notifications",
@@ -183,6 +184,41 @@ export const nextMeetingUpdateSchema = z.object({
 });
 
 export type NextMeetingUpdateData = z.infer<typeof nextMeetingUpdateSchema>;
+
+export const taskStatusSchema = z.enum(["TODO", "IN_PROGRESS", "DONE"], {
+    error: "ステータスが不正です",
+});
+
+export const taskUpsertSchema = z.object({
+    id: z.string().max(100).optional(),
+    title: z.string().min(1, "タイトルは必須です").max(100, "タイトルが長すぎます"),
+    description: z.string().max(1000, "説明が長すぎます").optional().default(""),
+    status: taskStatusSchema.optional().default("TODO"),
+    dueDate: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/, "期限はYYYY-MM-DD形式です")
+        .optional()
+        .or(z.literal("")),
+    assigneeStudentNumbers: z
+        .array(
+            z
+                .string()
+                .min(1, "担当者の学籍番号が空です")
+                .max(20, "担当者の学籍番号が長すぎます")
+                .regex(/^[A-Za-z0-9-]+$/, "担当者の学籍番号形式が不正です")
+        )
+        .max(30, "担当者が多すぎます")
+        .optional()
+        .default([]),
+});
+
+export type TaskUpsertData = z.infer<typeof taskUpsertSchema>;
+
+export const taskDeleteSchema = z.object({
+    id: z.string().min(1, "タスクIDは必須です").max(100, "タスクIDが長すぎます"),
+});
+
+export type TaskDeleteData = z.infer<typeof taskDeleteSchema>;
 
 /**
  * バリデーションエラーを整形して返す

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -105,6 +105,36 @@ export interface DashboardData {
     nextMeeting: NextMeetingSettings | null;
 }
 
+export const TASK_STATUSES = ["TODO", "IN_PROGRESS", "DONE"] as const;
+
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+    TODO: "未着手",
+    IN_PROGRESS: "進行中",
+    DONE: "完了",
+};
+
+export interface TaskAssignee {
+    studentNumber: string;
+    name: string;
+    nickname?: string | null;
+    displayName: string;
+}
+
+export interface Task {
+    id: string;
+    title: string;
+    description: string;
+    status: TaskStatus;
+    dueDate?: string | null;
+    createdBy?: string | null;
+    updatedBy?: string | null;
+    createdAt: string;
+    updatedAt: string;
+    assignees: TaskAssignee[];
+}
+
 // Items型（スプレッドシートのヘッダーに応じて調整してください）
 export interface Item {
     [key: string]: string | number | boolean | Date;

--- a/src/widgets/sidebar/ui/SidebarNav.tsx
+++ b/src/widgets/sidebar/ui/SidebarNav.tsx
@@ -8,6 +8,7 @@ import {
     faCalendarDays,
     faFileLines,
     faHouse,
+    faListCheck,
     faMicrophone,
     faNoteSticky,
     faUsers,
@@ -16,6 +17,7 @@ import {
 const navItems = [
     { href: "/home", label: "ホーム", icon: faHouse },
     { href: "/calendar", label: "カレンダー", icon: faCalendarDays },
+    { href: "/tasks", label: "タスク", icon: faListCheck },
     { href: "/items", label: "機材一覧", icon: faMicrophone },
     { href: "/members", label: "名簿", icon: faUsers },
     { href: "/notifications", label: "お知らせ", icon: faBell },


### PR DESCRIPTION
## 概要
- タスク管理ページを追加
- タスクの作成・編集・削除・進捗変更に対応
- 部員をタスク担当者としてアサインできるように変更
- D1 に tasks / task_assignees テーブルを追加
- Worker に tasks API を追加

## 確認
- npm run build
- cloudflare/nb-portal-api で npm test
- production D1 migration 適用済み
- production Worker deploy 済み
- production tasks API の作成・削除スモーク確認済み