### PR TITLE
出欠入力期限を追加

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -23,6 +23,10 @@ import {
     CACHE_TTL_MS,
     CLIENT_CACHE_KEYS,
 } from "@/src/shared/lib/cache-policy";
+import {
+    formatDateInput,
+    getDefaultAttendanceDeadline,
+} from "@/src/shared/lib/schedule-deadline";
 
 // イベントカラーの定義
 export const EVENT_COLORS = [
@@ -63,6 +67,7 @@ type ScheduleMutationData = {
     endDate?: string | number;
     color?: string;
     attendanceMode?: string;
+    attendanceDeadline?: string;
 };
 
 interface SelectedDateInfo {
@@ -100,6 +105,7 @@ interface EventForm {
     isAllDay: boolean;
     color: EventColorId;
     attendanceMode: ScheduleAttendanceMode;
+    attendanceDeadline: string;
 }
 
 const CALENDAR_REFRESH_INTERVAL = CACHE_TTL_MS.pageData;
@@ -115,6 +121,9 @@ const getScheduleAttendanceMode = (
 const getScheduleEventId = (schedule: Schedule) =>
     String(schedule.EVENT_ID ?? Object.values(schedule)[0] ?? "");
 
+const getScheduleAttendanceDeadline = (schedule: Schedule) =>
+    String(schedule.ATTENDANCE_DEADLINE ?? schedule.attendanceDeadline ?? "");
+
 const getScheduleDateStr = (schedule: Schedule) => {
     const values = Object.values(schedule);
     const year = String(values[1] ?? "").padStart(4, "0");
@@ -128,6 +137,23 @@ const parseDateStr = (dateStr: string) => {
     const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (!match) return null;
     return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+};
+
+const splitDateInput = (dateInput: string) => {
+    const match = dateInput.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    return {
+        year: match?.[1] || "",
+        month: match?.[2] ? String(Number(match[2])) : "",
+        date: match?.[3] ? String(Number(match[3])) : "",
+    };
+};
+
+const buildDateInput = (year: string, month: string, date: string) => {
+    if (!year || !month || !date) return "";
+    return `${year.padStart(4, "0")}-${month.padStart(2, "0")}-${date.padStart(
+        2,
+        "0"
+    )}`;
 };
 
 export default function CalendarPage() {
@@ -165,6 +191,7 @@ export default function CalendarPage() {
         isAllDay: false,
         color: "primary",
         attendanceMode: "ABSENCE",
+        attendanceDeadline: "",
     });
     const [editForm, setEditForm] = useState<EventForm>({
         title: "",
@@ -183,6 +210,7 @@ export default function CalendarPage() {
         isAllDay: false,
         color: "primary",
         attendanceMode: "ABSENCE",
+        attendanceDeadline: "",
     });
 
     useEffect(() => {
@@ -454,6 +482,39 @@ export default function CalendarPage() {
             isAllDay: !hasTime && hasEndDate,
             color: (values[12] as EventColorId) || "primary",
             attendanceMode: getScheduleAttendanceMode(event),
+            attendanceDeadline:
+                getScheduleAttendanceDeadline(event) ||
+                getDefaultAttendanceDeadline(
+                    `${String(values[1] ?? "").padStart(4, "0")}-${String(
+                        values[2] ?? ""
+                    ).padStart(2, "0")}-${String(values[3] ?? "").padStart(
+                        2,
+                        "0"
+                    )}`
+                ),
+        };
+    };
+
+    const buildAddForm = (date: Date): EventForm => {
+        const startDate = formatDateInput(date);
+        return {
+            title: "",
+            where: "",
+            detail: "",
+            timeHH: "",
+            timeMM: "",
+            endTimeHH: "",
+            endTimeMM: "",
+            year: String(date.getFullYear()),
+            month: String(date.getMonth() + 1),
+            date: String(date.getDate()),
+            endYear: String(date.getFullYear()),
+            endMonth: String(date.getMonth() + 1),
+            endDate: String(date.getDate()),
+            isAllDay: false,
+            color: "primary",
+            attendanceMode: "ABSENCE",
+            attendanceDeadline: getDefaultAttendanceDeadline(startDate),
         };
     };
 
@@ -481,6 +542,7 @@ export default function CalendarPage() {
             if (nextSelectedDate) {
                 setSelectedDate(nextSelectedDate);
                 setSelectedEvent(null);
+                setAddForm(buildAddForm(nextSelectedDate.date));
                 setShowAddModal(true);
                 setShowEditModal(false);
                 setShowDeleteConfirm(false);
@@ -546,6 +608,7 @@ export default function CalendarPage() {
             isAllDay: false,
             color: "primary",
             attendanceMode: "ABSENCE",
+            attendanceDeadline: "",
         });
         setEditForm({
             title: "",
@@ -564,12 +627,16 @@ export default function CalendarPage() {
             isAllDay: false,
             color: "primary",
             attendanceMode: "ABSENCE",
+            attendanceDeadline: "",
         });
         clearUrlModal(["date", "event"]);
     };
 
     // 追加モーダルを開く
     const openAddModal = () => {
+        if (selectedDate) {
+            setAddForm(buildAddForm(selectedDate.date));
+        }
         setShowAddModal(true);
         updateUrlModal({
             modal: "schedule-create",
@@ -598,6 +665,7 @@ export default function CalendarPage() {
             isAllDay: false,
             color: "primary",
             attendanceMode: "ABSENCE",
+            attendanceDeadline: "",
         });
         updateUrlModal({
             modal: "schedule-date",
@@ -629,11 +697,18 @@ export default function CalendarPage() {
                     title: addForm.title.trim(),
                     where: addForm.where.trim(),
                     detail: addForm.detail.trim(),
-                    endYear: addForm.endYear || undefined,
-                    endMonth: addForm.endMonth || undefined,
-                    endDate: addForm.endDate || undefined,
+                    endYear: addForm.isAllDay
+                        ? addForm.endYear || undefined
+                        : undefined,
+                    endMonth: addForm.isAllDay
+                        ? addForm.endMonth || undefined
+                        : undefined,
+                    endDate: addForm.isAllDay
+                        ? addForm.endDate || undefined
+                        : undefined,
                     color: addForm.color,
                     attendanceMode: addForm.attendanceMode,
+                    attendanceDeadline: addForm.attendanceDeadline,
                 }),
             });
 
@@ -660,6 +735,9 @@ export default function CalendarPage() {
                     ATTENDANCE_MODE: scheduleData.attendanceMode || "ABSENCE",
                     END_TIME_HH: scheduleData.endTimeHH || "",
                     END_TIME_MM: scheduleData.endTimeMM || "",
+                    ATTENDANCE_DEADLINE:
+                        scheduleData.attendanceDeadline ||
+                        addForm.attendanceDeadline,
                 };
                 setSchedules((prev) => {
                     const next = [...prev, newSchedule];
@@ -744,6 +822,7 @@ export default function CalendarPage() {
             isAllDay: false,
             color: "primary",
             attendanceMode: "ABSENCE",
+            attendanceDeadline: "",
         });
         if (selectedEvent) {
             updateUrlModal({
@@ -831,11 +910,18 @@ export default function CalendarPage() {
                     title: editForm.title.trim(),
                     where: editForm.where.trim(),
                     detail: editForm.detail.trim(),
-                    endYear: editForm.endYear || undefined,
-                    endMonth: editForm.endMonth || undefined,
-                    endDate: editForm.endDate || undefined,
+                    endYear: editForm.isAllDay
+                        ? editForm.endYear || undefined
+                        : undefined,
+                    endMonth: editForm.isAllDay
+                        ? editForm.endMonth || undefined
+                        : undefined,
+                    endDate: editForm.isAllDay
+                        ? editForm.endDate || undefined
+                        : undefined,
                     color: editForm.color,
                     attendanceMode: editForm.attendanceMode,
+                    attendanceDeadline: editForm.attendanceDeadline,
                 }),
             });
 
@@ -867,6 +953,9 @@ export default function CalendarPage() {
                                 COLOR: scheduleData.color || "primary",
                                 ATTENDANCE_MODE:
                                     scheduleData.attendanceMode || "ABSENCE",
+                                ATTENDANCE_DEADLINE:
+                                    scheduleData.attendanceDeadline ||
+                                    editForm.attendanceDeadline,
                             };
                         }
                         return schedule;
@@ -1865,6 +1954,21 @@ export default function CalendarPage() {
                                                 endTimeMM: e.target.checked
                                                     ? ""
                                                     : addForm.endTimeMM,
+                                                endYear:
+                                                    e.target.checked &&
+                                                    !addForm.endYear
+                                                        ? addForm.year
+                                                        : addForm.endYear,
+                                                endMonth:
+                                                    e.target.checked &&
+                                                    !addForm.endMonth
+                                                        ? addForm.month
+                                                        : addForm.endMonth,
+                                                endDate:
+                                                    e.target.checked &&
+                                                    !addForm.endDate
+                                                        ? addForm.date
+                                                        : addForm.endDate,
                                             })
                                         }
                                     />
@@ -1931,6 +2035,27 @@ export default function CalendarPage() {
                                     </label>
                                 </div>
                             </div>
+                            <div className="form-control">
+                                <label className="label">
+                                    <span className="label-text">
+                                        出欠入力期限
+                                    </span>
+                                </label>
+                                <input
+                                    type="date"
+                                    className="input input-bordered w-full"
+                                    value={addForm.attendanceDeadline}
+                                    onChange={(e) =>
+                                        setAddForm({
+                                            ...addForm,
+                                            attendanceDeadline: e.target.value,
+                                        })
+                                    }
+                                />
+                                <p className="mt-1 text-xs text-base-content/60">
+                                    期限後でも、当日5:00からイベント終了までは入力できます。
+                                </p>
+                            </div>
                             {addForm.isAllDay ? (
                                 <>
                                     <div className="form-control">
@@ -1959,57 +2084,27 @@ export default function CalendarPage() {
                                                 </span>
                                             </span>
                                         </label>
-                                        <div className="flex items-center gap-2">
-                                            <input
-                                                type="number"
-                                                placeholder="年"
-                                                min="2020"
-                                                max="2100"
-                                                className="input input-bordered w-24"
-                                                value={addForm.endYear}
-                                                onChange={(e) =>
-                                                    setAddForm({
-                                                        ...addForm,
-                                                        endYear: e.target.value,
-                                                    })
-                                                }
-                                                required
-                                            />
-                                            <span>年</span>
-                                            <input
-                                                type="number"
-                                                placeholder="月"
-                                                min="1"
-                                                max="12"
-                                                className="input input-bordered w-20"
-                                                value={addForm.endMonth}
-                                                onChange={(e) =>
-                                                    setAddForm({
-                                                        ...addForm,
-                                                        endMonth:
-                                                            e.target.value,
-                                                    })
-                                                }
-                                                required
-                                            />
-                                            <span>月</span>
-                                            <input
-                                                type="number"
-                                                placeholder="日"
-                                                min="1"
-                                                max="31"
-                                                className="input input-bordered w-20"
-                                                value={addForm.endDate}
-                                                onChange={(e) =>
-                                                    setAddForm({
-                                                        ...addForm,
-                                                        endDate: e.target.value,
-                                                    })
-                                                }
-                                                required
-                                            />
-                                            <span>日</span>
-                                        </div>
+                                        <input
+                                            type="date"
+                                            className="input input-bordered w-full"
+                                            value={buildDateInput(
+                                                addForm.endYear,
+                                                addForm.endMonth,
+                                                addForm.endDate
+                                            )}
+                                            onChange={(e) => {
+                                                const next = splitDateInput(
+                                                    e.target.value
+                                                );
+                                                setAddForm({
+                                                    ...addForm,
+                                                    endYear: next.year,
+                                                    endMonth: next.month,
+                                                    endDate: next.date,
+                                                });
+                                            }}
+                                            required
+                                        />
                                     </div>
                                 </>
                             ) : (
@@ -2197,6 +2292,9 @@ export default function CalendarPage() {
                     const rawTimeMM = values[5];
                     const rawEndTimeHH = values[18];
                     const rawEndTimeMM = values[19];
+                    const rawEndYear = values[9];
+                    const rawEndMonth = values[10];
+                    const rawEndDate = values[11];
                     const title = String(values[6] ?? "予定");
                     const where = String(values[7] ?? "");
                     const detail = String(values[8] ?? "");
@@ -2243,6 +2341,18 @@ export default function CalendarPage() {
                         timeLabel && endTimeLabel
                             ? `${timeLabel}-${endTimeLabel}`
                             : timeLabel;
+                    const startDateInput = `${String(year).padStart(4, "0")}-${String(
+                        month
+                    ).padStart(2, "0")}-${String(date).padStart(2, "0")}`;
+                    const endDateInput =
+                        rawEndYear && rawEndMonth && rawEndDate
+                            ? `${String(rawEndYear).padStart(4, "0")}-${String(
+                                  rawEndMonth
+                              ).padStart(2, "0")}-${String(rawEndDate).padStart(
+                                  2,
+                                  "0"
+                              )}`
+                            : undefined;
 
                     const eventAbsences = absences.filter((absence) => {
                         const absenceValues = Object.values(absence);
@@ -2259,6 +2369,13 @@ export default function CalendarPage() {
                             attendanceMode={attendanceMode}
                             dateLabel={dateLabel}
                             timeLabel={timeRangeLabel}
+                            startDate={startDateInput}
+                            endDate={endDateInput}
+                            startTime={timeLabel}
+                            endTime={endTimeLabel}
+                            attendanceDeadline={getScheduleAttendanceDeadline(
+                                selectedEvent
+                            )}
                             defaultOpen={true}
                             onClose={closeEventModal}
                             onEdit={openEditModal}
@@ -2329,6 +2446,21 @@ export default function CalendarPage() {
                                                 endTimeMM: e.target.checked
                                                     ? ""
                                                     : editForm.endTimeMM,
+                                                endYear:
+                                                    e.target.checked &&
+                                                    !editForm.endYear
+                                                        ? editForm.year
+                                                        : editForm.endYear,
+                                                endMonth:
+                                                    e.target.checked &&
+                                                    !editForm.endMonth
+                                                        ? editForm.month
+                                                        : editForm.endMonth,
+                                                endDate:
+                                                    e.target.checked &&
+                                                    !editForm.endDate
+                                                        ? editForm.date
+                                                        : editForm.endDate,
                                             })
                                         }
                                     />
@@ -2402,56 +2534,32 @@ export default function CalendarPage() {
                                         <span className="text-error">*</span>
                                     </span>
                                 </label>
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        type="number"
-                                        placeholder="年"
-                                        min="2020"
-                                        max="2100"
-                                        className="input input-bordered w-24"
-                                        value={editForm.year}
-                                        onChange={(e) =>
-                                            setEditForm({
-                                                ...editForm,
-                                                year: e.target.value,
-                                            })
-                                        }
-                                        required
-                                    />
-                                    <span>年</span>
-                                    <input
-                                        type="number"
-                                        placeholder="月"
-                                        min="1"
-                                        max="12"
-                                        className="input input-bordered w-20"
-                                        value={editForm.month}
-                                        onChange={(e) =>
-                                            setEditForm({
-                                                ...editForm,
-                                                month: e.target.value,
-                                            })
-                                        }
-                                        required
-                                    />
-                                    <span>月</span>
-                                    <input
-                                        type="number"
-                                        placeholder="日"
-                                        min="1"
-                                        max="31"
-                                        className="input input-bordered w-20"
-                                        value={editForm.date}
-                                        onChange={(e) =>
-                                            setEditForm({
-                                                ...editForm,
-                                                date: e.target.value,
-                                            })
-                                        }
-                                        required
-                                    />
-                                    <span>日</span>
-                                </div>
+                                <input
+                                    type="date"
+                                    className="input input-bordered w-full"
+                                    value={buildDateInput(
+                                        editForm.year,
+                                        editForm.month,
+                                        editForm.date
+                                    )}
+                                    onChange={(e) => {
+                                        const next = splitDateInput(
+                                            e.target.value
+                                        );
+                                        setEditForm({
+                                            ...editForm,
+                                            year: next.year,
+                                            month: next.month,
+                                            date: next.date,
+                                            attendanceDeadline:
+                                                editForm.attendanceDeadline ||
+                                                getDefaultAttendanceDeadline(
+                                                    e.target.value
+                                                ),
+                                        });
+                                    }}
+                                    required
+                                />
                             </div>
                             {editForm.isAllDay ? (
                                 <div className="form-control">
@@ -2463,56 +2571,27 @@ export default function CalendarPage() {
                                             </span>
                                         </span>
                                     </label>
-                                    <div className="flex items-center gap-2">
-                                        <input
-                                            type="number"
-                                            placeholder="年"
-                                            min="2020"
-                                            max="2100"
-                                            className="input input-bordered w-24"
-                                            value={editForm.endYear}
-                                            onChange={(e) =>
-                                                setEditForm({
-                                                    ...editForm,
-                                                    endYear: e.target.value,
-                                                })
-                                            }
-                                            required
-                                        />
-                                        <span>年</span>
-                                        <input
-                                            type="number"
-                                            placeholder="月"
-                                            min="1"
-                                            max="12"
-                                            className="input input-bordered w-20"
-                                            value={editForm.endMonth}
-                                            onChange={(e) =>
-                                                setEditForm({
-                                                    ...editForm,
-                                                    endMonth: e.target.value,
-                                                })
-                                            }
-                                            required
-                                        />
-                                        <span>月</span>
-                                        <input
-                                            type="number"
-                                            placeholder="日"
-                                            min="1"
-                                            max="31"
-                                            className="input input-bordered w-20"
-                                            value={editForm.endDate}
-                                            onChange={(e) =>
-                                                setEditForm({
-                                                    ...editForm,
-                                                    endDate: e.target.value,
-                                                })
-                                            }
-                                            required
-                                        />
-                                        <span>日</span>
-                                    </div>
+                                    <input
+                                        type="date"
+                                        className="input input-bordered w-full"
+                                        value={buildDateInput(
+                                            editForm.endYear,
+                                            editForm.endMonth,
+                                            editForm.endDate
+                                        )}
+                                        onChange={(e) => {
+                                            const next = splitDateInput(
+                                                e.target.value
+                                            );
+                                            setEditForm({
+                                                ...editForm,
+                                                endYear: next.year,
+                                                endMonth: next.month,
+                                                endDate: next.date,
+                                            });
+                                        }}
+                                        required
+                                    />
                                 </div>
                             ) : (
                                 <div className="grid gap-4 sm:grid-cols-2">
@@ -2533,8 +2612,7 @@ export default function CalendarPage() {
                                                 onChange={(e) =>
                                                     setEditForm({
                                                         ...editForm,
-                                                        timeHH:
-                                                            e.target.value,
+                                                        timeHH: e.target.value,
                                                     })
                                                 }
                                             />
@@ -2549,8 +2627,7 @@ export default function CalendarPage() {
                                                 onChange={(e) =>
                                                     setEditForm({
                                                         ...editForm,
-                                                        timeMM:
-                                                            e.target.value,
+                                                        timeMM: e.target.value,
                                                     })
                                                 }
                                             />
@@ -2598,6 +2675,27 @@ export default function CalendarPage() {
                                     </div>
                                 </div>
                             )}
+                            <div className="form-control">
+                                <label className="label">
+                                    <span className="label-text">
+                                        出欠入力期限
+                                    </span>
+                                </label>
+                                <input
+                                    type="date"
+                                    className="input input-bordered w-full"
+                                    value={editForm.attendanceDeadline}
+                                    onChange={(e) =>
+                                        setEditForm({
+                                            ...editForm,
+                                            attendanceDeadline: e.target.value,
+                                        })
+                                    }
+                                />
+                                <p className="mt-1 text-xs text-base-content/60">
+                                    期限後でも、当日5:00からイベント終了までは入力できます。
+                                </p>
+                            </div>
                             <div className="form-control">
                                 <label className="label">
                                     <span className="label-text">場所</span>

--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -171,6 +171,9 @@ export default async function HomePage() {
                                             const rawTimeMM = values[5]; // F列 (TIME_MM)
                                             const rawEndTimeHH = values[18]; // S列 (END_TIME_HH)
                                             const rawEndTimeMM = values[19]; // T列 (END_TIME_MM)
+                                            const rawEndYear = values[9];
+                                            const rawEndMonth = values[10];
+                                            const rawEndDate = values[11];
                                             const title = String(
                                                 values[6] ?? "予定"
                                             ); // G列 (TITLE)
@@ -231,6 +234,13 @@ export default async function HomePage() {
                                                 timeLabel && endTimeLabel
                                                     ? `${timeLabel}-${endTimeLabel}`
                                                     : timeLabel;
+                                            const startDateInput = `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(date).padStart(2, "0")}`;
+                                            const endDateInput =
+                                                rawEndYear &&
+                                                rawEndMonth &&
+                                                rawEndDate
+                                                    ? `${String(rawEndYear).padStart(4, "0")}-${String(rawEndMonth).padStart(2, "0")}-${String(rawEndDate).padStart(2, "0")}`
+                                                    : undefined;
 
                                             // このイベントの欠席者をフィルタリング
                                             // absence_data シートの列構成: A:タイムスタンプ, B:EVENT_ID, C:学籍番号, D:氏名...
@@ -264,6 +274,14 @@ export default async function HomePage() {
                                                     }
                                                     dateLabel={dateLabel}
                                                     timeLabel={timeRangeLabel}
+                                                    startDate={startDateInput}
+                                                    endDate={endDateInput}
+                                                    startTime={timeLabel}
+                                                    endTime={endTimeLabel}
+                                                    attendanceDeadline={String(
+                                                        schedule.ATTENDANCE_DEADLINE ??
+                                                            ""
+                                                    )}
                                                 />
                                             );
                                         }

--- a/app/api/absence/route.ts
+++ b/app/api/absence/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/src/shared/lib/validation";
 import { validateOrigin, validateContentType } from "@/src/shared/lib/csrf";
 import { sendDiscordWebhook } from "@/src/shared/lib/discord";
+import { isAttendanceResponseAllowed } from "@/src/shared/lib/schedule-deadline";
 
 import { getBackendApiHeaders, getBackendApiUrl } from "@/src/shared/lib/server-env";
 
@@ -72,6 +73,81 @@ const postToBackend = async (path: string, body: unknown) => {
             error: `Backend API returned non-JSON response: ${response.status}`,
         };
     }
+};
+
+const fetchScheduleByEventId = async (eventId: string) => {
+    if (!BACKEND_API_URL || !eventId) return null;
+
+    const url = new URL(BACKEND_API_URL);
+    url.searchParams.append("path", "schedules");
+
+    const response = await fetch(url.toString(), {
+        method: "GET",
+        cache: "no-store",
+        headers: getBackendApiHeaders(),
+    });
+    const data = (await response.json()) as {
+        success?: boolean;
+        data?: Array<Record<string, unknown>>;
+    };
+    if (!response.ok || !data.success || !Array.isArray(data.data)) {
+        return null;
+    }
+
+    return (
+        data.data.find(
+            (schedule) => String(schedule.EVENT_ID ?? "") === eventId
+        ) || null
+    );
+};
+
+const getScheduleResponseWindow = (schedule: Record<string, unknown>) => ({
+    startDate:
+        schedule.YYYY && schedule.MM && schedule.DD
+            ? `${String(schedule.YYYY).padStart(4, "0")}-${String(
+                  schedule.MM
+              ).padStart(2, "0")}-${String(schedule.DD).padStart(2, "0")}`
+            : "",
+    endDate:
+        schedule.END_YYYY && schedule.END_MM && schedule.END_DD
+            ? `${String(schedule.END_YYYY).padStart(4, "0")}-${String(
+                  schedule.END_MM
+              ).padStart(2, "0")}-${String(schedule.END_DD).padStart(2, "0")}`
+            : "",
+    startTime:
+        schedule.TIME_HH !== "" &&
+        schedule.TIME_HH !== null &&
+        schedule.TIME_HH !== undefined
+            ? `${String(schedule.TIME_HH).padStart(2, "0")}:${String(
+                  schedule.TIME_MM || "0"
+              ).padStart(2, "0")}`
+            : "",
+    endTime:
+        schedule.END_TIME_HH !== "" &&
+        schedule.END_TIME_HH !== null &&
+        schedule.END_TIME_HH !== undefined
+            ? `${String(schedule.END_TIME_HH).padStart(2, "0")}:${String(
+                  schedule.END_TIME_MM || "0"
+              ).padStart(2, "0")}`
+            : "",
+    deadlineDate: String(schedule.ATTENDANCE_DEADLINE ?? ""),
+});
+
+const validateAttendanceDeadline = async (eventId: string) => {
+    const schedule = await fetchScheduleByEventId(eventId);
+    if (!schedule) return null;
+
+    if (isAttendanceResponseAllowed(getScheduleResponseWindow(schedule))) {
+        return null;
+    }
+
+    return NextResponse.json(
+        {
+            success: false,
+            error: "この予定の出欠連絡期限を過ぎています",
+        },
+        { status: 403 }
+    );
 };
 
 const getAbsenceColor = (type: AbsenceSubmitData["type"]) => {
@@ -231,6 +307,11 @@ export async function POST(request: NextRequest) {
         }
 
         const validatedData = validationResult.data;
+        const deadlineError = await validateAttendanceDeadline(
+            validatedData.eventId
+        );
+        if (deadlineError) return deadlineError;
+
         const data = await postToBackend("absences", validatedData);
 
         if (data?.success === true) {
@@ -296,6 +377,11 @@ export async function PUT(request: NextRequest) {
                 { status: 400 }
             );
         }
+
+        const deadlineError = await validateAttendanceDeadline(
+            validationResult.data.eventId
+        );
+        if (deadlineError) return deadlineError;
 
         const data = await postToBackend("absences/update", validationResult.data);
 

--- a/cloudflare/nb-portal-api/migrations/0008_schedule_attendance_deadline.sql
+++ b/cloudflare/nb-portal-api/migrations/0008_schedule_attendance_deadline.sql
@@ -1,0 +1,5 @@
+ALTER TABLE schedules ADD COLUMN attendance_deadline TEXT;
+
+UPDATE schedules
+SET attendance_deadline = date(date, '-2 days')
+WHERE attendance_deadline IS NULL OR attendance_deadline = '';

--- a/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
+++ b/cloudflare/nb-portal-api/scripts/build-import-sql.mjs
@@ -108,6 +108,14 @@ const buildDate = (year, month, day) => {
 	return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
 };
 
+const addDays = (dateString, days) => {
+	const match = String(dateString ?? "").match(/^(\d{4})-(\d{2})-(\d{2})$/);
+	if (!match) return "";
+	const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+	date.setDate(date.getDate() + days);
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+};
+
 const buildTime = (hour, minute) => {
 	const h = String(hour ?? "").trim();
 	const m = String(minute ?? "").trim();
@@ -158,14 +166,15 @@ for (const member of readCsv(files.members)) {
 for (const schedule of readCsv(files.schedules)) {
 	const eventId = schedule.EVENT_ID;
 	if (!eventId) continue;
+	const startDate = buildDate(schedule.YYYY, schedule.MM, schedule.DD);
 
 	statements.push(`INSERT INTO schedules (
-  id, title, date, end_date, start_time, end_time, location, description, color, attendance_mode,
+  id, title, date, end_date, start_time, end_time, location, description, color, attendance_mode, attendance_deadline,
   is_past, created_by, created_at, updated_by, updated_at
 ) VALUES (
   ${sqlString(eventId)},
   ${sqlString(schedule.TITLE)},
-  ${sqlString(buildDate(schedule.YYYY, schedule.MM, schedule.DD))},
+  ${sqlString(startDate)},
   ${sqlNullableString(buildDate(schedule.END_YYYY, schedule.END_MM, schedule.END_DD))},
   ${sqlNullableString(buildTime(schedule.TIME_HH, schedule.TIME_MM))},
   ${sqlNullableString(buildTime(schedule.END_TIME_HH, schedule.END_TIME_MM))},
@@ -173,7 +182,8 @@ for (const schedule of readCsv(files.schedules)) {
   ${sqlNullableString(schedule.DETAIL)},
   ${sqlString(schedule.COLOR || "primary")},
   ${sqlString(schedule.ATTENDANCE_MODE || "ABSENCE")},
-  ${buildDate(schedule.YYYY, schedule.MM, schedule.DD) < todayJst ? "1" : "0"},
+  ${sqlString(schedule.ATTENDANCE_DEADLINE || addDays(startDate, -2))},
+  ${startDate < todayJst ? "1" : "0"},
   ${sqlNullableString(schedule.CREATED_BY)},
   ${sqlString(parseSpreadsheetDateTime(schedule.CREATED_AT) || new Date().toISOString())},
   ${sqlNullableString(schedule.UPDATED_BY)},

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -50,6 +50,7 @@ type ScheduleRow = {
 	description: string | null;
 	color: string | null;
 	attendance_mode: string;
+	attendance_deadline: string | null;
 	is_past: number;
 	created_by: string | null;
 	created_at: string;
@@ -243,6 +244,23 @@ const getJstTimestamp = (date = new Date()) => {
 const toScheduleIsPast = (date: string, endDate?: string | null) =>
 	(endDate || date) < getJstDateParts().date ? 1 : 0;
 
+const getDefaultAttendanceDeadline = (date: string) => {
+	const parsed = parseDateInput(date);
+	if (!parsed) return null;
+	parsed.setDate(parsed.getDate() - 2);
+	const year = parsed.getFullYear();
+	const month = String(parsed.getMonth() + 1).padStart(2, "0");
+	const day = String(parsed.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+};
+
+const normalizeAttendanceDeadline = (value: unknown, date: string) => {
+	const deadline = String(value ?? "").trim();
+	return /^\d{4}-\d{2}-\d{2}$/.test(deadline)
+		? deadline
+		: getDefaultAttendanceDeadline(date);
+};
+
 const generatePrefixedId = (prefix: string) =>
 	`${prefix}-${crypto.randomUUID().toUpperCase()}`;
 
@@ -288,6 +306,8 @@ const toScheduleResponse = (row: ScheduleRow) => {
 		END_TIME_HH: endTime.hour,
 		END_TIME_MM: endTime.minute,
 		IS_PAST: row.is_past === 1,
+		ATTENDANCE_DEADLINE:
+			row.attendance_deadline || getDefaultAttendanceDeadline(row.date) || "",
 	};
 };
 
@@ -486,7 +506,7 @@ const verifyMember = async (url: URL, env: Env) => {
 const getSchedules = async (env: Env) => {
 	const rows = await env.DB.prepare(
 		`SELECT id, title, date, end_date, start_time, end_time, location, description,
-			color, attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+			color, attendance_mode, attendance_deadline, is_past, created_by, created_at, updated_by, updated_at
 		FROM schedules
 		ORDER BY date, start_time, id`
 	).all<ScheduleRow>();
@@ -504,13 +524,17 @@ const createSchedule = async (request: Request, env: Env) => {
 	const date = buildDate(body.year, body.month, body.date);
 	const endDate = buildDate(body.endYear, body.endMonth, body.endDate) || null;
 	if (!date) return error("Schedule date is required", 400);
+	const attendanceDeadline = normalizeAttendanceDeadline(
+		body.attendanceDeadline,
+		date
+	);
 
 	await env.DB.prepare(
 		`INSERT INTO schedules (
 			id, title, date, end_date, start_time, end_time, location, description,
-			color, attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+			color, attendance_mode, attendance_deadline, is_past, created_by, created_at, updated_by, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ${JST_SQL_TIMESTAMP}, ?, ${JST_SQL_TIMESTAMP})`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ${JST_SQL_TIMESTAMP}, ?, ${JST_SQL_TIMESTAMP})`
 	)
 		.bind(
 			eventId,
@@ -523,6 +547,7 @@ const createSchedule = async (request: Request, env: Env) => {
 			String(body.detail ?? "").trim(),
 			String(body.color ?? "primary").trim() || "primary",
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
+			attendanceDeadline,
 			toScheduleIsPast(date, endDate),
 			String(body.createdBy ?? "").trim(),
 			String(body.createdBy ?? "").trim()
@@ -546,6 +571,7 @@ const createSchedule = async (request: Request, env: Env) => {
 		endDate: String(body.endDate ?? ""),
 		color: String(body.color ?? "primary"),
 		attendanceMode: String(body.attendanceMode ?? "ABSENCE"),
+		attendanceDeadline: attendanceDeadline || "",
 	});
 };
 
@@ -557,11 +583,15 @@ const updateSchedule = async (request: Request, env: Env) => {
 	const date = buildDate(body.year, body.month, body.date);
 	const endDate = buildDate(body.endYear, body.endMonth, body.endDate) || null;
 	if (!date) return error("Schedule date is required", 400);
+	const attendanceDeadline = normalizeAttendanceDeadline(
+		body.attendanceDeadline,
+		date
+	);
 
 	await env.DB.prepare(
 		`UPDATE schedules SET
 			title = ?, date = ?, end_date = ?, start_time = ?, end_time = ?, location = ?,
-			description = ?, color = ?, attendance_mode = ?, is_past = ?, updated_by = ?, updated_at = ${JST_SQL_TIMESTAMP}
+			description = ?, color = ?, attendance_mode = ?, attendance_deadline = ?, is_past = ?, updated_by = ?, updated_at = ${JST_SQL_TIMESTAMP}
 		WHERE id = ?`
 	)
 		.bind(
@@ -574,6 +604,7 @@ const updateSchedule = async (request: Request, env: Env) => {
 			String(body.detail ?? "").trim(),
 			String(body.color ?? "primary").trim() || "primary",
 			String(body.attendanceMode ?? "ABSENCE").trim() || "ABSENCE",
+			attendanceDeadline,
 			toScheduleIsPast(date, endDate),
 			String(body.updatedBy ?? "").trim(),
 			eventId
@@ -597,6 +628,7 @@ const updateSchedule = async (request: Request, env: Env) => {
 		endDate: String(body.endDate ?? ""),
 		color: String(body.color ?? "primary"),
 		attendanceMode: String(body.attendanceMode ?? "ABSENCE"),
+		attendanceDeadline: attendanceDeadline || "",
 	});
 };
 
@@ -743,9 +775,9 @@ const updateNextMeeting = async (request: Request, env: Env) => {
 	await env.DB.prepare(
 		`INSERT INTO schedules (
 			id, title, date, end_date, start_time, end_time, location, description,
-			color, attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+			color, attendance_mode, attendance_deadline, is_past, created_by, created_at, updated_by, updated_at
 		)
-		VALUES (?, '部会', ?, NULL, ?, NULL, ?, '次回部会', 'primary', 'ABSENCE', ?, ?, ${JST_SQL_TIMESTAMP}, ?, ${JST_SQL_TIMESTAMP})
+		VALUES (?, '部会', ?, NULL, ?, NULL, ?, '次回部会', 'primary', 'ABSENCE', ?, ?, ?, ${JST_SQL_TIMESTAMP}, ?, ${JST_SQL_TIMESTAMP})
 		ON CONFLICT(id) DO UPDATE SET
 			title = excluded.title,
 			date = excluded.date,
@@ -756,6 +788,7 @@ const updateNextMeeting = async (request: Request, env: Env) => {
 			description = excluded.description,
 			color = excluded.color,
 			attendance_mode = excluded.attendance_mode,
+			attendance_deadline = excluded.attendance_deadline,
 			is_past = excluded.is_past,
 			updated_by = excluded.updated_by,
 			updated_at = ${JST_SQL_TIMESTAMP}`
@@ -765,6 +798,7 @@ const updateNextMeeting = async (request: Request, env: Env) => {
 			date,
 			time,
 			mode === "DISCORD" ? "Discord" : "対面",
+			getDefaultAttendanceDeadline(date),
 			toScheduleIsPast(date),
 			updatedBy,
 			updatedBy
@@ -811,7 +845,7 @@ const getDashboardData = async (env: Env) => {
 		env.DB.prepare("SELECT * FROM absences ORDER BY submitted_at").all<AbsenceRow>(),
 		env.DB.prepare(
 			`SELECT id, title, date, start_time, end_time, location, description,
-				attendance_mode, is_past, created_by, created_at, updated_by, updated_at
+				end_date, color, attendance_mode, attendance_deadline, is_past, created_by, created_at, updated_by, updated_at
 			FROM schedules
 			ORDER BY date, start_time, id`
 		).all<ScheduleRow>(),

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -25,6 +25,7 @@ describe("Hello World worker", () => {
 				description TEXT,
 				color TEXT NOT NULL DEFAULT 'primary',
 				attendance_mode TEXT NOT NULL DEFAULT 'ABSENCE',
+				attendance_deadline TEXT,
 				created_by TEXT,
 				updated_by TEXT,
 				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -122,6 +123,7 @@ describe("Hello World worker", () => {
 			TIME_HH: "18",
 			TIME_MM: "0",
 			WHERE: "Discord",
+			ATTENDANCE_DEADLINE: "2099-01-21",
 		});
 	});
 
@@ -141,6 +143,7 @@ describe("Hello World worker", () => {
 				detail: "終日イベント",
 				color: "green",
 				attendanceMode: "ABSENCE",
+				attendanceDeadline: "2099-02-08",
 				createdBy: "test",
 			}),
 		});
@@ -184,6 +187,7 @@ describe("Hello World worker", () => {
 			END_YYYY: "2099",
 			END_MM: "2",
 			END_DD: "12",
+			ATTENDANCE_DEADLINE: "2099-02-08",
 			IS_PAST: false,
 		});
 	});

--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -17,6 +17,10 @@ import type {
 } from "@/src/shared/types/api";
 import { AppModal } from "@/src/shared/ui/AppModal";
 import { useUrlModal } from "@/src/shared/lib/use-url-modal";
+import {
+    getAttendanceDeadlineLabel,
+    isAttendanceResponseAllowed,
+} from "@/src/shared/lib/schedule-deadline";
 
 type AbsenceFormState = {
     type: string;
@@ -108,6 +112,11 @@ interface ScheduleCardProps {
     attendanceMode?: ScheduleAttendanceMode;
     currentStudentNumber?: string | null;
     currentDisplayName?: string | null;
+    startDate?: string;
+    endDate?: string;
+    startTime?: string;
+    endTime?: string;
+    attendanceDeadline?: string;
     dateLabel?: string;
     timeLabel?: string;
     defaultOpen?: boolean;
@@ -126,6 +135,11 @@ export default function ScheduleCard({
     attendanceMode = "ABSENCE",
     currentStudentNumber,
     currentDisplayName,
+    startDate,
+    endDate,
+    startTime,
+    endTime,
+    attendanceDeadline,
     dateLabel,
     timeLabel,
     defaultOpen = false,
@@ -171,6 +185,23 @@ export default function ScheduleCard({
     const attendanceDateTimeLabel = [dateLabel, timeLabel]
         .filter(Boolean)
         .join(" ");
+    const canSubmitResponse = isAttendanceResponseAllowed({
+        startDate,
+        endDate,
+        startTime,
+        endTime,
+        deadlineDate: attendanceDeadline,
+    });
+    const attendanceDeadlineLabel = getAttendanceDeadlineLabel({
+        startDate,
+        endDate,
+        startTime,
+        endTime,
+        deadlineDate: attendanceDeadline,
+    });
+    const responseClosedMessage = attendanceDeadlineLabel
+        ? `出欠入力期限は${attendanceDeadlineLabel}です。期限後は当日5:00からイベント終了まで入力できます。`
+        : "現在は出欠入力の受付時間外です。";
     const normalizedStudentNumber = profile.studentNumber.trim().toLowerCase();
     const displayedAbsences = dedupeAbsencesByStudent(localAbsences);
     const ownResponse =
@@ -325,6 +356,10 @@ export default function ScheduleCard({
     };
 
     const openAttendanceForm = () => {
+        if (!canSubmitResponse) {
+            setAttendanceSubmitMessage(responseClosedMessage);
+            return;
+        }
         setAttendanceSubmitMessage(null);
         setAttendanceNote(ownResponse?.reasonDetail || "");
         setIsAttendanceConfirmOpen(true);
@@ -332,6 +367,10 @@ export default function ScheduleCard({
     };
 
     const openAbsenceForm = () => {
+        if (!canSubmitResponse) {
+            setAbsenceSubmitMessage(responseClosedMessage);
+            return;
+        }
         setAbsenceSubmitMessage(null);
         setAbsenceForm(
             ownResponse
@@ -350,6 +389,10 @@ export default function ScheduleCard({
     };
 
     const submitAttendance = async () => {
+        if (!canSubmitResponse) {
+            setAttendanceSubmitMessage(responseClosedMessage);
+            return;
+        }
         setIsAttendanceSubmitting(true);
         setAttendanceSubmitMessage(null);
 
@@ -405,6 +448,10 @@ export default function ScheduleCard({
 
     const submitAbsence = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
+        if (!canSubmitResponse) {
+            setAbsenceSubmitMessage(responseClosedMessage);
+            return;
+        }
         setIsAbsenceSubmitting(true);
         setAbsenceSubmitMessage(null);
 
@@ -1033,6 +1080,11 @@ export default function ScheduleCard({
                                     >
                                         {responseSectionTitle}
                                     </h4>
+                                    {!canSubmitResponse && (
+                                        <div className="alert alert-warning mb-3">
+                                            <span>{responseClosedMessage}</span>
+                                        </div>
+                                    )}
                                     {displayedAbsences.length > 0 ? (
                                         <div className="space-y-2">
                                             {displayedAbsences.map(
@@ -1095,7 +1147,8 @@ export default function ScheduleCard({
                                                                             disabled={
                                                                                 isAttendanceSubmitting ||
                                                                                 isAbsenceSubmitting ||
-                                                                                isDeletingResponse
+                                                                                isDeletingResponse ||
+                                                                                !canSubmitResponse
                                                                             }
                                                                         >
                                                                             編集
@@ -1157,17 +1210,29 @@ export default function ScheduleCard({
                                             type="button"
                                             className="btn btn-primary"
                                             onClick={openAttendanceForm}
-                                            disabled={!!ownResponse}
+                                            disabled={
+                                                !!ownResponse ||
+                                                !canSubmitResponse
+                                            }
                                         >
-                                            {ownResponse ? "申告済み" : actionLabel}
+                                            {ownResponse
+                                                ? "申告済み"
+                                                : canSubmitResponse
+                                                  ? actionLabel
+                                                  : "受付時間外"}
                                         </button>
                                     ) : (
                                         <button
                                             type="button"
                                             className="btn btn-primary"
                                             onClick={openAbsenceForm}
+                                            disabled={!canSubmitResponse}
                                         >
-                                            {ownResponse ? "連絡を編集" : actionLabel}
+                                            {ownResponse
+                                                ? "連絡を編集"
+                                                : canSubmitResponse
+                                                  ? actionLabel
+                                                  : "受付時間外"}
                                         </button>
                                     )}
                                 </div>

--- a/src/shared/lib/schedule-deadline.ts
+++ b/src/shared/lib/schedule-deadline.ts
@@ -1,0 +1,92 @@
+type AttendanceResponseWindow = {
+    startDate?: string | null;
+    endDate?: string | null;
+    startTime?: string | null;
+    endTime?: string | null;
+    deadlineDate?: string | null;
+};
+
+const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const TIME_PATTERN = /^(\d{1,2}):(\d{2})$/;
+
+export const formatDateInput = (date: Date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+};
+
+export const addDaysToDateInput = (dateInput: string, days: number) => {
+    const match = dateInput.match(DATE_PATTERN);
+    if (!match) return "";
+
+    const date = new Date(
+        Number(match[1]),
+        Number(match[2]) - 1,
+        Number(match[3])
+    );
+    date.setDate(date.getDate() + days);
+    return formatDateInput(date);
+};
+
+export const getDefaultAttendanceDeadline = (startDate: string) =>
+    addDaysToDateInput(startDate, -2);
+
+const normalizeTime = (time: string | null | undefined, fallback: string) => {
+    const match = String(time ?? "").match(TIME_PATTERN);
+    if (!match) return fallback;
+
+    return `${match[1].padStart(2, "0")}:${match[2]}`;
+};
+
+const jstDateTime = (date: string, time: string) =>
+    new Date(`${date}T${time}:00+09:00`);
+
+export const getAttendanceResponseWindow = ({
+    startDate,
+    endDate,
+    endTime,
+    deadlineDate,
+}: AttendanceResponseWindow) => {
+    const normalizedStartDate = String(startDate ?? "");
+    if (!DATE_PATTERN.test(normalizedStartDate)) return null;
+
+    const normalizedEndDate = DATE_PATTERN.test(String(endDate ?? ""))
+        ? String(endDate)
+        : normalizedStartDate;
+    const normalizedDeadlineDate = DATE_PATTERN.test(String(deadlineDate ?? ""))
+        ? String(deadlineDate)
+        : getDefaultAttendanceDeadline(normalizedStartDate);
+
+    return {
+        deadlineEnd: jstDateTime(normalizedDeadlineDate, "23:59"),
+        sameDayStart: jstDateTime(normalizedStartDate, "05:00"),
+        eventEnd: jstDateTime(
+            normalizedEndDate,
+            normalizeTime(endTime, "23:59")
+        ),
+        deadlineDate: normalizedDeadlineDate,
+    };
+};
+
+export const isAttendanceResponseAllowed = (
+    windowInput: AttendanceResponseWindow,
+    now = new Date()
+) => {
+    const window = getAttendanceResponseWindow(windowInput);
+    if (!window) return true;
+
+    return (
+        now <= window.deadlineEnd ||
+        (now >= window.sameDayStart && now <= window.eventEnd)
+    );
+};
+
+export const getAttendanceDeadlineLabel = (
+    windowInput: AttendanceResponseWindow
+) => {
+    const window = getAttendanceResponseWindow(windowInput);
+    if (!window) return "";
+
+    return window.deadlineDate.replaceAll("-", "/");
+};


### PR DESCRIPTION
## 概要
- スケジュールに出欠入力期限を追加
- 作成・編集モーダルで期限日を設定できるように変更
- 期限後でも当日5:00からイベント終了までは出欠入力できるように制御
- D1に `attendance_deadline` カラムを追加し、既存スケジュールへデフォルト期限を設定

## 確認
- `npm run build`
- `npm test`（cloudflare/nb-portal-api）