### PR TITLE
出欠表示のバッジ配置を調整

### DIFF
--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -2052,9 +2052,11 @@ export default function CalendarPage() {
                                         })
                                     }
                                 />
-                                <p className="mt-1 text-xs text-base-content/60">
-                                    期限後でも、当日5:00からイベント終了までは入力できます。
-                                </p>
+                                {addForm.attendanceMode === "ABSENCE" && (
+                                    <p className="mt-1 text-xs text-base-content/60">
+                                        期限後でも、当日5:00からイベント終了までは入力できます。
+                                    </p>
+                                )}
                             </div>
                             {addForm.isAllDay ? (
                                 <>
@@ -2692,9 +2694,11 @@ export default function CalendarPage() {
                                         })
                                     }
                                 />
-                                <p className="mt-1 text-xs text-base-content/60">
-                                    期限後でも、当日5:00からイベント終了までは入力できます。
-                                </p>
+                                {editForm.attendanceMode === "ABSENCE" && (
+                                    <p className="mt-1 text-xs text-base-content/60">
+                                        期限後でも、当日5:00からイベント終了までは入力できます。
+                                    </p>
+                                )}
                             </div>
                             <div className="form-control">
                                 <label className="label">

--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -200,7 +200,9 @@ export default function ScheduleCard({
         deadlineDate: attendanceDeadline,
     });
     const responseClosedMessage = attendanceDeadlineLabel
-        ? `出欠入力期限は${attendanceDeadlineLabel}です。期限後は当日5:00からイベント終了まで入力できます。`
+        ? isAttendanceEvent
+            ? `出席申告の期限は${attendanceDeadlineLabel}です。`
+            : `出欠入力期限は${attendanceDeadlineLabel}です。期限後は当日5:00からイベント終了まで入力できます。`
         : "現在は出欠入力の受付時間外です。";
     const normalizedStudentNumber = profile.studentNumber.trim().toLowerCase();
     const displayedAbsences = dedupeAbsencesByStudent(localAbsences);
@@ -1106,25 +1108,29 @@ export default function ScheduleCard({
                                                             <div className="flex items-start justify-between gap-3">
                                                                 <div>
                                                                     <div
-                                                                        className="font-medium text-base-content"
+                                                                        className="grid items-center gap-2 text-base-content [grid-template-columns:minmax(7rem,12rem)_auto_minmax(0,1fr)]"
                                                                         style={{
                                                                             fontSize:
                                                                                 "clamp(0.875rem, 2vw, 1rem)",
                                                                         }}
                                                                     >
-                                                                        {
-                                                                            values.name
-                                                                        }{" "}
-                                                                        <span className="badge badge-primary badge-sm ml-2">
+                                                                        <span className="font-medium break-words">
                                                                             {
-                                                                                values.type
+                                                                                values.name
                                                                             }
                                                                         </span>
-                                                                        {isOwnResponse && (
-                                                                            <span className="badge badge-outline badge-sm ml-2">
-                                                                                自分
+                                                                        <span className="flex flex-wrap items-center gap-2">
+                                                                            <span className="badge badge-primary badge-sm">
+                                                                                {
+                                                                                    values.type
+                                                                                }
                                                                             </span>
-                                                                        )}
+                                                                            {isOwnResponse && (
+                                                                                <span className="badge badge-outline badge-sm">
+                                                                                    自分
+                                                                                </span>
+                                                                            )}
+                                                                        </span>
                                                                     </div>
                                                                     {values.reasonDetail && (
                                                                         <p className="mt-1 text-sm text-base-content/70 whitespace-pre-wrap break-words">


### PR DESCRIPTION
## 概要
- 出欠一覧の名前列とバッジ列を分け、出席/欠席バッジの位置を揃える
- 自分の出欠レコードには `自分` バッジを表示する
- 希望者参加の出席申告では、当日5:00以降の補足文を表示しない

## 確認
- `npm run build`