### PR TITLE
部会と欠席者通知の送信条件を修正

### DIFF
--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -1161,15 +1161,28 @@ const buildNextMeetingReminderEmbed = (
 	};
 };
 
-const getNextMeetingRow = (env: Env) =>
+const getTodayNextMeetingRow = (
+	env: Env,
+	today: string,
+	mode: "IN_PERSON" | "DISCORD"
+) =>
 	env.DB.prepare(
-		`SELECT event_id, date, time, mode, updated_by, updated_at
-		FROM next_meeting_settings WHERE id = 1`
-	).first<NextMeetingRow>();
+		`SELECT n.event_id, n.date, n.time, n.mode, n.updated_by, n.updated_at
+		FROM next_meeting_settings n
+		INNER JOIN schedules s ON s.id = n.event_id
+		WHERE n.id = 1
+			AND n.date = ?
+			AND n.mode = ?
+			AND s.date = ?
+			AND s.title = '部会'
+		LIMIT 1`
+	)
+		.bind(today, mode, today)
+		.first<NextMeetingRow>();
 
-const hasFutureSchedule = async (env: Env, today: string) => {
+const hasFutureMeetingSchedule = async (env: Env, today: string) => {
 	const row = await env.DB.prepare(
-		"SELECT id FROM schedules WHERE date > ? ORDER BY date LIMIT 1"
+		"SELECT id FROM schedules WHERE date > ? AND title = '部会' ORDER BY date LIMIT 1"
 	)
 		.bind(today)
 		.first<{ id: string }>();
@@ -1202,8 +1215,8 @@ const sendNextMeetingInPersonReminder = async (
 	}
 ) => {
 	const today = getJstDateParts().date;
-	const settings = await getNextMeetingRow(env);
-	if (!settings || settings.date !== today || settings.mode !== "IN_PERSON") {
+	const settings = await getTodayNextMeetingRow(env, today, "IN_PERSON");
+	if (!settings) {
 		return;
 	}
 
@@ -1218,15 +1231,15 @@ const sendNextMeetingInPersonReminder = async (
 		],
 	});
 
-	if (checkFutureSchedule && !(await hasFutureSchedule(env, today))) {
+	if (checkFutureSchedule && !(await hasFutureMeetingSchedule(env, today))) {
 		await sendNextMeetingUnsetReminder(env);
 	}
 };
 
 const sendNextMeetingEveningReminder = async (env: RuntimeEnv) => {
 	const today = getJstDateParts().date;
-	const settings = await getNextMeetingRow(env);
-	if (!settings || settings.date !== today || settings.mode !== "DISCORD") {
+	const settings = await getTodayNextMeetingRow(env, today, "DISCORD");
+	if (!settings) {
 		return;
 	}
 
@@ -1241,7 +1254,7 @@ const sendNextMeetingEveningReminder = async (env: RuntimeEnv) => {
 		],
 	});
 
-	if (!(await hasFutureSchedule(env, today))) {
+	if (!(await hasFutureMeetingSchedule(env, today))) {
 		await sendNextMeetingUnsetReminder(env);
 	}
 };
@@ -1253,6 +1266,10 @@ const sendTodayAbsences = async (env: RuntimeEnv) => {
 	)
 		.bind(date)
 		.first<{ count: number }>();
+	if ((todayScheduleCount?.count || 0) === 0) {
+		return;
+	}
+
 	const rows = await env.DB.prepare(
 		`SELECT
 			a.name,
@@ -1279,10 +1296,7 @@ const sendTodayAbsences = async (env: RuntimeEnv) => {
 			: [
 					{
 						name: "情報",
-						value:
-							(todayScheduleCount?.count || 0) === 0
-								? "本日の予定はありません"
-								: "本日の欠席者はいません",
+						value: "本日の欠席者はいません",
 						inline: false,
 					},
 				];

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -41,6 +41,18 @@ describe("Hello World worker", () => {
 				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 			)`
 		).run();
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS cron_executions (
+				id TEXT PRIMARY KEY,
+				cron TEXT NOT NULL,
+				scheduled_time TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'running',
+				started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				completed_at TEXT,
+				error TEXT,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`
+		).run();
 	});
 
 	it("responds with health status (unit style)", async () => {
@@ -109,5 +121,53 @@ describe("Hello World worker", () => {
 			TIME_MM: "0",
 			WHERE: "Discord",
 		});
+	});
+
+	it("skips scheduled Discord sends when there is no event today", async () => {
+		const ctx = createExecutionContext();
+		await worker.scheduled(
+			{
+				cron: "50 23 * * *",
+				scheduledTime: Date.now(),
+				noRetry: () => {},
+			} as ScheduledController,
+			env,
+			ctx
+		);
+		await waitOnExecutionContext(ctx);
+	});
+
+	it("skips meeting reminder when next meeting settings have no schedule row", async () => {
+		const today = new Intl.DateTimeFormat("en-CA", {
+			timeZone: "Asia/Tokyo",
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+		}).format(new Date());
+		await env.DB.prepare(
+			`INSERT INTO next_meeting_settings (id, event_id, date, time, mode, updated_by, updated_at)
+			VALUES (1, 'missing-event', ?, '18:00', 'DISCORD', 'test', CURRENT_TIMESTAMP)
+			ON CONFLICT(id) DO UPDATE SET
+				event_id = excluded.event_id,
+				date = excluded.date,
+				time = excluded.time,
+				mode = excluded.mode,
+				updated_by = excluded.updated_by,
+				updated_at = CURRENT_TIMESTAMP`
+		)
+			.bind(today)
+			.run();
+
+		const ctx = createExecutionContext();
+		await worker.scheduled(
+			{
+				cron: "0 9 * * *",
+				scheduledTime: Date.now(),
+				noRetry: () => {},
+			} as ScheduledController,
+			env,
+			ctx
+		);
+		await waitOnExecutionContext(ctx);
 	});
 });


### PR DESCRIPTION
## 概要
- 部会リマインドは next_meeting_settings だけでなく、当日の schedules に実在する「部会」行がある場合だけ送信するように変更
- 次回部会未設定リマインドの判定対象を未来の「部会」予定に限定
- 欠席者一覧通知は本日の予定がない場合は Discord に送信しないように変更
- scheduled handler のスキップ条件をテスト追加

## 調査結果
- 部会通知は next_meeting_settings が当日を指していると、対応する schedule がなくても送信される余地がありました
- 欠席者一覧通知は本日の予定が 0 件でも「本日の予定はありません」を Discord に送る実装でした

## 確認
- cloudflare/nb-portal-api で npm test
- npm run build