### PR TITLE
スケジュールカラーを保存する

### DIFF
--- a/cloudflare/nb-portal-api/migrations/0007_schedule_color.sql
+++ b/cloudflare/nb-portal-api/migrations/0007_schedule_color.sql
@@ -1,0 +1,1 @@
+ALTER TABLE schedules ADD COLUMN color TEXT NOT NULL DEFAULT 'primary';

--- a/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
+++ b/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
@@ -160,7 +160,7 @@ for (const schedule of readCsv(files.schedules)) {
 	if (!eventId) continue;
 
 	statements.push(`INSERT INTO schedules (
-  id, title, date, end_date, start_time, end_time, location, description, attendance_mode,
+  id, title, date, end_date, start_time, end_time, location, description, color, attendance_mode,
   is_past, created_by, created_at, updated_by, updated_at
 ) VALUES (
   ${sqlString(eventId)},
@@ -171,6 +171,7 @@ for (const schedule of readCsv(files.schedules)) {
   ${sqlNullableString(buildTime(schedule.END_TIME_HH, schedule.END_TIME_MM))},
   ${sqlNullableString(schedule.WHERE)},
   ${sqlNullableString(schedule.DETAIL)},
+  ${sqlString(schedule.COLOR || "primary")},
   ${sqlString(schedule.ATTENDANCE_MODE || "ABSENCE")},
   ${buildDate(schedule.YYYY, schedule.MM, schedule.DD) < todayJst ? "1" : "0"},
   ${sqlNullableString(schedule.CREATED_BY)},

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -48,6 +48,7 @@ type ScheduleRow = {
 	end_time: string | null;
 	location: string | null;
 	description: string | null;
+	color: string | null;
 	attendance_mode: string;
 	is_past: number;
 	created_by: string | null;
@@ -260,7 +261,7 @@ const toScheduleResponse = (row: ScheduleRow) => {
 		END_YYYY: endDate.year,
 		END_MM: endDate.month,
 		END_DD: endDate.day,
-		COLOR: "primary",
+		COLOR: row.color || "primary",
 		CREATED_BY: row.created_by || "",
 		CREATED_AT: row.created_at || "",
 		UPDATED_BY: row.updated_by || "",
@@ -467,7 +468,7 @@ const verifyMember = async (url: URL, env: Env) => {
 const getSchedules = async (env: Env) => {
 	const rows = await env.DB.prepare(
 		`SELECT id, title, date, end_date, start_time, end_time, location, description,
-			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+			color, attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		FROM schedules
 		ORDER BY date, start_time, id`
 	).all<ScheduleRow>();
@@ -489,9 +490,9 @@ const createSchedule = async (request: Request, env: Env) => {
 	await env.DB.prepare(
 		`INSERT INTO schedules (
 			id, title, date, end_date, start_time, end_time, location, description,
-			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+			color, attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`
 	)
 		.bind(
 			eventId,
@@ -502,6 +503,7 @@ const createSchedule = async (request: Request, env: Env) => {
 			buildTime(body.endTimeHH, body.endTimeMM),
 			String(body.where ?? "").trim(),
 			String(body.detail ?? "").trim(),
+			String(body.color ?? "primary").trim() || "primary",
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
 			toScheduleIsPast(date, endDate),
 			String(body.createdBy ?? "").trim(),
@@ -541,7 +543,7 @@ const updateSchedule = async (request: Request, env: Env) => {
 	await env.DB.prepare(
 		`UPDATE schedules SET
 			title = ?, date = ?, end_date = ?, start_time = ?, end_time = ?, location = ?,
-			description = ?, attendance_mode = ?, is_past = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP
+			description = ?, color = ?, attendance_mode = ?, is_past = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?`
 	)
 		.bind(
@@ -552,6 +554,7 @@ const updateSchedule = async (request: Request, env: Env) => {
 			buildTime(body.endTimeHH, body.endTimeMM),
 			String(body.where ?? "").trim(),
 			String(body.detail ?? "").trim(),
+			String(body.color ?? "primary").trim() || "primary",
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
 			toScheduleIsPast(date, endDate),
 			String(body.updatedBy ?? "").trim(),
@@ -722,9 +725,9 @@ const updateNextMeeting = async (request: Request, env: Env) => {
 	await env.DB.prepare(
 		`INSERT INTO schedules (
 			id, title, date, end_date, start_time, end_time, location, description,
-			attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+			color, attendance_mode, is_past, created_by, created_at, updated_by, updated_at
 		)
-		VALUES (?, '部会', ?, NULL, ?, NULL, ?, '次回部会', 'ABSENCE', ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)
+		VALUES (?, '部会', ?, NULL, ?, NULL, ?, '次回部会', 'primary', 'ABSENCE', ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			title = excluded.title,
 			date = excluded.date,
@@ -733,6 +736,7 @@ const updateNextMeeting = async (request: Request, env: Env) => {
 			end_time = excluded.end_time,
 			location = excluded.location,
 			description = excluded.description,
+			color = excluded.color,
 			attendance_mode = excluded.attendance_mode,
 			is_past = excluded.is_past,
 			updated_by = excluded.updated_by,

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -23,6 +23,7 @@ describe("Hello World worker", () => {
 				end_time TEXT,
 				location TEXT,
 				description TEXT,
+				color TEXT NOT NULL DEFAULT 'primary',
 				attendance_mode TEXT NOT NULL DEFAULT 'ABSENCE',
 				created_by TEXT,
 				updated_by TEXT,
@@ -138,6 +139,7 @@ describe("Hello World worker", () => {
 				title: "合宿",
 				where: "校外",
 				detail: "終日イベント",
+				color: "green",
 				attendanceMode: "ABSENCE",
 				createdBy: "test",
 			}),
@@ -178,6 +180,7 @@ describe("Hello World worker", () => {
 
 		expect(schedule).toMatchObject({
 			TITLE: "合宿",
+			COLOR: "green",
 			END_YYYY: "2099",
 			END_MM: "2",
 			END_DD: "12",


### PR DESCRIPTION
## 概要
- D1 の schedules に color カラムを追加する migration を追加
- スケジュール作成・更新・一覧取得で color を保存/返却
- 次回部会の自動生成スケジュールは primary を保存
- CSV import と Worker テスト schema を color 対応

## 確認
- cloudflare/nb-portal-api で npm test
- npm run build