### PR TITLE
今後のスケジュールモーダルのスクロールロック残留を修正

### DIFF
--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -15,6 +15,7 @@ import type {
     Absence,
     ScheduleAttendanceMode,
 } from "@/src/shared/types/api";
+import { cleanupStaleModalScrollLock } from "@/src/shared/lib/modal-scroll-lock";
 import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 
 type AbsenceFormState = {
@@ -220,6 +221,12 @@ export default function ScheduleCard({
     }, [absences]);
 
     useEffect(() => {
+        return () => {
+            cleanupStaleModalScrollLock();
+        };
+    }, []);
+
+    useEffect(() => {
         const params = new URLSearchParams(urlModalQuery);
         if (params.get("event") !== eventId) return;
 
@@ -260,6 +267,7 @@ export default function ScheduleCard({
         setAttendanceNote("");
         onClose?.();
         clearUrlModal(["event"]);
+        cleanupStaleModalScrollLock();
     };
 
     const resetAbsenceForm = () => {

--- a/src/shared/lib/modal-scroll-lock.ts
+++ b/src/shared/lib/modal-scroll-lock.ts
@@ -1,0 +1,23 @@
+const scheduleAfterPaint = (callback: () => void) => {
+    window.requestAnimationFrame(() => {
+        window.setTimeout(callback, 0);
+    });
+};
+
+export const cleanupStaleModalScrollLock = () => {
+    if (typeof document === "undefined") return;
+
+    scheduleAfterPaint(() => {
+        const hasOpenModal = document.querySelector(
+            "dialog[open], .modal.modal-open"
+        );
+        if (hasOpenModal) return;
+
+        document.documentElement.classList.remove("modal-open");
+        document.body.classList.remove("modal-open");
+        document.documentElement.style.removeProperty("overflow");
+        document.body.style.removeProperty("overflow");
+        document.documentElement.style.removeProperty("padding-right");
+        document.body.style.removeProperty("padding-right");
+    });
+};


### PR DESCRIPTION
## 概要
- 今後のスケジュールのモーダルを閉じた後に、body/html のスクロールロックが残る場合がある問題を修正
- モーダルが完全に閉じた後、他に開いているモーダルがなければ stale な modal-open class と overflow/padding-right style を掃除
- ScheduleCard のアンマウント時にも同じ掃除を実行

## 確認
- npm run build