### PR TITLE
スケジュールモーダルのスクロールロック残留を再修正

### DIFF
--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -158,7 +158,7 @@ export default async function HomePage() {
                             {upcomingSchedules.length > 0 ? (
                                 <div className="overflow-hidden rounded-xl bg-base-100 ring-1 ring-base-300/70 divide-y divide-base-300/70">
                                     {upcomingSchedules.map(
-                                        (schedule: Schedule, index: number) => {
+                                        (schedule: Schedule) => {
                                             const values =
                                                 Object.values(schedule);
                                             const eventId = String(
@@ -246,7 +246,7 @@ export default async function HomePage() {
 
                                             return (
                                                 <ScheduleCard
-                                                    key={index}
+                                                    key={eventId}
                                                     eventId={eventId}
                                                     title={title}
                                                     where={where}

--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -15,7 +15,10 @@ import type {
     Absence,
     ScheduleAttendanceMode,
 } from "@/src/shared/types/api";
-import { cleanupStaleModalScrollLock } from "@/src/shared/lib/modal-scroll-lock";
+import {
+    cleanupStaleModalScrollLock,
+    prepareModalScrollLock,
+} from "@/src/shared/lib/modal-scroll-lock";
 import { useUrlModal } from "@/src/shared/lib/use-url-modal";
 
 type AbsenceFormState = {
@@ -227,29 +230,42 @@ export default function ScheduleCard({
     }, []);
 
     useEffect(() => {
+        if (isModalOpen) {
+            prepareModalScrollLock();
+            return;
+        }
+
+        cleanupStaleModalScrollLock();
+    }, [isModalOpen]);
+
+    useEffect(() => {
         const params = new URLSearchParams(urlModalQuery);
         if (params.get("event") !== eventId) return;
 
         const modal = params.get("modal");
         if (modal === "schedule-response") {
+            prepareModalScrollLock();
             setIsModalOpen(true);
             setIsAttendanceConfirmOpen(false);
             setIsAbsenceFormOpen(false);
             setIsDeleteConfirmOpen(false);
         }
         if (modal === "response-confirm") {
+            prepareModalScrollLock();
             setIsModalOpen(true);
             setIsAttendanceConfirmOpen(true);
             setIsAbsenceFormOpen(false);
             setIsDeleteConfirmOpen(false);
         }
         if (modal === "response-form") {
+            prepareModalScrollLock();
             setIsModalOpen(true);
             setIsAttendanceConfirmOpen(false);
             setIsAbsenceFormOpen(true);
             setIsDeleteConfirmOpen(false);
         }
         if (modal === "response-delete") {
+            prepareModalScrollLock();
             setIsModalOpen(true);
             setIsAttendanceConfirmOpen(false);
             setIsAbsenceFormOpen(false);
@@ -523,6 +539,7 @@ export default function ScheduleCard({
             {!hideCard && (
                 <div
                     onClick={() => {
+                        prepareModalScrollLock();
                         setIsModalOpen(true);
                         updateUrlModal({
                             modal: "schedule-response",

--- a/src/shared/lib/modal-scroll-lock.ts
+++ b/src/shared/lib/modal-scroll-lock.ts
@@ -1,17 +1,33 @@
-const scheduleAfterPaint = (callback: () => void) => {
+const modalScrollLockProperties = [
+    "--page-has-backdrop",
+    "--page-overflow",
+    "--page-scroll-bg",
+    "--page-scroll-gutter",
+    "--page-scroll-transition",
+];
+
+const scheduleAfterPaint = (callback: () => void, delay = 0) => {
     window.requestAnimationFrame(() => {
-        window.setTimeout(callback, 0);
+        window.setTimeout(callback, delay);
+    });
+};
+
+const hasOpenModal = () =>
+    Boolean(document.querySelector("dialog[open], .modal.modal-open"));
+
+export const prepareModalScrollLock = () => {
+    if (typeof document === "undefined") return;
+
+    modalScrollLockProperties.forEach((property) => {
+        document.documentElement.style.removeProperty(property);
     });
 };
 
 export const cleanupStaleModalScrollLock = () => {
     if (typeof document === "undefined") return;
 
-    scheduleAfterPaint(() => {
-        const hasOpenModal = document.querySelector(
-            "dialog[open], .modal.modal-open"
-        );
-        if (hasOpenModal) return;
+    const cleanup = () => {
+        if (hasOpenModal()) return;
 
         document.documentElement.classList.remove("modal-open");
         document.body.classList.remove("modal-open");
@@ -19,5 +35,25 @@ export const cleanupStaleModalScrollLock = () => {
         document.body.style.removeProperty("overflow");
         document.documentElement.style.removeProperty("padding-right");
         document.body.style.removeProperty("padding-right");
-    });
+
+        document.documentElement.style.setProperty("--page-has-backdrop", "0");
+        document.documentElement.style.setProperty("--page-overflow", "visible");
+        document.documentElement.style.setProperty(
+            "--page-scroll-bg",
+            "var(--root-bg, var(--color-base-100))"
+        );
+        document.documentElement.style.setProperty(
+            "--page-scroll-gutter",
+            "auto"
+        );
+        document.documentElement.style.setProperty(
+            "--page-scroll-transition",
+            "none"
+        );
+    };
+
+    cleanup();
+    scheduleAfterPaint(cleanup);
+    scheduleAfterPaint(cleanup, 80);
+    scheduleAfterPaint(cleanup, 300);
 };


### PR DESCRIPTION
## 概要
- daisyUI の root CSS 変数によるスクロールロックが残るケースを明示的に解除
- モーダルを開く前に解除用の inline override をリセット
- 今後のスケジュール一覧の key を index から eventId に変更し、一覧更新時の state 再利用を防止

## 確認
- npm run build
- npm run lint は既存の別ファイル lint エラーで失敗