### PR TITLE
スケジュール変更時のプッシュ通知を復旧

### DIFF
--- a/app/api/next-meeting/route.ts
+++ b/app/api/next-meeting/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/src/shared/lib/validation";
 import { getBackendApiHeaders, getBackendApiUrl } from "@/src/shared/lib/server-env";
 import { validateWriteRequest } from "@/src/shared/lib/csrf";
+import { sendPushNotification } from "@/src/shared/lib/push-notification-server";
 
 const BACKEND_API_URL = getBackendApiUrl();
 
@@ -15,6 +16,11 @@ const extractStudentId = (email: string | null | undefined): string => {
     if (!email) return "";
     const localPart = email.split("@")[0];
     return localPart.substring(0, 7).toLowerCase();
+};
+
+const formatNextMeetingPushBody = (date: string, time: string, mode: string) => {
+    const place = mode === "DISCORD" ? "Discord" : "対面";
+    return `${date.replaceAll("-", "/")} ${time} ${place}`;
 };
 
 export async function POST(request: NextRequest) {
@@ -98,6 +104,16 @@ export async function POST(request: NextRequest) {
             revalidateTag(CACHE_TAGS.nextMeeting, "max");
             revalidateTag(CACHE_TAGS.schedules, "max");
             revalidateTag(CACHE_TAGS.notifications, "max");
+            await sendPushNotification(request.nextUrl.origin, {
+                title: "次回部会が登録されました",
+                body: formatNextMeetingPushBody(
+                    validation.data.date,
+                    validation.data.time,
+                    validation.data.mode
+                ),
+                url: "/home",
+                tag: "nb-portal-next-meeting",
+            });
         }
 
         return NextResponse.json(data);

--- a/app/api/next-meeting/route.ts
+++ b/app/api/next-meeting/route.ts
@@ -23,6 +23,27 @@ const formatNextMeetingPushBody = (date: string, time: string, mode: string) => 
     return `${date.replaceAll("-", "/")} ${time} ${place}`;
 };
 
+const fetchCurrentNextMeeting = async (): Promise<Record<string, unknown> | null> => {
+    if (!BACKEND_API_URL) return null;
+
+    try {
+        const url = new URL(BACKEND_API_URL);
+        url.searchParams.append("path", "next-meeting");
+        const response = await fetch(url.toString(), {
+            headers: getBackendApiHeaders(),
+            cache: "no-store",
+        });
+        const data = (await response.json()) as {
+            success?: boolean;
+            data?: Record<string, unknown> | null;
+        };
+        return data.success ? data.data || null : null;
+    } catch (error) {
+        console.error("Failed to fetch current next meeting:", error);
+        return null;
+    }
+};
+
 export async function POST(request: NextRequest) {
     const writeRequestError = validateWriteRequest(request);
     if (writeRequestError) return writeRequestError;
@@ -70,6 +91,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
+        const currentMeeting = await fetchCurrentNextMeeting();
         const updatedBy =
             session.studentId ||
             extractStudentId(session.user.email) ||
@@ -104,15 +126,16 @@ export async function POST(request: NextRequest) {
             revalidateTag(CACHE_TAGS.nextMeeting, "max");
             revalidateTag(CACHE_TAGS.schedules, "max");
             revalidateTag(CACHE_TAGS.notifications, "max");
+            const actionLabel = currentMeeting ? "更新" : "登録";
             await sendPushNotification(request.nextUrl.origin, {
-                title: "次回部会が登録されました",
+                title: `次回部会が${actionLabel}されました`,
                 body: formatNextMeetingPushBody(
                     validation.data.date,
                     validation.data.time,
                     validation.data.mode
                 ),
                 url: "/home",
-                tag: "nb-portal-next-meeting",
+                tag: `nb-portal-next-meeting-${actionLabel}`,
             });
         }
 

--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -16,25 +16,83 @@ const extractStudentId = (email: string | null | undefined): string => {
 };
 
 const formatScheduleDate = (data: Record<string, unknown>) => {
-    const year = String(data.year ?? "");
-    const month = String(data.month ?? "");
-    const date = String(data.date ?? "");
+    const year = String(data.year ?? data.YYYY ?? "");
+    const month = String(data.month ?? data.MM ?? "");
+    const date = String(data.date ?? data.DD ?? "");
     if (!year || !month || !date) return "";
     return `${year}/${month}/${date}`;
 };
 
 const formatScheduleTime = (data: Record<string, unknown>) => {
-    const hour = String(data.timeHH ?? "");
-    const minute = String(data.timeMM ?? "");
+    const hour = String(data.timeHH ?? data.TIME_HH ?? "");
+    const minute = String(data.timeMM ?? data.TIME_MM ?? "");
     if (!hour) return "";
     return `${hour.padStart(2, "0")}:${(minute || "0").padStart(2, "0")}`;
 };
 
+const getScheduleTitle = (data: Record<string, unknown>) =>
+    String(data.title ?? data.TITLE ?? "予定");
+
+const getScheduleKindLabel = (data: Record<string, unknown>) =>
+    getScheduleTitle(data) === "部会" ? "部会" : "予定";
+
+const getScheduleEventId = (data: Record<string, unknown>) =>
+    String(data.eventId ?? data.EVENT_ID ?? "");
+
 const buildSchedulePushBody = (data: Record<string, unknown>) => {
     const date = formatScheduleDate(data);
     const time = formatScheduleTime(data);
-    const place = String(data.where ?? "");
+    const place = String(data.where ?? data.WHERE ?? "");
     return [date, time, place].filter(Boolean).join(" ");
+};
+
+const fetchScheduleForNotification = async (
+    eventId: string
+): Promise<Record<string, unknown> | null> => {
+    if (!BACKEND_API_URL || !eventId) return null;
+
+    try {
+        const url = new URL(BACKEND_API_URL);
+        url.searchParams.append("path", "schedules");
+        const response = await fetch(url.toString(), {
+            headers: getBackendApiHeaders(),
+            cache: "no-store",
+        });
+        const data = (await response.json()) as {
+            success?: boolean;
+            data?: Array<Record<string, unknown>>;
+        };
+        if (!data.success || !Array.isArray(data.data)) return null;
+        return (
+            data.data.find((schedule) => getScheduleEventId(schedule) === eventId) ||
+            null
+        );
+    } catch (error) {
+        console.error("Failed to fetch schedule for push notification:", error);
+        return null;
+    }
+};
+
+const sendSchedulePushNotification = async (
+    origin: string,
+    action: "created" | "updated" | "deleted",
+    scheduleData: Record<string, unknown>
+) => {
+    const actionLabel = {
+        created: "追加",
+        updated: "更新",
+        deleted: "削除",
+    }[action];
+    const eventId = getScheduleEventId(scheduleData);
+
+    await sendPushNotification(origin, {
+        title: `${getScheduleKindLabel(scheduleData)}が${actionLabel}されました: ${getScheduleTitle(scheduleData)}`,
+        body: buildSchedulePushBody(scheduleData),
+        url: "/calendar",
+        tag: eventId
+            ? `nb-portal-schedule-${action}-${eventId}`
+            : `nb-portal-schedule-${action}`,
+    });
 };
 
 // スケジュール新規作成
@@ -90,12 +148,11 @@ export async function POST(request: NextRequest) {
             revalidateTag(CACHE_TAGS.nextMeeting, "max");
             revalidateTag(CACHE_TAGS.notifications, "max");
             const scheduleData = data.data || body;
-            await sendPushNotification(request.nextUrl.origin, {
-                title: `予定が追加されました: ${String(scheduleData.title ?? "予定")}`,
-                body: buildSchedulePushBody(scheduleData),
-                url: "/calendar",
-                tag: "nb-portal-schedule-created",
-            });
+            await sendSchedulePushNotification(
+                request.nextUrl.origin,
+                "created",
+                scheduleData
+            );
         }
 
         return NextResponse.json(data);
@@ -133,6 +190,8 @@ export async function DELETE(request: NextRequest) {
 
     try {
         const body = (await request.json()) as Record<string, unknown>;
+        const eventId = getScheduleEventId(body);
+        const scheduleBeforeDelete = await fetchScheduleForNotification(eventId);
 
         // Backend APIに転送
         const url = new URL(BACKEND_API_URL);
@@ -156,6 +215,11 @@ export async function DELETE(request: NextRequest) {
             revalidateTag(CACHE_TAGS.schedules, "max");
             revalidateTag(CACHE_TAGS.nextMeeting, "max");
             revalidateTag(CACHE_TAGS.notifications, "max");
+            await sendSchedulePushNotification(
+                request.nextUrl.origin,
+                "deleted",
+                scheduleBeforeDelete || body
+            );
         }
 
         return NextResponse.json(data);
@@ -215,6 +279,7 @@ export async function PUT(request: NextRequest) {
 
         const data = (await response.json()) as {
             success?: boolean;
+            data?: Record<string, unknown>;
             error?: string;
         };
 
@@ -222,6 +287,11 @@ export async function PUT(request: NextRequest) {
             revalidateTag(CACHE_TAGS.schedules, "max");
             revalidateTag(CACHE_TAGS.nextMeeting, "max");
             revalidateTag(CACHE_TAGS.notifications, "max");
+            await sendSchedulePushNotification(
+                request.nextUrl.origin,
+                "updated",
+                data.data || body
+            );
         }
 
         return NextResponse.json(data);

--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/src/auth";
 import { CACHE_TAGS } from "@/src/shared/lib/cache-policy";
 import { getBackendApiHeaders, getBackendApiUrl } from "@/src/shared/lib/server-env";
 import { validateWriteRequest } from "@/src/shared/lib/csrf";
+import { sendPushNotification } from "@/src/shared/lib/push-notification-server";
 
 const BACKEND_API_URL = getBackendApiUrl();
 
@@ -12,6 +13,28 @@ const extractStudentId = (email: string | null | undefined): string => {
     if (!email) return "";
     const localPart = email.split("@")[0];
     return localPart.substring(0, 7).toLowerCase();
+};
+
+const formatScheduleDate = (data: Record<string, unknown>) => {
+    const year = String(data.year ?? "");
+    const month = String(data.month ?? "");
+    const date = String(data.date ?? "");
+    if (!year || !month || !date) return "";
+    return `${year}/${month}/${date}`;
+};
+
+const formatScheduleTime = (data: Record<string, unknown>) => {
+    const hour = String(data.timeHH ?? "");
+    const minute = String(data.timeMM ?? "");
+    if (!hour) return "";
+    return `${hour.padStart(2, "0")}:${(minute || "0").padStart(2, "0")}`;
+};
+
+const buildSchedulePushBody = (data: Record<string, unknown>) => {
+    const date = formatScheduleDate(data);
+    const time = formatScheduleTime(data);
+    const place = String(data.where ?? "");
+    return [date, time, place].filter(Boolean).join(" ");
 };
 
 // スケジュール新規作成
@@ -58,6 +81,7 @@ export async function POST(request: NextRequest) {
 
         const data = (await response.json()) as {
             success?: boolean;
+            data?: Record<string, unknown>;
             error?: string;
         };
 
@@ -65,6 +89,13 @@ export async function POST(request: NextRequest) {
             revalidateTag(CACHE_TAGS.schedules, "max");
             revalidateTag(CACHE_TAGS.nextMeeting, "max");
             revalidateTag(CACHE_TAGS.notifications, "max");
+            const scheduleData = data.data || body;
+            await sendPushNotification(request.nextUrl.origin, {
+                title: `予定が追加されました: ${String(scheduleData.title ?? "予定")}`,
+                body: buildSchedulePushBody(scheduleData),
+                url: "/calendar",
+                tag: "nb-portal-schedule-created",
+            });
         }
 
         return NextResponse.json(data);

--- a/src/shared/lib/push-notification-server.ts
+++ b/src/shared/lib/push-notification-server.ts
@@ -1,0 +1,46 @@
+type PushNotificationPayload = {
+    title: string;
+    body?: string;
+    url?: string;
+    tag?: string;
+};
+
+type PushSendResult = {
+    success?: boolean;
+    sent?: number;
+    failed?: number;
+    total?: number;
+    message?: string;
+    error?: string;
+};
+
+export const sendPushNotification = async (
+    origin: string,
+    payload: PushNotificationPayload
+): Promise<PushSendResult | null> => {
+    const secret = process.env.PUSH_API_SECRET;
+    if (!secret) {
+        console.error("Push notification skipped: PUSH_API_SECRET is not configured");
+        return null;
+    }
+
+    try {
+        const response = await fetch(new URL("/api/push-send", origin), {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${secret}`,
+            },
+            body: JSON.stringify(payload),
+        });
+
+        const result = (await response.json()) as PushSendResult;
+        if (!response.ok || result.error) {
+            console.error("Push notification failed:", result);
+        }
+        return result;
+    } catch (error) {
+        console.error("Push notification request failed:", error);
+        return null;
+    }
+};


### PR DESCRIPTION
## 概要
- スケジュールの作成・更新・削除時にプッシュ通知を送信
- 次回部会の登録・更新時にプッシュ通知を送信
- 削除通知では削除前のスケジュール情報を取得して通知文に反映

## 確認
- npm run build
- cloudflare/nb-portal-api で npm test