### PR TITLE
スケジュールモーダルに余白を追加

### DIFF
--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -618,9 +618,9 @@ export default function ScheduleCard({
 
             {/* Modal */}
             {isModalOpen && (
-                <dialog className="modal modal-open">
+                <dialog className="modal modal-open px-4 py-16 sm:py-20">
                     <div
-                        className={`modal-box bg-base-100 ${
+                        className={`modal-box max-h-[calc(100dvh-8rem)] overflow-y-auto bg-base-100 sm:max-h-[calc(100dvh-10rem)] ${
                             isAttendanceConfirmOpen || isDeleteConfirmOpen
                                 ? "w-[min(calc(100vw-2rem),34rem)] max-w-none"
                                 : "max-w-2xl"


### PR DESCRIPTION
## 概要
- 今後のスケジュールから開く ScheduleCard モーダルに上下余白を追加
- modal-box の最大高さを viewport から差し引き、上端・下端が見切れにくいように調整
- 内容が長い場合は modal-box 内でスクロールできるように変更

## 関連
- スクロール不能の残存バグは #169 に切り出し

## 確認
- npm run build