### PR TITLE
終日イベントの終了日を保存する

### DIFF
--- a/cloudflare/nb-portal-api/migrations/0006_schedule_end_date.sql
+++ b/cloudflare/nb-portal-api/migrations/0006_schedule_end_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE schedules ADD COLUMN end_date TEXT;

--- a/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
+++ b/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
@@ -159,13 +159,14 @@ for (const schedule of readCsv(files.schedules)) {
 	const eventId = schedule.EVENT_ID;
 	if (!eventId) continue;
 
-statements.push(`INSERT INTO schedules (
-  id, title, date, start_time, end_time, location, description, attendance_mode,
+	statements.push(`INSERT INTO schedules (
+  id, title, date, end_date, start_time, end_time, location, description, attendance_mode,
   is_past, created_by, created_at, updated_by, updated_at
 ) VALUES (
   ${sqlString(eventId)},
   ${sqlString(schedule.TITLE)},
   ${sqlString(buildDate(schedule.YYYY, schedule.MM, schedule.DD))},
+  ${sqlNullableString(buildDate(schedule.END_YYYY, schedule.END_MM, schedule.END_DD))},
   ${sqlNullableString(buildTime(schedule.TIME_HH, schedule.TIME_MM))},
   ${sqlNullableString(buildTime(schedule.END_TIME_HH, schedule.END_TIME_MM))},
   ${sqlNullableString(schedule.WHERE)},

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -43,6 +43,7 @@ type ScheduleRow = {
 	id: string;
 	title: string;
 	date: string;
+	end_date: string | null;
 	start_time: string | null;
 	end_time: string | null;
 	location: string | null;
@@ -220,7 +221,8 @@ const getJstDateParts = (date = new Date()) => {
 	};
 };
 
-const toScheduleIsPast = (date: string) => (date < getJstDateParts().date ? 1 : 0);
+const toScheduleIsPast = (date: string, endDate?: string | null) =>
+	(endDate || date) < getJstDateParts().date ? 1 : 0;
 
 const generatePrefixedId = (prefix: string) =>
 	`${prefix}-${crypto.randomUUID().toUpperCase()}`;
@@ -241,6 +243,7 @@ const toMemberResponse = (row: MemberRow, rowNumber: number) => ({
 
 const toScheduleResponse = (row: ScheduleRow) => {
 	const startDate = splitDate(row.date);
+	const endDate = splitDate(row.end_date);
 	const startTime = splitTime(row.start_time);
 	const endTime = splitTime(row.end_time);
 
@@ -254,9 +257,9 @@ const toScheduleResponse = (row: ScheduleRow) => {
 		TITLE: row.title,
 		WHERE: row.location || "",
 		DETAIL: row.description || "",
-		END_YYYY: "",
-		END_MM: "",
-		END_DD: "",
+		END_YYYY: endDate.year,
+		END_MM: endDate.month,
+		END_DD: endDate.day,
 		COLOR: "primary",
 		CREATED_BY: row.created_by || "",
 		CREATED_AT: row.created_at || "",
@@ -463,7 +466,7 @@ const verifyMember = async (url: URL, env: Env) => {
 
 const getSchedules = async (env: Env) => {
 	const rows = await env.DB.prepare(
-		`SELECT id, title, date, start_time, end_time, location, description,
+		`SELECT id, title, date, end_date, start_time, end_time, location, description,
 			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		FROM schedules
 		ORDER BY date, start_time, id`
@@ -480,25 +483,27 @@ const createSchedule = async (request: Request, env: Env) => {
 		String(body.eventId ?? "").trim() ||
 		generatePrefixedId("E");
 	const date = buildDate(body.year, body.month, body.date);
+	const endDate = buildDate(body.endYear, body.endMonth, body.endDate) || null;
 	if (!date) return error("Schedule date is required", 400);
 
 	await env.DB.prepare(
 		`INSERT INTO schedules (
-			id, title, date, start_time, end_time, location, description,
+			id, title, date, end_date, start_time, end_time, location, description,
 			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`
 	)
 		.bind(
 			eventId,
 			String(body.title ?? "").trim(),
 			date,
+			endDate,
 			buildTime(body.timeHH, body.timeMM),
 			buildTime(body.endTimeHH, body.endTimeMM),
 			String(body.where ?? "").trim(),
 			String(body.detail ?? "").trim(),
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
-			toScheduleIsPast(date),
+			toScheduleIsPast(date, endDate),
 			String(body.createdBy ?? "").trim(),
 			String(body.createdBy ?? "").trim()
 		)
@@ -516,6 +521,9 @@ const createSchedule = async (request: Request, env: Env) => {
 		title: String(body.title ?? ""),
 		where: String(body.where ?? ""),
 		detail: String(body.detail ?? ""),
+		endYear: String(body.endYear ?? ""),
+		endMonth: String(body.endMonth ?? ""),
+		endDate: String(body.endDate ?? ""),
 		color: String(body.color ?? "primary"),
 		attendanceMode: String(body.attendanceMode ?? "ABSENCE"),
 	});
@@ -527,23 +535,25 @@ const updateSchedule = async (request: Request, env: Env) => {
 	if (!eventId) return error("eventId is required", 400);
 
 	const date = buildDate(body.year, body.month, body.date);
+	const endDate = buildDate(body.endYear, body.endMonth, body.endDate) || null;
 	if (!date) return error("Schedule date is required", 400);
 
 	await env.DB.prepare(
 		`UPDATE schedules SET
-			title = ?, date = ?, start_time = ?, end_time = ?, location = ?,
+			title = ?, date = ?, end_date = ?, start_time = ?, end_time = ?, location = ?,
 			description = ?, attendance_mode = ?, is_past = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?`
 	)
 		.bind(
 			String(body.title ?? "").trim(),
 			date,
+			endDate,
 			buildTime(body.timeHH, body.timeMM),
 			buildTime(body.endTimeHH, body.endTimeMM),
 			String(body.where ?? "").trim(),
 			String(body.detail ?? "").trim(),
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
-			toScheduleIsPast(date),
+			toScheduleIsPast(date, endDate),
 			String(body.updatedBy ?? "").trim(),
 			eventId
 		)
@@ -711,13 +721,14 @@ const updateNextMeeting = async (request: Request, env: Env) => {
 
 	await env.DB.prepare(
 		`INSERT INTO schedules (
-			id, title, date, start_time, end_time, location, description,
+			id, title, date, end_date, start_time, end_time, location, description,
 			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		)
-		VALUES (?, '部会', ?, ?, NULL, ?, '次回部会', 'ABSENCE', ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)
+		VALUES (?, '部会', ?, NULL, ?, NULL, ?, '次回部会', 'ABSENCE', ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			title = excluded.title,
 			date = excluded.date,
+			end_date = excluded.end_date,
 			start_time = excluded.start_time,
 			end_time = excluded.end_time,
 			location = excluded.location,
@@ -1404,9 +1415,9 @@ const updateSchedulePastState = async (env: RuntimeEnv) => {
 	const today = getJstDateParts().date;
 	await env.DB.prepare(
 		`UPDATE schedules
-		SET is_past = CASE WHEN date < ? THEN 1 ELSE 0 END,
+		SET is_past = CASE WHEN COALESCE(end_date, date) < ? THEN 1 ELSE 0 END,
 			updated_at = CASE
-				WHEN is_past != CASE WHEN date < ? THEN 1 ELSE 0 END
+				WHEN is_past != CASE WHEN COALESCE(end_date, date) < ? THEN 1 ELSE 0 END
 				THEN CURRENT_TIMESTAMP
 				ELSE updated_at
 			END`

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -18,6 +18,7 @@ describe("Hello World worker", () => {
 				id TEXT PRIMARY KEY,
 				title TEXT NOT NULL,
 				date TEXT NOT NULL,
+				end_date TEXT,
 				start_time TEXT,
 				end_time TEXT,
 				location TEXT,
@@ -120,6 +121,67 @@ describe("Hello World worker", () => {
 			TIME_HH: "18",
 			TIME_MM: "0",
 			WHERE: "Discord",
+		});
+	});
+
+	it("stores and returns schedule end date", async () => {
+		const request = new IncomingRequest("http://example.com/schedules", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				year: "2099",
+				month: "2",
+				date: "10",
+				endYear: "2099",
+				endMonth: "2",
+				endDate: "12",
+				title: "合宿",
+				where: "校外",
+				detail: "終日イベント",
+				attendanceMode: "ABSENCE",
+				createdBy: "test",
+			}),
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+
+		const responseBody = (await response.json()) as {
+			success?: boolean;
+			data?: {
+				eventId?: string;
+				endYear?: string;
+				endMonth?: string;
+				endDate?: string;
+			};
+		};
+		expect(responseBody.success).toBe(true);
+		expect(responseBody.data).toMatchObject({
+			endYear: "2099",
+			endMonth: "2",
+			endDate: "12",
+		});
+
+		const schedulesResponse = await worker.fetch(
+			new IncomingRequest("http://example.com/schedules"),
+			env,
+			createExecutionContext()
+		);
+		const schedulesBody = (await schedulesResponse.json()) as {
+			success?: boolean;
+			data?: Array<Record<string, unknown>>;
+		};
+		const schedule = schedulesBody.data?.find(
+			(item) => item.EVENT_ID === responseBody.data?.eventId
+		);
+
+		expect(schedule).toMatchObject({
+			TITLE: "合宿",
+			END_YYYY: "2099",
+			END_MM: "2",
+			END_DD: "12",
+			IS_PAST: false,
 		});
 	});
 


### PR DESCRIPTION
## 概要
- D1 の schedules に end_date カラムを追加する migration を追加
- スケジュール作成・更新・一覧取得で終了日を保存/返却
- 複数日イベントの is_past 判定を終了日基準に変更
- CSV import と Worker テスト schema を end_date 対応

## 確認
- cloudflare/nb-portal-api で npm test
- npm run build