### PR TITLE
モーダル状態をURLで共有可能にする

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { ScheduleCard } from "@/features/schedule-card";
+import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 import {
     normalizeScheduleAttendanceMode,
     SCHEDULE_ATTENDANCE_MODE_LABELS,
@@ -110,7 +111,27 @@ const getScheduleAttendanceMode = (
         schedule.ATTENDANCE_MODE ?? schedule.attendanceMode
     );
 
+const getScheduleEventId = (schedule: Schedule) =>
+    String(schedule.EVENT_ID ?? Object.values(schedule)[0] ?? "");
+
+const getScheduleDateStr = (schedule: Schedule) => {
+    const values = Object.values(schedule);
+    const year = String(values[1] ?? "").padStart(4, "0");
+    const month = String(values[2] ?? "").padStart(2, "0");
+    const date = String(values[3] ?? "").padStart(2, "0");
+    if (!year || !month || !date) return "";
+    return `${year}-${month}-${date}`;
+};
+
+const parseDateStr = (dateStr: string) => {
+    const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+};
+
 export default function CalendarPage() {
+    const { searchParams, updateUrlModal, clearUrlModal } = useUrlModal();
+    const urlModalQuery = searchParams.toString();
     const [schedules, setSchedules] = useState<Schedule[]>([]);
     const [absences, setAbsences] = useState<Absence[]>([]);
     const [error, setError] = useState<string | null>(null);
@@ -354,10 +375,151 @@ export default function CalendarPage() {
         }
     });
 
+    const buildSelectedDateInfo = (dateStr: string): SelectedDateInfo | null => {
+        const date = parseDateStr(dateStr);
+        if (!date) return null;
+        return {
+            date,
+            dateStr,
+            events: eventsByDate.get(dateStr) || [],
+        };
+    };
+
+    const buildEditForm = (event: Schedule): EventForm => {
+        const values = Object.values(event);
+        const rawTimeHH = values[4];
+        const rawTimeMM = values[5];
+        const rawEndTimeHH = values[18];
+        const rawEndTimeMM = values[19];
+        const rawEndYear = values[9];
+        const rawEndMonth = values[10];
+        const rawEndDate = values[11];
+        const hasTime =
+            rawTimeHH !== "" && rawTimeHH !== null && rawTimeHH !== undefined;
+        const hasEndDate =
+            rawEndYear !== "" &&
+            rawEndYear !== null &&
+            rawEndYear !== undefined;
+
+        return {
+            title: String(values[6] ?? ""),
+            where: String(values[7] ?? ""),
+            detail: String(values[8] ?? ""),
+            timeHH:
+                rawTimeHH !== "" &&
+                rawTimeHH !== null &&
+                rawTimeHH !== undefined
+                    ? String(rawTimeHH)
+                    : "",
+            timeMM:
+                rawTimeMM !== "" &&
+                rawTimeMM !== null &&
+                rawTimeMM !== undefined
+                    ? String(rawTimeMM)
+                    : "",
+            endTimeHH:
+                rawEndTimeHH !== "" &&
+                rawEndTimeHH !== null &&
+                rawEndTimeHH !== undefined
+                    ? String(rawEndTimeHH)
+                    : "",
+            endTimeMM:
+                rawEndTimeMM !== "" &&
+                rawEndTimeMM !== null &&
+                rawEndTimeMM !== undefined
+                    ? String(rawEndTimeMM)
+                    : "",
+            year: String(values[1] ?? ""),
+            month: String(values[2] ?? ""),
+            date: String(values[3] ?? ""),
+            endYear:
+                rawEndYear !== "" &&
+                rawEndYear !== null &&
+                rawEndYear !== undefined
+                    ? String(rawEndYear)
+                    : "",
+            endMonth:
+                rawEndMonth !== "" &&
+                rawEndMonth !== null &&
+                rawEndMonth !== undefined
+                    ? String(rawEndMonth)
+                    : "",
+            endDate:
+                rawEndDate !== "" &&
+                rawEndDate !== null &&
+                rawEndDate !== undefined
+                    ? String(rawEndDate)
+                    : "",
+            isAllDay: !hasTime && hasEndDate,
+            color: (values[12] as EventColorId) || "primary",
+            attendanceMode: getScheduleAttendanceMode(event),
+        };
+    };
+
+    useEffect(() => {
+        if (isLoading) return;
+
+        const params = new URLSearchParams(urlModalQuery);
+        const modal = params.get("modal");
+        const dateStr = params.get("date") || "";
+        const eventId = params.get("event") || "";
+        if (modal === "schedule-date" && dateStr) {
+            const nextSelectedDate = buildSelectedDateInfo(dateStr);
+            if (nextSelectedDate) {
+                setSelectedDate(nextSelectedDate);
+                setSelectedEvent(null);
+                setShowAddModal(false);
+                setShowEditModal(false);
+                setShowDeleteConfirm(false);
+            }
+            return;
+        }
+
+        if (modal === "schedule-create" && dateStr) {
+            const nextSelectedDate = buildSelectedDateInfo(dateStr);
+            if (nextSelectedDate) {
+                setSelectedDate(nextSelectedDate);
+                setSelectedEvent(null);
+                setShowAddModal(true);
+                setShowEditModal(false);
+                setShowDeleteConfirm(false);
+            }
+            return;
+        }
+
+        if (
+            [
+                "schedule-detail",
+                "schedule-edit",
+                "schedule-delete",
+            ].includes(modal || "") &&
+            eventId
+        ) {
+            const event = schedules.find(
+                (schedule) => getScheduleEventId(schedule) === eventId
+            );
+            if (!event) return;
+            const eventDateStr = getScheduleDateStr(event);
+            const nextSelectedDate = buildSelectedDateInfo(eventDateStr);
+            setSelectedDate(nextSelectedDate);
+            setSelectedEvent(event);
+            setShowAddModal(false);
+            if (modal === "schedule-edit" || modal === "schedule-delete") {
+                setEditForm(buildEditForm(event));
+                setShowEditModal(true);
+                setShowDeleteConfirm(modal === "schedule-delete");
+            } else {
+                setShowEditModal(false);
+                setShowDeleteConfirm(false);
+            }
+        }
+    }, [isLoading, schedules, urlModalQuery]);
+
     // 日付クリック時のハンドラー
     const handleDateClick = (date: Date, dateStr: string) => {
         const events = eventsByDate.get(dateStr) || [];
         setSelectedDate({ date, dateStr, events });
+        updateUrlModal({ modal: "schedule-date", date: dateStr, event: null });
     };
 
     // モーダルを閉じる
@@ -402,11 +564,17 @@ export default function CalendarPage() {
             color: "primary",
             attendanceMode: "ABSENCE",
         });
+        clearUrlModal(["date", "event"]);
     };
 
     // 追加モーダルを開く
     const openAddModal = () => {
         setShowAddModal(true);
+        updateUrlModal({
+            modal: "schedule-create",
+            date: selectedDate?.dateStr,
+            event: null,
+        });
     };
 
     // 追加モーダルを閉じる（一覧に戻る）
@@ -429,6 +597,11 @@ export default function CalendarPage() {
             isAllDay: false,
             color: "primary",
             attendanceMode: "ABSENCE",
+        });
+        updateUrlModal({
+            modal: "schedule-date",
+            date: selectedDate?.dateStr,
+            event: null,
         });
     };
 
@@ -516,89 +689,37 @@ export default function CalendarPage() {
     // 一覧からイベントを選択
     const handleEventSelect = (event: Schedule) => {
         setSelectedEvent(event);
+        updateUrlModal({
+            modal: "schedule-detail",
+            event: getScheduleEventId(event),
+            date: null,
+        });
     };
 
     // 詳細モーダルを閉じて一覧に戻る
     const closeEventModal = () => {
         setSelectedEvent(null);
+        if (selectedDate) {
+            updateUrlModal({
+                modal: "schedule-date",
+                date: selectedDate.dateStr,
+                event: null,
+            });
+        } else {
+            clearUrlModal(["date", "event"]);
+        }
     };
 
     // 編集モーダルを開く
     const openEditModal = () => {
         if (!selectedEvent) return;
-        const values = Object.values(selectedEvent);
-        const rawTimeHH = values[4];
-        const rawTimeMM = values[5];
-        const rawEndTimeHH = values[18];
-        const rawEndTimeMM = values[19];
-        // 終了日はインデックス9, 10, 11（END_YYYY, END_MM, END_DD）
-        const rawEndYear = values[9];
-        const rawEndMonth = values[10];
-        const rawEndDate = values[11];
-
-        // 終日判定: 時刻がなく、終了日がある場合は終日
-        const hasTime =
-            rawTimeHH !== "" && rawTimeHH !== null && rawTimeHH !== undefined;
-        const hasEndDate =
-            rawEndYear !== "" &&
-            rawEndYear !== null &&
-            rawEndYear !== undefined;
-        const isAllDay = !hasTime && hasEndDate;
-
-        setEditForm({
-            title: String(values[6] ?? ""),
-            where: String(values[7] ?? ""),
-            detail: String(values[8] ?? ""),
-            timeHH:
-                rawTimeHH !== "" &&
-                rawTimeHH !== null &&
-                rawTimeHH !== undefined
-                    ? String(rawTimeHH)
-                    : "",
-            timeMM:
-                rawTimeMM !== "" &&
-                rawTimeMM !== null &&
-                rawTimeMM !== undefined
-                    ? String(rawTimeMM)
-                    : "",
-            endTimeHH:
-                rawEndTimeHH !== "" &&
-                rawEndTimeHH !== null &&
-                rawEndTimeHH !== undefined
-                    ? String(rawEndTimeHH)
-                    : "",
-            endTimeMM:
-                rawEndTimeMM !== "" &&
-                rawEndTimeMM !== null &&
-                rawEndTimeMM !== undefined
-                    ? String(rawEndTimeMM)
-                    : "",
-            year: String(values[1] ?? ""),
-            month: String(values[2] ?? ""),
-            date: String(values[3] ?? ""),
-            endYear:
-                rawEndYear !== "" &&
-                rawEndYear !== null &&
-                rawEndYear !== undefined
-                    ? String(rawEndYear)
-                    : "",
-            endMonth:
-                rawEndMonth !== "" &&
-                rawEndMonth !== null &&
-                rawEndMonth !== undefined
-                    ? String(rawEndMonth)
-                    : "",
-            endDate:
-                rawEndDate !== "" &&
-                rawEndDate !== null &&
-                rawEndDate !== undefined
-                    ? String(rawEndDate)
-                    : "",
-            isAllDay,
-            color: (values[12] as EventColorId) || "primary",
-            attendanceMode: getScheduleAttendanceMode(selectedEvent),
-        });
+        setEditForm(buildEditForm(selectedEvent));
         setShowEditModal(true);
+        updateUrlModal({
+            modal: "schedule-edit",
+            event: getScheduleEventId(selectedEvent),
+            date: null,
+        });
     };
 
     // 編集モーダルを閉じる
@@ -623,6 +744,13 @@ export default function CalendarPage() {
             color: "primary",
             attendanceMode: "ABSENCE",
         });
+        if (selectedEvent) {
+            updateUrlModal({
+                modal: "schedule-detail",
+                event: getScheduleEventId(selectedEvent),
+                date: null,
+            });
+        }
     };
 
     // イベント削除の処理
@@ -2546,9 +2674,18 @@ export default function CalendarPage() {
                                         <button
                                             type="button"
                                             className="btn btn-sm btn-ghost"
-                                            onClick={() =>
-                                                setShowDeleteConfirm(false)
-                                            }
+                                            onClick={() => {
+                                                setShowDeleteConfirm(false);
+                                                if (selectedEvent) {
+                                                    updateUrlModal({
+                                                        modal: "schedule-edit",
+                                                        event: getScheduleEventId(
+                                                            selectedEvent
+                                                        ),
+                                                        date: null,
+                                                    });
+                                                }
+                                            }}
                                         >
                                             キャンセル
                                         </button>
@@ -2571,9 +2708,18 @@ export default function CalendarPage() {
                                     <button
                                         type="button"
                                         className="btn btn-outline btn-error"
-                                        onClick={() =>
-                                            setShowDeleteConfirm(true)
-                                        }
+                                        onClick={() => {
+                                            setShowDeleteConfirm(true);
+                                            if (selectedEvent) {
+                                                updateUrlModal({
+                                                    modal: "schedule-delete",
+                                                    event: getScheduleEventId(
+                                                        selectedEvent
+                                                    ),
+                                                    date: null,
+                                                });
+                                            }
+                                        }}
                                     >
                                         削除
                                     </button>

--- a/app/(authenticated)/items/page.tsx
+++ b/app/(authenticated)/items/page.tsx
@@ -15,6 +15,7 @@ import {
     CACHE_TTL_MS,
     CLIENT_CACHE_KEYS,
 } from "@/src/shared/lib/cache-policy";
+import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 
 type CategoryFilter = "all" | "MIC" | "SPK" | "CAB" | "OTHER";
 type ItemCategory = "MIC" | "SPK" | "CAB" | "OTH";
@@ -32,6 +33,8 @@ const getCategoryFromItemId = (itemId: string): string => {
 };
 
 export default function ItemsPage() {
+    const { searchParams, updateUrlModal, clearUrlModal } = useUrlModal();
+    const urlModalQuery = searchParams.toString();
     const [items, setItems] = useState<Item[]>([]);
     const [error, setError] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -110,6 +113,38 @@ export default function ItemsPage() {
     }, []);
 
     useEffect(() => {
+        if (isLoading) return;
+
+        const params = new URLSearchParams(urlModalQuery);
+        const modal = params.get("modal");
+        const itemId = params.get("item");
+        if (modal === "item-create") {
+            setModalError(null);
+            setIsCreateModalOpen(true);
+            return;
+        }
+
+        if ((modal === "item-edit" || modal === "item-delete") && itemId) {
+            const item = items.find(
+                (currentItem) => String(Object.values(currentItem)[0]) === itemId
+            );
+            if (!item) return;
+
+            const name = String(Object.values(item)[1] ?? "");
+            setSelectedItem({ itemId, name });
+            setModalError(null);
+            if (modal === "item-edit") {
+                setEditForm({ name });
+                setIsDeleteModalOpen(false);
+                setIsEditModalOpen(true);
+            } else {
+                setIsEditModalOpen(false);
+                setIsDeleteModalOpen(true);
+            }
+        }
+    }, [isLoading, items, urlModalQuery]);
+
+    useEffect(() => {
         if (isCreateModalOpen) {
             createModalRef.current?.showModal();
         } else {
@@ -152,6 +187,7 @@ export default function ItemsPage() {
 
             if (data.success) {
                 setIsCreateModalOpen(false);
+                clearUrlModal(["item"]);
                 setCreateForm({ category: "MIC", name: "", count: 1 });
                 clearClientCache(CLIENT_CACHE_KEYS.items);
                 await fetchItems(false);
@@ -187,6 +223,7 @@ export default function ItemsPage() {
 
             if (data.success) {
                 setIsEditModalOpen(false);
+                clearUrlModal(["item"]);
                 setSelectedItem(null);
                 setEditForm({ name: "" });
                 clearClientCache(CLIENT_CACHE_KEYS.items);
@@ -217,6 +254,7 @@ export default function ItemsPage() {
 
             if (data.success) {
                 setIsDeleteModalOpen(false);
+                clearUrlModal(["item"]);
                 setSelectedItem(null);
                 clearClientCache(CLIENT_CACHE_KEYS.items);
                 await fetchItems(false);
@@ -235,12 +273,14 @@ export default function ItemsPage() {
         setEditForm({ name });
         setModalError(null);
         setIsEditModalOpen(true);
+        updateUrlModal({ modal: "item-edit", item: itemId });
     };
 
     const openDeleteModal = (itemId: string, name: string) => {
         setSelectedItem({ itemId, name });
         setModalError(null);
         setIsDeleteModalOpen(true);
+        updateUrlModal({ modal: "item-delete", item: itemId });
     };
 
     const filteredItems =
@@ -396,6 +436,7 @@ export default function ItemsPage() {
                         onClick={() => {
                             setModalError(null);
                             setIsCreateModalOpen(true);
+                            updateUrlModal({ modal: "item-create", item: null });
                         }}
                     >
                         追加
@@ -463,6 +504,7 @@ export default function ItemsPage() {
                         onClick={() => {
                             setModalError(null);
                             setIsCreateModalOpen(true);
+                            updateUrlModal({ modal: "item-create", item: null });
                         }}
                     >
                         機材を追加
@@ -504,7 +546,10 @@ export default function ItemsPage() {
             <dialog
                 ref={createModalRef}
                 className="modal"
-                onClose={() => setIsCreateModalOpen(false)}
+                onClose={() => {
+                    setIsCreateModalOpen(false);
+                    clearUrlModal(["item"]);
+                }}
             >
                 <div className="modal-box">
                     <h3 className="font-bold text-lg mb-4">機材を登録</h3>
@@ -581,7 +626,10 @@ export default function ItemsPage() {
                     <div className="modal-action">
                         <button
                             className="btn btn-ghost"
-                            onClick={() => setIsCreateModalOpen(false)}
+                            onClick={() => {
+                                setIsCreateModalOpen(false);
+                                clearUrlModal(["item"]);
+                            }}
                             disabled={isSubmitting}
                         >
                             キャンセル
@@ -611,7 +659,10 @@ export default function ItemsPage() {
             <dialog
                 ref={editModalRef}
                 className="modal"
-                onClose={() => setIsEditModalOpen(false)}
+                onClose={() => {
+                    setIsEditModalOpen(false);
+                    clearUrlModal(["item"]);
+                }}
             >
                 <div className="modal-box">
                     <h3 className="font-bold text-lg mb-4">機材を編集</h3>
@@ -667,7 +718,10 @@ export default function ItemsPage() {
                         <div className="flex gap-2">
                             <button
                                 className="btn btn-ghost"
-                                onClick={() => setIsEditModalOpen(false)}
+                                onClick={() => {
+                                    setIsEditModalOpen(false);
+                                    clearUrlModal(["item"]);
+                                }}
                                 disabled={isSubmitting}
                             >
                                 キャンセル
@@ -698,7 +752,10 @@ export default function ItemsPage() {
             <dialog
                 ref={deleteModalRef}
                 className="modal"
-                onClose={() => setIsDeleteModalOpen(false)}
+                onClose={() => {
+                    setIsDeleteModalOpen(false);
+                    clearUrlModal(["item"]);
+                }}
             >
                 <div className="modal-box">
                     <h3 className="font-bold text-lg mb-4">機材を削除</h3>
@@ -731,7 +788,10 @@ export default function ItemsPage() {
                     <div className="modal-action">
                         <button
                             className="btn btn-ghost"
-                            onClick={() => setIsDeleteModalOpen(false)}
+                            onClick={() => {
+                                setIsDeleteModalOpen(false);
+                                clearUrlModal(["item"]);
+                            }}
                             disabled={isSubmitting}
                         >
                             キャンセル

--- a/app/(authenticated)/members/page.tsx
+++ b/app/(authenticated)/members/page.tsx
@@ -29,6 +29,7 @@ import {
     CACHE_TTL_MS,
     CLIENT_CACHE_KEYS,
 } from "@/src/shared/lib/cache-policy";
+import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 
 const HEADER_LABELS: Record<string, string> = {
     studentnumber: "学籍番号",
@@ -219,6 +220,8 @@ const getAdmissionYear = (studentNumber: SheetCellValue): string | null => {
 };
 
 export default function MembersPage() {
+    const { searchParams, updateUrlModal, clearUrlModal } = useUrlModal();
+    const urlModalQuery = searchParams.toString();
     const [headers, setHeaders] = useState<string[]>([]);
     const [members, setMembers] = useState<MemberRow[]>([]);
     const [query, setQuery] = useState("");
@@ -318,6 +321,14 @@ export default function MembersPage() {
         [headers]
     );
 
+    const getMemberStudentNumber = useCallback(
+        (member: MemberRow) =>
+            studentNumberColumnIndex >= 0
+                ? stringifyCell(member.values[studentNumberColumnIndex])
+                : "",
+        [studentNumberColumnIndex]
+    );
+
     const lineNameColumnIndex = useMemo(
         () => headers.findIndex(isLineNameHeader),
         [headers]
@@ -392,6 +403,54 @@ export default function MembersPage() {
         selectedAdmissionYear !== "all" ||
         checkedMemberRows.size > 0;
 
+    useEffect(() => {
+        if (isLoading) return;
+
+        const params = new URLSearchParams(urlModalQuery);
+        const modal = params.get("modal");
+        const studentNumber = params.get("member");
+        if (modal === "member-create") {
+            setCreateValues(headers.map(() => ""));
+            setModalError(null);
+            setIsCreateModalOpen(true);
+            return;
+        }
+
+        if (modal === "checked-members") {
+            setIsCheckedListModalOpen(true);
+            return;
+        }
+
+        if ((modal === "member-edit" || modal === "member-delete") && studentNumber) {
+            const member = members.find(
+                (currentMember) =>
+                    getMemberStudentNumber(currentMember) === studentNumber
+            );
+            if (!member) return;
+
+            setModalError(null);
+            if (modal === "member-edit") {
+                setEditingMember(member);
+                setEditValues(
+                    headers.map((_, index) =>
+                        stringifyCell(member.values[index])
+                    )
+                );
+                setDeletingMember(null);
+            } else {
+                setDeletingMember(member);
+                setEditingMember(null);
+                setEditValues([]);
+            }
+        }
+    }, [
+        getMemberStudentNumber,
+        headers,
+        isLoading,
+        members,
+        urlModalQuery,
+    ]);
+
     const clearFilters = () => {
         setQuery("");
         setSelectedAdmissionYear("all");
@@ -448,6 +507,7 @@ export default function MembersPage() {
         setCreateValues(headers.map(() => ""));
         setModalError(null);
         setIsCreateModalOpen(true);
+        updateUrlModal({ modal: "member-create", member: null });
     };
 
     const closeCreateModal = (force = false) => {
@@ -455,11 +515,13 @@ export default function MembersPage() {
         setIsCreateModalOpen(false);
         setCreateValues([]);
         setModalError(null);
+        clearUrlModal(["member"]);
     };
 
     const closeCheckedListModal = () => {
         setIsCheckedListModalOpen(false);
         setLineNameCopyStatus("idle");
+        clearUrlModal(["member"]);
     };
 
     const copyCheckedLineNames = async () => {
@@ -488,6 +550,10 @@ export default function MembersPage() {
             headers.map((_, index) => stringifyCell(member.values[index]))
         );
         setModalError(null);
+        updateUrlModal({
+            modal: "member-edit",
+            member: getMemberStudentNumber(member),
+        });
     };
 
     const closeEditModal = (force = false) => {
@@ -495,6 +561,7 @@ export default function MembersPage() {
         setEditingMember(null);
         setEditValues([]);
         setModalError(null);
+        clearUrlModal(["member"]);
     };
 
     const openDeleteModalFromEdit = () => {
@@ -503,12 +570,17 @@ export default function MembersPage() {
         setEditingMember(null);
         setEditValues([]);
         setModalError(null);
+        updateUrlModal({
+            modal: "member-delete",
+            member: getMemberStudentNumber(editingMember),
+        });
     };
 
     const closeDeleteModal = (force = false) => {
         if (isSubmitting && !force) return;
         setDeletingMember(null);
         setModalError(null);
+        clearUrlModal(["member"]);
     };
 
     const handleCreate = async () => {
@@ -644,7 +716,13 @@ export default function MembersPage() {
                         <button
                             type="button"
                             className="btn btn-outline btn-sm gap-2"
-                            onClick={() => setIsCheckedListModalOpen(true)}
+                            onClick={() => {
+                                setIsCheckedListModalOpen(true);
+                                updateUrlModal({
+                                    modal: "checked-members",
+                                    member: null,
+                                });
+                            }}
                             disabled={isLoading || checkedMembers.length === 0}
                         >
                             <FontAwesomeIcon

--- a/app/(authenticated)/tasks/TasksClient.tsx
+++ b/app/(authenticated)/tasks/TasksClient.tsx
@@ -16,6 +16,7 @@ import type {
     TaskStatus,
 } from "@/src/shared/types/api";
 import { TASK_STATUS_LABELS } from "@/src/shared/types/api";
+import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 
 type MemberOption = {
     studentNumber: string;
@@ -77,6 +78,8 @@ const resolveMembers = (data: MembersData | undefined): MemberOption[] => {
 };
 
 export default function TasksClient({ currentStudentId }: TasksClientProps) {
+    const { searchParams, updateUrlModal, clearUrlModal } = useUrlModal();
+    const urlModalQuery = searchParams.toString();
     const [tasks, setTasks] = useState<Task[]>([]);
     const [members, setMembers] = useState<MemberOption[]>([]);
     const [form, setForm] = useState<TaskFormState>(emptyForm);
@@ -148,6 +151,47 @@ export default function TasksClient({ currentStudentId }: TasksClientProps) {
         void loadData();
     }, []);
 
+    useEffect(() => {
+        if (isLoading) return;
+
+        const params = new URLSearchParams(urlModalQuery);
+        const modal = params.get("modal");
+        const taskId = params.get("task");
+        if (modal === "task-create") {
+            setForm(emptyForm);
+            setError(null);
+            setSuccessMessage(null);
+            setDeleteTargetTask(null);
+            setIsTaskModalOpen(true);
+            return;
+        }
+
+        if ((modal === "task-edit" || modal === "task-delete") && taskId) {
+            const task = tasks.find((item) => item.id === taskId);
+            if (!task) return;
+
+            setError(null);
+            setSuccessMessage(null);
+            if (modal === "task-edit") {
+                setDeleteTargetTask(null);
+                setForm({
+                    id: task.id,
+                    title: task.title,
+                    description: task.description,
+                    status: task.status,
+                    dueDate: task.dueDate || "",
+                    assigneeStudentNumbers: task.assignees.map(
+                        (assignee) => assignee.studentNumber
+                    ),
+                });
+                setIsTaskModalOpen(true);
+            } else {
+                setIsTaskModalOpen(false);
+                setDeleteTargetTask(task);
+            }
+        }
+    }, [isLoading, tasks, urlModalQuery]);
+
     const resetForm = () => {
         setForm(emptyForm);
         setSuccessMessage(null);
@@ -158,22 +202,26 @@ export default function TasksClient({ currentStudentId }: TasksClientProps) {
         setError(null);
         setSuccessMessage(null);
         setIsTaskModalOpen(true);
+        updateUrlModal({ modal: "task-create", task: null });
     };
 
     const closeTaskModal = () => {
         setIsTaskModalOpen(false);
         resetForm();
+        clearUrlModal(["task"]);
     };
 
     const openDeleteTaskModal = (task: Task) => {
         setDeleteTargetTask(task);
         setError(null);
         setSuccessMessage(null);
+        updateUrlModal({ modal: "task-delete", task: task.id });
     };
 
     const closeDeleteTaskModal = () => {
         if (isDeleting) return;
         setDeleteTargetTask(null);
+        clearUrlModal(["task"]);
     };
 
     const toggleAssignee = (studentNumber: string) => {
@@ -211,6 +259,7 @@ export default function TasksClient({ currentStudentId }: TasksClientProps) {
             setSuccessMessage(form.id ? "タスクを更新しました" : "タスクを追加しました");
             setIsTaskModalOpen(false);
             resetForm();
+            clearUrlModal(["task"]);
         } catch (caught) {
             setError(
                 caught instanceof Error
@@ -236,6 +285,7 @@ export default function TasksClient({ currentStudentId }: TasksClientProps) {
         setSuccessMessage(null);
         setError(null);
         setIsTaskModalOpen(true);
+        updateUrlModal({ modal: "task-edit", task: task.id });
     };
 
     const updateTaskStatus = async (task: Task, status: TaskStatus) => {
@@ -284,6 +334,7 @@ export default function TasksClient({ currentStudentId }: TasksClientProps) {
             );
             setDeleteTargetTask(null);
             setSuccessMessage("タスクを削除しました");
+            clearUrlModal(["task"]);
         } catch (caught) {
             setError(
                 caught instanceof Error

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,7 +2,24 @@ import { signIn } from "@/src/auth";
 import Image from "next/image";
 import { LoginButton } from "./LoginButton";
 
-export default function LoginPage() {
+type LoginPageProps = {
+    searchParams?: Promise<{
+        callbackUrl?: string | string[];
+    }>;
+};
+
+const normalizeCallbackUrl = (value: string | string[] | undefined) => {
+    const callbackUrl = Array.isArray(value) ? value[0] : value;
+    if (!callbackUrl || !callbackUrl.startsWith("/") || callbackUrl.startsWith("//")) {
+        return "/home";
+    }
+    return callbackUrl;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+    const params = searchParams ? await searchParams : {};
+    const callbackUrl = normalizeCallbackUrl(params.callbackUrl);
+
     return (
         <div className="min-h-dvh flex items-center justify-center bg-base-200">
             <div className="card w-96 bg-base-100 shadow-xl">
@@ -28,7 +45,7 @@ export default function LoginPage() {
                         action={async () => {
                             "use server";
                             await signIn("microsoft-entra-id", {
-                                redirectTo: "/home",
+                                redirectTo: callbackUrl,
                             });
                         }}
                     >

--- a/proxy.ts
+++ b/proxy.ts
@@ -36,6 +36,10 @@ export async function proxy(request: NextRequest) {
     // 未認証ならログインページにリダイレクト
     if (!isLoggedIn) {
         const loginUrl = new URL("/login", request.nextUrl.origin);
+        loginUrl.searchParams.set(
+            "callbackUrl",
+            `${request.nextUrl.pathname}${request.nextUrl.search}`
+        );
         return NextResponse.redirect(loginUrl);
     }
 

--- a/src/features/next-meeting/NextMeetingCard.tsx
+++ b/src/features/next-meeting/NextMeetingCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     faCalendarDays,
@@ -15,6 +15,7 @@ import {
     type NextMeetingSettings,
 } from "@/src/shared/types/api";
 import { announceNextMeeting, updateNextMeeting } from "@/src/shared/api";
+import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 
 const canManageNextMeeting = (permission?: MemberPermission) =>
     permission === "HEAD" || permission === "SUB_HEAD" || permission === "ACCOUNTANT";
@@ -58,6 +59,8 @@ export function NextMeetingCard({
     permission,
     className = "",
 }: NextMeetingCardProps) {
+    const { searchParams, updateUrlModal, clearUrlModal } = useUrlModal();
+    const urlModalQuery = searchParams.toString();
     const [meeting, setMeeting] = useState(initialMeeting);
     const [date, setDate] = useState(initialMeeting?.date || "");
     const [time, setTime] = useState(initialMeeting?.time || "21:00");
@@ -76,6 +79,27 @@ export function NextMeetingCard({
         [permission]
     );
 
+    useEffect(() => {
+        const params = new URLSearchParams(urlModalQuery);
+        const modal = params.get("modal");
+        if (!canManage) return;
+        if (modal === "next-meeting-edit") {
+            setDate(meeting?.date || "");
+            setTime(meeting?.time || "21:00");
+            setMode(meeting?.mode || "DISCORD");
+            setError(null);
+            setSuccessMessage(null);
+            setIsEditorOpen(true);
+            setIsAnnounceConfirmOpen(false);
+        }
+        if (modal === "next-meeting-announce") {
+            setError(null);
+            setSuccessMessage(null);
+            setIsAnnounceConfirmOpen(true);
+            setIsEditorOpen(false);
+        }
+    }, [canManage, meeting, urlModalQuery]);
+
     const openEditor = () => {
         setDate(meeting?.date || "");
         setTime(meeting?.time || "21:00");
@@ -83,18 +107,27 @@ export function NextMeetingCard({
         setError(null);
         setSuccessMessage(null);
         setIsEditorOpen(true);
+        updateUrlModal({ modal: "next-meeting-edit" });
     };
 
     const closeEditor = () => {
         if (isSubmitting) return;
         setIsEditorOpen(false);
         setError(null);
+        clearUrlModal();
     };
 
     const openAnnounceConfirm = () => {
         setError(null);
         setSuccessMessage(null);
         setIsAnnounceConfirmOpen(true);
+        updateUrlModal({ modal: "next-meeting-announce" });
+    };
+
+    const closeAnnounceConfirm = () => {
+        if (isAnnouncing) return;
+        setIsAnnounceConfirmOpen(false);
+        clearUrlModal();
     };
 
     const handleSubmit = async (event: React.FormEvent) => {
@@ -118,6 +151,7 @@ export function NextMeetingCard({
             setMeeting(result.data);
             setSuccessMessage("次回部会を更新しました");
             setIsEditorOpen(false);
+            clearUrlModal();
         } catch (submitError) {
             setError(
                 submitError instanceof Error
@@ -143,6 +177,7 @@ export function NextMeetingCard({
 
             setSuccessMessage("次回部会連絡をDiscordに送信しました");
             setIsAnnounceConfirmOpen(false);
+            clearUrlModal();
         } catch (announceError) {
             setError(
                 announceError instanceof Error
@@ -352,9 +387,7 @@ export function NextMeetingCard({
                             <button
                                 type="button"
                                 className="btn"
-                                onClick={() =>
-                                    setIsAnnounceConfirmOpen(false)
-                                }
+                                onClick={closeAnnounceConfirm}
                                 disabled={isAnnouncing}
                             >
                                 キャンセル
@@ -375,11 +408,7 @@ export function NextMeetingCard({
                     <form
                         method="dialog"
                         className="modal-backdrop"
-                        onSubmit={() => {
-                            if (!isAnnouncing) {
-                                setIsAnnounceConfirmOpen(false);
-                            }
-                        }}
+                        onSubmit={closeAnnounceConfirm}
                     >
                         <button type="submit">close</button>
                     </form>

--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -15,6 +15,7 @@ import type {
     Absence,
     ScheduleAttendanceMode,
 } from "@/src/shared/types/api";
+import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 
 type AbsenceFormState = {
     type: string;
@@ -132,6 +133,8 @@ export default function ScheduleCard({
     hideCard = false,
     color = "#2a83a2",
 }: ScheduleCardProps) {
+    const { searchParams, updateUrlModal, clearUrlModal } = useUrlModal();
+    const urlModalQuery = searchParams.toString();
     const [isModalOpen, setIsModalOpen] = useState(defaultOpen);
     const [isAttendanceConfirmOpen, setIsAttendanceConfirmOpen] =
         useState(false);
@@ -216,6 +219,37 @@ export default function ScheduleCard({
         setLocalAbsences(absences);
     }, [absences]);
 
+    useEffect(() => {
+        const params = new URLSearchParams(urlModalQuery);
+        if (params.get("event") !== eventId) return;
+
+        const modal = params.get("modal");
+        if (modal === "schedule-response") {
+            setIsModalOpen(true);
+            setIsAttendanceConfirmOpen(false);
+            setIsAbsenceFormOpen(false);
+            setIsDeleteConfirmOpen(false);
+        }
+        if (modal === "response-confirm") {
+            setIsModalOpen(true);
+            setIsAttendanceConfirmOpen(true);
+            setIsAbsenceFormOpen(false);
+            setIsDeleteConfirmOpen(false);
+        }
+        if (modal === "response-form") {
+            setIsModalOpen(true);
+            setIsAttendanceConfirmOpen(false);
+            setIsAbsenceFormOpen(true);
+            setIsDeleteConfirmOpen(false);
+        }
+        if (modal === "response-delete") {
+            setIsModalOpen(true);
+            setIsAttendanceConfirmOpen(false);
+            setIsAbsenceFormOpen(false);
+            setIsDeleteConfirmOpen(true);
+        }
+    }, [eventId, urlModalQuery]);
+
     const handleClose = () => {
         setIsModalOpen(false);
         setIsAttendanceConfirmOpen(false);
@@ -225,6 +259,7 @@ export default function ScheduleCard({
         setAbsenceSubmitMessage(null);
         setAttendanceNote("");
         onClose?.();
+        clearUrlModal(["event"]);
     };
 
     const resetAbsenceForm = () => {
@@ -271,6 +306,7 @@ export default function ScheduleCard({
         setIsAttendanceConfirmOpen(false);
         setAttendanceSubmitMessage(null);
         setAttendanceNote("");
+        updateUrlModal({ modal: "schedule-response", event: eventId });
     };
 
     const closeAbsenceForm = () => {
@@ -278,17 +314,20 @@ export default function ScheduleCard({
         setIsAbsenceFormOpen(false);
         setAbsenceSubmitMessage(null);
         resetAbsenceForm();
+        updateUrlModal({ modal: "schedule-response", event: eventId });
     };
 
     const closeDeleteConfirm = () => {
         if (isDeletingResponse) return;
         setIsDeleteConfirmOpen(false);
+        updateUrlModal({ modal: "schedule-response", event: eventId });
     };
 
     const openAttendanceForm = () => {
         setAttendanceSubmitMessage(null);
         setAttendanceNote(ownResponse?.reasonDetail || "");
         setIsAttendanceConfirmOpen(true);
+        updateUrlModal({ modal: "response-confirm", event: eventId });
     };
 
     const openAbsenceForm = () => {
@@ -306,6 +345,7 @@ export default function ScheduleCard({
                 : emptyAbsenceForm
         );
         setIsAbsenceFormOpen(true);
+        updateUrlModal({ modal: "response-form", event: eventId });
     };
 
     const submitAttendance = async () => {
@@ -474,7 +514,13 @@ export default function ScheduleCard({
         <>
             {!hideCard && (
                 <div
-                    onClick={() => setIsModalOpen(true)}
+                    onClick={() => {
+                        setIsModalOpen(true);
+                        updateUrlModal({
+                            modal: "schedule-response",
+                            event: eventId,
+                        });
+                    }}
                     className="group bg-base-100 p-5 transition-colors cursor-pointer hover:bg-base-200/50"
                 >
                     <div className="flex items-stretch gap-4">
@@ -1055,11 +1101,17 @@ export default function ScheduleCard({
                                                                         <button
                                                                             type="button"
                                                                             className="btn btn-ghost btn-xs text-error"
-                                                                            onClick={() =>
+                                                                            onClick={() => {
                                                                                 setIsDeleteConfirmOpen(
                                                                                     true
-                                                                                )
-                                                                            }
+                                                                                );
+                                                                                updateUrlModal(
+                                                                                    {
+                                                                                        modal: "response-delete",
+                                                                                        event: eventId,
+                                                                                    }
+                                                                                );
+                                                                            }}
                                                                             disabled={
                                                                                 isAttendanceSubmitting ||
                                                                                 isAbsenceSubmitting ||

--- a/src/shared/lib/use-url-modal.ts
+++ b/src/shared/lib/use-url-modal.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type UrlModalParams = Record<string, string | null | undefined>;
+
+export const useUrlModal = () => {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const updateUrlModal = (params: UrlModalParams, replace = false) => {
+        const next = new URLSearchParams(searchParams.toString());
+        Object.entries(params).forEach(([key, value]) => {
+            if (value === null || value === undefined || value === "") {
+                next.delete(key);
+            } else {
+                next.set(key, value);
+            }
+        });
+        const query = next.toString();
+        const url = query ? `${pathname}?${query}` : pathname;
+        if (replace) {
+            router.replace(url, { scroll: false });
+        } else {
+            router.push(url, { scroll: false });
+        }
+    };
+
+    const clearUrlModal = (keys: string[] = []) => {
+        const next = new URLSearchParams(searchParams.toString());
+        next.delete("modal");
+        keys.forEach((key) => next.delete(key));
+        const query = next.toString();
+        router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    };
+
+    return { searchParams, updateUrlModal, clearUrlModal };
+};


### PR DESCRIPTION
## 概要
- modal クエリパラメータで主要モーダルの開閉状態を復元
- タスク、カレンダー予定、機材、部員、次回部会、出欠カードのモーダルを URL 対応
- 未ログイン時は login に callbackUrl を付けてリダイレクトし、Microsoft ログイン後に共有元 URL へ戻す
- URL 更新用の共通 hook を追加

## URL 例
- /tasks?modal=task-edit&task=<taskId>
- /calendar?modal=schedule-detail&event=<eventId>
- /calendar?modal=schedule-create&date=2026-06-15
- /members?modal=member-edit&member=<studentNumber>
- /items?modal=item-edit&item=<itemId>
- /home?modal=next-meeting-edit

## 確認
- npm run build

## 補足
- ヘルプ内のデモモーダルと PWA の自動プロンプトは共有対象外