### PR TITLE
部会メモの入力UIとDiscord向け出力を改善

### DIFF
--- a/app/(authenticated)/memo/page.tsx
+++ b/app/(authenticated)/memo/page.tsx
@@ -4,8 +4,8 @@ import { MeetingMemoForm } from "@/features/meeting-memo";
 
 export default function MemoPage() {
     return (
-        <div className="p-4 lg:p-6 w-full">
-            <div className="max-w-4xl mx-auto">
+        <div className="w-full px-4 py-5 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-5xl">
                 {/* ヘッダー */}
                 <div className="flex items-center gap-3 mb-6">
                     <FontAwesomeIcon

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",

--- a/src/features/meeting-memo/ui/MeetingMemoForm.tsx
+++ b/src/features/meeting-memo/ui/MeetingMemoForm.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    faCirclePlus,
+    faTrashCan,
+    faXmark,
+} from "@fortawesome/free-solid-svg-icons";
 import {
     CACHE_TTL_MS,
     CLIENT_CACHE_KEYS,
@@ -16,11 +22,21 @@ import {
 
 const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"] as const;
 const LOCATIONS = ["Discord", "クラブ棟前", "部室", "その他"] as const;
+const SECTION_CLASS = "space-y-4 border-b border-base-300 px-2 pb-8 sm:px-4";
+const FIELD_LABEL_CLASS = "block text-sm font-medium text-base-content/70";
+const DATE_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 interface ScheduleItem {
     id: string;
     title: string;
-    details: string;
+    details?: string;
+    detailBlocks: ScheduleDetailBlock[];
+}
+
+interface ScheduleDetailBlock {
+    id: string;
+    heading: string;
+    body: string;
 }
 
 interface MemoFormData {
@@ -49,7 +65,13 @@ const createDefaultFormData = (): MemoFormData => {
         time: "21:00",
         location: "Discord",
         customLocation: "",
-        scheduleItems: [{ id: generateId(), title: "", details: "" }],
+        scheduleItems: [
+            {
+                id: generateId(),
+                title: "",
+                detailBlocks: [{ id: generateId(), heading: "", body: "" }],
+            },
+        ],
         accountingNote: "@部費滞納者\n計画的に部費の支払いをお願いします",
         bundanNote: "特になし",
         otherNote: "",
@@ -68,7 +90,8 @@ const normalizeDraft = (draft: Partial<MemoFormData>): MemoFormData => {
                 item &&
                 typeof item.id === "string" &&
                 typeof item.title === "string" &&
-                typeof item.details === "string"
+                (typeof item.details === "string" ||
+                    Array.isArray(item.detailBlocks))
         )
             ? draft.scheduleItems
                   .filter(
@@ -76,12 +99,47 @@ const normalizeDraft = (draft: Partial<MemoFormData>): MemoFormData => {
                           !!item &&
                           typeof item.id === "string" &&
                           typeof item.title === "string" &&
-                          typeof item.details === "string"
+                          (typeof item.details === "string" ||
+                              Array.isArray(item.detailBlocks))
                   )
                   .map((item) => ({
                       id: item.id || generateId(),
                       title: item.title,
-                      details: item.details,
+                      detailBlocks:
+                          Array.isArray(item.detailBlocks) &&
+                          item.detailBlocks.some(
+                              (block) =>
+                                  block &&
+                                  typeof block.id === "string" &&
+                                  typeof block.heading === "string" &&
+                                  typeof block.body === "string"
+                          )
+                              ? item.detailBlocks
+                                    .filter(
+                                        (
+                                            block
+                                        ): block is ScheduleDetailBlock =>
+                                            !!block &&
+                                            typeof block.id === "string" &&
+                                            typeof block.heading ===
+                                                "string" &&
+                                            typeof block.body === "string"
+                                    )
+                                    .map((block) => ({
+                                        id: block.id || generateId(),
+                                        heading: block.heading,
+                                        body: block.body,
+                                    }))
+                              : [
+                                    {
+                                        id: generateId(),
+                                        heading: "",
+                                        body:
+                                            typeof item.details === "string"
+                                                ? item.details
+                                                : "",
+                                    },
+                                ],
                   }))
             : defaults.scheduleItems;
 
@@ -123,6 +181,31 @@ const normalizeDraft = (draft: Partial<MemoFormData>): MemoFormData => {
                 : defaults.nextMeetingLocation,
     };
 };
+
+const formatScheduleDetailBlock = (
+    block: ScheduleDetailBlock,
+    formatHeading: (value: string) => string
+) => {
+    const heading = block.heading.trim()
+        ? formatHeading(block.heading.trim())
+        : "";
+    const bodyLines = block.body
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+    const body = bodyLines.map((line) => `    - ${line}`).join("\n");
+
+    if (heading && body) return `  - **${heading}**\n${body}`;
+    if (heading) return `  - **${heading}**`;
+    if (body) return body;
+    return "";
+};
+
+const hasScheduleItemContent = (item: ScheduleItem) =>
+    item.title.trim() &&
+    item.detailBlocks.some(
+        (block) => block.heading.trim() || block.body.trim()
+    );
 
 /**
  * 部会メモ作成フォームコンポーネント
@@ -188,7 +271,11 @@ export function MeetingMemoForm() {
             ...prev,
             scheduleItems: [
                 ...prev.scheduleItems,
-                { id: generateId(), title: "", details: "" },
+                {
+                    id: generateId(),
+                    title: "",
+                    detailBlocks: [{ id: generateId(), heading: "", body: "" }],
+                },
             ],
         }));
     };
@@ -202,13 +289,72 @@ export function MeetingMemoForm() {
 
     const updateScheduleItem = (
         id: string,
-        field: "title" | "details",
+        field: "title",
         value: string
     ) => {
         setFormData((prev) => ({
             ...prev,
             scheduleItems: prev.scheduleItems.map((item) =>
                 item.id === id ? { ...item, [field]: value } : item
+            ),
+        }));
+    };
+
+    const addScheduleDetailBlock = (scheduleItemId: string) => {
+        setFormData((prev) => ({
+            ...prev,
+            scheduleItems: prev.scheduleItems.map((item) =>
+                item.id === scheduleItemId
+                    ? {
+                          ...item,
+                          detailBlocks: [
+                              ...item.detailBlocks,
+                              { id: generateId(), heading: "", body: "" },
+                          ],
+                      }
+                    : item
+            ),
+        }));
+    };
+
+    const removeScheduleDetailBlock = (
+        scheduleItemId: string,
+        detailBlockId: string
+    ) => {
+        setFormData((prev) => ({
+            ...prev,
+            scheduleItems: prev.scheduleItems.map((item) =>
+                item.id === scheduleItemId
+                    ? {
+                          ...item,
+                          detailBlocks: item.detailBlocks.filter(
+                              (block) => block.id !== detailBlockId
+                          ),
+                      }
+                    : item
+            ),
+        }));
+    };
+
+    const updateScheduleDetailBlock = (
+        scheduleItemId: string,
+        detailBlockId: string,
+        field: "heading" | "body",
+        value: string
+    ) => {
+        setFormData((prev) => ({
+            ...prev,
+            scheduleItems: prev.scheduleItems.map((item) =>
+                item.id === scheduleItemId
+                    ? {
+                          ...item,
+                          detailBlocks: item.detailBlocks.map((block) =>
+                              block.id === detailBlockId
+                                  ? { ...block, [field]: value }
+                                  : block
+                          ),
+                      }
+                    : item
             ),
         }));
     };
@@ -223,41 +369,41 @@ export function MeetingMemoForm() {
         }- 部会@${location}`;
 
         const scheduleSection =
-            formData.scheduleItems.filter((item) => item.title.trim()).length >
+            formData.scheduleItems.filter(hasScheduleItemContent).length >
             0
                 ? `### ◯ 今後の予定\n\n${formData.scheduleItems
-                      .filter((item) => item.title.trim())
+                      .filter(hasScheduleItemContent)
                       .map((item) => {
-                          const titleLine = `-   ${item.title}`;
-                          if (!item.details.trim()) {
-                              return titleLine;
-                          }
-                          const detailLines = item.details
-                              .split("\n")
-                              .map((line) => `    -   ${line}`)
+                          const titleLine = `- **${item.title.trim()}**`;
+                          const detailBlocks = item.detailBlocks
+                              .map((block) =>
+                                  formatScheduleDetailBlock(block, formatDate)
+                              )
+                              .filter(Boolean)
                               .join("\n");
-                          return `${titleLine}\n${detailLines}`;
+                          if (!detailBlocks) return titleLine;
+                          return `${titleLine}\n${detailBlocks}`;
                       })
-                      .join("\n")}`
+                      .join("\n\n")}`
                 : "";
 
         const accountingSection = formData.accountingNote.trim()
-            ? `### ◯ 会計\n\n${formData.accountingNote}`
+            ? `**◯ 会計**\n\n${formData.accountingNote}`
             : "";
 
-        const bunkouSection = `### ◯ 文団\n\n${
+        const bunkouSection = `**◯ 文団**\n\n${
             formData.bundanNote || "特になし"
         }`;
 
         const otherSection = formData.otherNote.trim()
-            ? `### ◯ その他\n\n${formData.otherNote}`
+            ? `**◯ その他**\n\n${formData.otherNote}`
             : "";
 
         const nextMeetingLocation =
             formData.nextMeetingLocation === "その他"
                 ? formData.customLocation
                 : formData.nextMeetingLocation;
-        const nextMeetingSection = `### 次回部会\n\n**${formatDate(
+        const nextMeetingSection = `**次回部会**\n\n**${formatDate(
             formData.nextMeetingDate
         )} ${formData.nextMeetingTime}- 部会@${nextMeetingLocation}**`;
 
@@ -287,302 +433,346 @@ export function MeetingMemoForm() {
 
     return (
         <div className="space-y-6">
-            {/* 基本情報 */}
-            <div className="card bg-base-100 border border-base-300">
-                <div className="card-body">
-                    <h3 className="card-title text-base">基本情報</h3>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                        <div className="form-control">
-                            <label className="label">
-                                <span className="label-text mr-3 mb-2">
-                                    日付
-                                </span>
-                            </label>
-                            <input
-                                type="date"
-                                className="input input-bordered"
-                                value={formData.date}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        date: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-                        <div className="form-control">
-                            <label className="label">
-                                <span className="label-text mr-3 mb-2">
-                                    開始時刻
-                                </span>
-                            </label>
-                            <input
-                                type="time"
-                                className="input input-bordered"
-                                value={formData.time}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        time: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-                        <div className="form-control sm:col-span-2">
-                            <label className="label">
-                                <span className="label-text mb-2">場所</span>
-                            </label>
-                            <div className="flex flex-wrap gap-2">
-                                {LOCATIONS.map((loc) => (
-                                    <button
-                                        key={loc}
-                                        type="button"
-                                        className={`btn btn-sm ${
-                                            formData.location === loc
-                                                ? "btn-primary"
-                                                : "btn-outline"
-                                        }`}
-                                        onClick={() =>
-                                            setFormData({
-                                                ...formData,
-                                                location: loc,
-                                            })
-                                        }
-                                    >
-                                        {loc}
-                                    </button>
-                                ))}
-                            </div>
-                            {formData.location === "その他" && (
-                                <input
-                                    type="text"
-                                    className="input input-bordered mt-2"
-                                    placeholder="場所を入力"
-                                    value={formData.customLocation}
-                                    onChange={(e) =>
+            <section className={SECTION_CLASS}>
+                <h3 className="text-base font-semibold">基本情報</h3>
+                <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(min(100%,18rem),1fr))]">
+                    <div className="space-y-2">
+                        <label className={FIELD_LABEL_CLASS}>日付</label>
+                        <input
+                            type="date"
+                            className="input input-bordered w-full"
+                            value={formData.date}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    date: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <label className={FIELD_LABEL_CLASS}>開始時刻</label>
+                        <input
+                            type="time"
+                            className="input input-bordered w-full"
+                            value={formData.time}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    time: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="space-y-2 [grid-column:1/-1]">
+                        <label className={FIELD_LABEL_CLASS}>場所</label>
+                        <div className="flex flex-wrap gap-2">
+                            {LOCATIONS.map((loc) => (
+                                <button
+                                    key={loc}
+                                    type="button"
+                                    className={`btn btn-sm ${
+                                        formData.location === loc
+                                            ? "btn-primary"
+                                            : "btn-outline"
+                                    }`}
+                                    onClick={() =>
                                         setFormData({
                                             ...formData,
-                                            customLocation: e.target.value,
+                                            location: loc,
                                         })
                                     }
-                                />
-                            )}
+                                >
+                                    {loc}
+                                </button>
+                            ))}
                         </div>
+                        {formData.location === "その他" && (
+                            <input
+                                type="text"
+                                className="input input-bordered mt-2"
+                                placeholder="場所を入力"
+                                value={formData.customLocation}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        customLocation: e.target.value,
+                                    })
+                                }
+                            />
+                        )}
                     </div>
                 </div>
-            </div>
+            </section>
 
-            {/* 今後の予定 */}
-            <div className="card bg-base-100 border border-base-300">
-                <div className="card-body">
-                    <div className="flex items-center justify-between">
-                        <h3 className="card-title text-base">今後の予定</h3>
-                        <button
-                            type="button"
-                            className="btn btn-primary btn-sm"
-                            onClick={addScheduleItem}
+            <section className={SECTION_CLASS}>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h3 className="text-base font-semibold">今後の予定</h3>
+                    <button
+                        type="button"
+                        className="btn btn-primary btn-sm shrink-0 gap-2"
+                        onClick={addScheduleItem}
+                    >
+                        <FontAwesomeIcon icon={faCirclePlus} />
+                        イベントを追加
+                    </button>
+                </div>
+                <div className="divide-y divide-base-300">
+                    {formData.scheduleItems.map((item, index) => (
+                        <div
+                            key={item.id}
+                            className="py-4 first:pt-0 last:pb-0"
                         >
-                            追加
-                        </button>
-                    </div>
-                    <div className="space-y-4">
-                        {formData.scheduleItems.map((item, index) => (
-                            <div
-                                key={item.id}
-                                className="card p-3"
-                            >
-                                <div className="flex items-start gap-2">
-                                    <div className="flex-1 space-y-2">
-                                        <input
-                                            type="text"
-                                            className="input input-bordered w-full"
-                                            placeholder={`予定 ${
-                                                index + 1
-                                            }（例: 10/25(土) 若杉祭）`}
-                                            value={item.title}
-                                            onChange={(e) =>
-                                                updateScheduleItem(
-                                                    item.id,
-                                                    "title",
-                                                    e.target.value
-                                                )
-                                            }
-                                        />
-                                        <textarea
-                                            className="textarea textarea-bordered w-full text-sm"
-                                            placeholder="詳細（任意、複数行可）"
-                                            rows={2}
-                                            value={item.details}
-                                            onChange={(e) =>
-                                                updateScheduleItem(
-                                                    item.id,
-                                                    "details",
-                                                    e.target.value
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                    {formData.scheduleItems.length > 1 && (
-                                        <button
-                                            type="button"
-                                            className="btn btn-ghost btn-sm text-error"
-                                            onClick={() =>
-                                                removeScheduleItem(item.id)
-                                            }
-                                        >
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                className="h-5 w-5"
-                                                fill="none"
-                                                viewBox="0 0 24 24"
-                                                stroke="currentColor"
-                                            >
-                                                <path
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                    strokeWidth={2}
-                                                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                                                />
-                                            </svg>
-                                        </button>
-                                    )}
+                            <div className="flex items-end gap-2">
+                                <div className="min-w-0 flex-1 space-y-2">
+                                    <label className={FIELD_LABEL_CLASS}>
+                                        イベント {index + 1}（必須）
+                                    </label>
+                                    <input
+                                        type="text"
+                                        className="input input-bordered w-full"
+                                        placeholder="音団講習会"
+                                        value={item.title}
+                                        onChange={(e) =>
+                                            updateScheduleItem(
+                                                item.id,
+                                                "title",
+                                                e.target.value
+                                            )
+                                        }
+                                    />
                                 </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </div>
-
-            {/* 会計 */}
-            <div className="card bg-base-100 border border-base-300">
-                <div className="card-body">
-                    <h3 className="card-title text-base">会計</h3>
-                    <textarea
-                        className="textarea textarea-bordered w-full"
-                        rows={3}
-                        value={formData.accountingNote}
-                        onChange={(e) =>
-                            setFormData({
-                                ...formData,
-                                accountingNote: e.target.value,
-                            })
-                        }
-                    />
-                </div>
-            </div>
-
-            {/* 文団 */}
-            <div className="card bg-base-100 border border-base-300">
-                <div className="card-body">
-                    <h3 className="card-title text-base">文団</h3>
-                    <textarea
-                        className="textarea textarea-bordered w-full"
-                        rows={2}
-                        placeholder="特になし"
-                        value={formData.bundanNote}
-                        onChange={(e) =>
-                            setFormData({
-                                ...formData,
-                                bundanNote: e.target.value,
-                            })
-                        }
-                    />
-                </div>
-            </div>
-
-            {/* その他 */}
-            <div className="card bg-base-100 border border-base-300">
-                <div className="card-body">
-                    <h3 className="card-title text-base">その他（任意）</h3>
-                    <textarea
-                        className="textarea textarea-bordered w-full"
-                        rows={3}
-                        placeholder="その他の連絡事項があれば入力"
-                        value={formData.otherNote}
-                        onChange={(e) =>
-                            setFormData({
-                                ...formData,
-                                otherNote: e.target.value,
-                            })
-                        }
-                    />
-                </div>
-            </div>
-
-            {/* 次回部会 */}
-            <div className="card bg-base-100 border border-base-300">
-                <div className="card-body">
-                    <h3 className="card-title text-base">次回部会</h3>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                        <div className="form-control">
-                            <label className="label">
-                                <span className="label-text mb-2">日付</span>
-                            </label>
-                            <input
-                                type="date"
-                                className="input input-bordered"
-                                value={formData.nextMeetingDate}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        nextMeetingDate: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-                        <div className="form-control">
-                            <label className="label">
-                                <span className="label-text mb-2">時刻</span>
-                            </label>
-                            <input
-                                type="time"
-                                className="input input-bordered"
-                                value={formData.nextMeetingTime}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        nextMeetingTime: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-                        <div className="form-control">
-                            <label className="label">
-                                <span className="label-text mb-2">場所</span>
-                            </label>
-                            <select
-                                className="select select-bordered"
-                                value={formData.nextMeetingLocation}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        nextMeetingLocation: e.target.value,
-                                    })
-                                }
-                            >
-                                {LOCATIONS.map((loc) => (
-                                    <option
-                                        key={loc}
-                                        value={loc}
+                                {formData.scheduleItems.length > 1 && (
+                                    <button
+                                        type="button"
+                                        className="btn btn-ghost btn-sm mb-1 shrink-0 text-error"
+                                        onClick={() =>
+                                            removeScheduleItem(item.id)
+                                        }
+                                        aria-label={`イベント ${
+                                            index + 1
+                                        } を削除`}
                                     >
-                                        {loc}
-                                    </option>
-                                ))}
-                            </select>
+                                        <FontAwesomeIcon icon={faTrashCan} />
+                                    </button>
+                                )}
+                            </div>
+                            <div className="mt-3 divide-y divide-base-300/70">
+                                {item.detailBlocks.map(
+                                    (detailBlock, detailIndex) => (
+                                        <div
+                                            key={detailBlock.id}
+                                            className="py-3 first:pt-0 last:pb-0"
+                                        >
+                                            <div className="flex items-start gap-2">
+                                                <div className="min-w-0 flex-1 space-y-2">
+                                                    <div className="flex flex-wrap gap-2">
+                                                        <label className="space-y-2 flex-[1_1_10rem]">
+                                                            <span
+                                                                className={
+                                                                    FIELD_LABEL_CLASS
+                                                                }
+                                                            >
+                                                                日程{" "}
+                                                                {detailIndex +
+                                                                    1}
+                                                            </span>
+                                                            <input
+                                                                type="date"
+                                                                className="input input-bordered input-sm w-full"
+                                                                value={
+                                                                    DATE_INPUT_PATTERN.test(
+                                                                        detailBlock.heading
+                                                                    )
+                                                                        ? detailBlock.heading
+                                                                        : ""
+                                                                }
+                                                                onChange={(e) =>
+                                                                    updateScheduleDetailBlock(
+                                                                        item.id,
+                                                                        detailBlock.id,
+                                                                        "heading",
+                                                                        e.target
+                                                                            .value
+                                                                    )
+                                                                }
+                                                            />
+                                                        </label>
+                                                        <label className="min-w-0 space-y-2 flex-[999_1_24rem]">
+                                                            <span
+                                                                className={
+                                                                    FIELD_LABEL_CLASS
+                                                                }
+                                                            >
+                                                                連絡内容
+                                                            </span>
+                                                            <textarea
+                                                                className="textarea textarea-bordered textarea-sm min-h-20 w-full text-sm"
+                                                                placeholder={
+                                                                    "集合: 17:00 クラブ棟前\n内容: 機材搬入、物品搬出"
+                                                                }
+                                                                rows={3}
+                                                                value={
+                                                                    detailBlock.body
+                                                                }
+                                                                onChange={(e) =>
+                                                                    updateScheduleDetailBlock(
+                                                                        item.id,
+                                                                        detailBlock.id,
+                                                                        "body",
+                                                                        e.target
+                                                                            .value
+                                                                    )
+                                                                }
+                                                            />
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                {item.detailBlocks.length >
+                                                    1 && (
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-ghost btn-sm shrink-0 text-error"
+                                                        onClick={() =>
+                                                            removeScheduleDetailBlock(
+                                                                item.id,
+                                                                detailBlock.id
+                                                            )
+                                                        }
+                                                        aria-label="詳細を削除"
+                                                    >
+                                                        <FontAwesomeIcon
+                                                            icon={faXmark}
+                                                        />
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </div>
+                                    )
+                                )}
+                            </div>
+                            <button
+                                type="button"
+                                className="btn btn-ghost btn-sm mt-2 gap-2"
+                                onClick={() => addScheduleDetailBlock(item.id)}
+                            >
+                                <FontAwesomeIcon icon={faCirclePlus} />
+                                日程を追加
+                            </button>
                         </div>
+                    ))}
+                </div>
+            </section>
+
+            <section className={SECTION_CLASS}>
+                <h3 className="text-base font-semibold">会計</h3>
+                <textarea
+                    className="textarea textarea-bordered w-full"
+                    rows={3}
+                    value={formData.accountingNote}
+                    onChange={(e) =>
+                        setFormData({
+                            ...formData,
+                            accountingNote: e.target.value,
+                        })
+                    }
+                />
+            </section>
+
+            <section className={SECTION_CLASS}>
+                <h3 className="text-base font-semibold">文団</h3>
+                <textarea
+                    className="textarea textarea-bordered w-full"
+                    rows={2}
+                    placeholder="特になし"
+                    value={formData.bundanNote}
+                    onChange={(e) =>
+                        setFormData({
+                            ...formData,
+                            bundanNote: e.target.value,
+                        })
+                    }
+                />
+            </section>
+
+            <section className={SECTION_CLASS}>
+                <h3 className="text-base font-semibold">その他（任意）</h3>
+                <textarea
+                    className="textarea textarea-bordered w-full"
+                    rows={3}
+                    placeholder="その他の連絡事項があれば入力"
+                    value={formData.otherNote}
+                    onChange={(e) =>
+                        setFormData({
+                            ...formData,
+                            otherNote: e.target.value,
+                        })
+                    }
+                />
+            </section>
+
+            <section className={SECTION_CLASS}>
+                <h3 className="text-base font-semibold">次回部会</h3>
+                <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(min(100%,14rem),1fr))]">
+                    <div className="space-y-2">
+                        <label className={FIELD_LABEL_CLASS}>日付</label>
+                        <input
+                            type="date"
+                            className="input input-bordered w-full"
+                            value={formData.nextMeetingDate}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    nextMeetingDate: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <label className={FIELD_LABEL_CLASS}>時刻</label>
+                        <input
+                            type="time"
+                            className="input input-bordered w-full"
+                            value={formData.nextMeetingTime}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    nextMeetingTime: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <label className={FIELD_LABEL_CLASS}>場所</label>
+                        <select
+                            className="select select-bordered w-full"
+                            value={formData.nextMeetingLocation}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    nextMeetingLocation: e.target.value,
+                                })
+                            }
+                        >
+                            {LOCATIONS.map((loc) => (
+                                <option
+                                    key={loc}
+                                    value={loc}
+                                >
+                                    {loc}
+                                </option>
+                            ))}
+                        </select>
                     </div>
                 </div>
-            </div>
+            </section>
 
-            {/* プレビュー */}
-            <div className="card bg-base-200 border border-base-300">
-                <div className="card-body">
-                    <h3 className="card-title text-base">プレビュー</h3>
-                    <pre className="bg-base-100 p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap border border-base-300">
-                        {generateMarkdown()}
-                    </pre>
-                </div>
-            </div>
+            <section className="space-y-4 px-2 sm:px-4">
+                <h3 className="text-base font-semibold">プレビュー</h3>
+                <pre className="bg-base-200 p-4 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap border border-base-300">
+                    {generateMarkdown()}
+                </pre>
+            </section>
 
             {/* コピーボタン */}
             <div className="flex justify-center">


### PR DESCRIPTION
## 概要
- 部会メモの予定入力を、イベント単位で日付ごとの詳細を登録できる形に変更しました。
- Discordに貼ったとき、イベント・日付・詳細の階層が崩れないMarkdown出力に調整しました。
- 部会メモ画面のレスポンシブ表示を改善し、アプリのバージョンを 2.3.0 に更新しました。

## 確認
- npm run build