### PR TITLE
Discord通知の日時表示をJST表記に整える

### DIFF
--- a/app/api/absence/route.ts
+++ b/app/api/absence/route.ts
@@ -108,6 +108,29 @@ const getAbsenceNotificationTitle = (data: AbsenceSubmitData) =>
         data.type === "出席" ? "出席連絡" : `${data.type}連絡`
     }`;
 
+const formatDiscordDateTime = (value?: string) => {
+    if (!value) return "";
+
+    const jstWallClockMatch = value.match(
+        /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::\d{2})?(?:\+09:00)?$/
+    );
+    if (jstWallClockMatch) {
+        return `${jstWallClockMatch[1]}/${jstWallClockMatch[2]}/${jstWallClockMatch[3]} ${jstWallClockMatch[4]}:${jstWallClockMatch[5]}`;
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+
+    return date.toLocaleString("ja-JP", {
+        timeZone: "Asia/Tokyo",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+    });
+};
+
 const buildAbsenceDescription = (data: AbsenceSubmitData) => {
     const eventLines = [
         `**${data.eventTitle || data.eventId}**`,
@@ -132,7 +155,9 @@ const sendAbsenceDiscordNotification = async (
                 title: getAbsenceNotificationTitle(data),
                 description: buildAbsenceDescription(data),
                 color: getAbsenceColor(data.type),
-                ...(timestamp ? { footer: { text: timestamp } } : {}),
+                ...(timestamp
+                    ? { footer: { text: formatDiscordDateTime(timestamp) } }
+                    : {}),
             },
         ],
     });

--- a/app/api/next-meeting/announce/route.ts
+++ b/app/api/next-meeting/announce/route.ts
@@ -24,6 +24,13 @@ const formatNextMeetingDateLabel = (dateString: string, timeString: string) => {
 };
 
 const formatDateTime = (value: string) => {
+    const jstWallClockMatch = value.match(
+        /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::\d{2})?(?:\+09:00)?$/
+    );
+    if (jstWallClockMatch) {
+        return `${jstWallClockMatch[1]}/${jstWallClockMatch[2]}/${jstWallClockMatch[3]} ${jstWallClockMatch[4]}:${jstWallClockMatch[5]}`;
+    }
+
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return value;
 

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -1093,6 +1093,13 @@ const saveAccessLogs = async (request: Request, env: Env) => {
 
 const formatDateTime = (value: string | null) => {
 	if (!value) return "";
+	const jstWallClockMatch = value.match(
+		/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::\d{2})?(?:\+09:00)?$/
+	);
+	if (jstWallClockMatch) {
+		return `${jstWallClockMatch[1]}/${jstWallClockMatch[2]}/${jstWallClockMatch[3]} ${jstWallClockMatch[4]}:${jstWallClockMatch[5]}`;
+	}
+
 	const date = new Date(value);
 	if (Number.isNaN(date.getTime())) return value;
 


### PR DESCRIPTION
## 概要
- Discord embed の日時表示で +09:00 がそのまま出ないように整形
- 欠席/出席連絡の footer timestamp を YYYY/MM/DD HH:mm 表記に変更
- 次回部会通知と Cloudflare cron 通知の更新日時も同じ表示に統一
- 既存DBの YYYY-MM-DD HH:mm:ss 形式と新しい YYYY-MM-DDTHH:mm:ss+09:00 形式の両方に対応

## 確認
- npm run build
- cd cloudflare/nb-portal-api && npm test