### PR TITLE
D1 Worker APIに共有キー認証を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # D1 Backend API
 D1_BACKEND_URL=https://nb-portal-api-production.nit-housouken.workers.dev
-# Optional: set this if the Worker requires a server-to-server API key.
+# Required: shared secret for Next.js API routes to call the D1 Worker.
 D1_BACKEND_API_KEY=
 
 # NextAuth.js

--- a/cloudflare/nb-portal-api/package-lock.json
+++ b/cloudflare/nb-portal-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nb-portal-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nb-portal-api",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.4",
         "@types/node": "^25.9.3",

--- a/cloudflare/nb-portal-api/package.json
+++ b/cloudflare/nb-portal-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nb-portal-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -8,6 +8,7 @@ type ApiResponse<T> = {
 };
 
 type RuntimeEnv = Env & {
+	D1_BACKEND_API_KEY?: string;
 	PUSH_API_SECRET?: string;
 	APP_DISCORD_SEND_URL?: string;
 	DISCORD_MEETING_ROLE_MENTION?: string;
@@ -381,6 +382,48 @@ const getBody = async (request: Request) => {
 	} catch {
 		return {};
 	}
+};
+
+const getRequestPath = (url: URL) =>
+	url.searchParams.get("path") || url.pathname.replace(/^\//, "");
+
+const timingSafeEqual = async (a: string, b: string) => {
+	const encoder = new TextEncoder();
+	const [aHash, bHash] = await Promise.all([
+		crypto.subtle.digest("SHA-256", encoder.encode(a)),
+		crypto.subtle.digest("SHA-256", encoder.encode(b)),
+	]);
+	const aBytes = new Uint8Array(aHash);
+	const bBytes = new Uint8Array(bHash);
+	let diff = aBytes.length ^ bBytes.length;
+
+	for (let index = 0; index < Math.max(aBytes.length, bBytes.length); index += 1) {
+		diff |= (aBytes[index] || 0) ^ (bBytes[index] || 0);
+	}
+
+	return diff === 0;
+};
+
+const authorizeBackendRequest = async (
+	request: Request,
+	url: URL,
+	env: RuntimeEnv
+) => {
+	const path = getRequestPath(url);
+	if (request.method === "GET" && path === "health") {
+		return null;
+	}
+
+	if (!env.D1_BACKEND_API_KEY) {
+		return error("Backend API key is not configured", 503);
+	}
+
+	const providedKey = request.headers.get("x-nb-portal-api-key") || "";
+	if (!(await timingSafeEqual(providedKey, env.D1_BACKEND_API_KEY))) {
+		return error("Unauthorized", 401);
+	}
+
+	return null;
 };
 
 const getMembers = async (env: Env) => {
@@ -1628,7 +1671,7 @@ const health = async (env: Env) => {
 };
 
 const routeGet = (url: URL, env: Env) => {
-	const path = url.searchParams.get("path") || url.pathname.replace(/^\//, "");
+	const path = getRequestPath(url);
 
 	switch (path) {
 		case "health":
@@ -1663,7 +1706,7 @@ const routeGet = (url: URL, env: Env) => {
 };
 
 const routePost = (request: Request, url: URL, env: Env) => {
-	const path = url.searchParams.get("path") || url.pathname.replace(/^\//, "");
+	const path = getRequestPath(url);
 
 	switch (path) {
 		case "members":
@@ -1709,6 +1752,13 @@ export default {
 		const url = new URL(request.url);
 
 		try {
+			const authorizationError = await authorizeBackendRequest(
+				request,
+				url,
+				env as RuntimeEnv
+			);
+			if (authorizationError) return authorizationError;
+
 			if (request.method === "GET") {
 				return routeGet(url, env);
 			}

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -10,6 +10,15 @@ import worker from "../src/index";
 // For now, you'll need to do something like this to get a correctly-typed
 // `Request` to pass to `worker.fetch()`.
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+const BACKEND_API_KEY = "test-backend-api-key";
+const authorizedEnv = {
+	...env,
+	D1_BACKEND_API_KEY: BACKEND_API_KEY,
+};
+const authorizedHeaders = (headers?: HeadersInit) => ({
+	...headers,
+	"x-nb-portal-api-key": BACKEND_API_KEY,
+});
 
 describe("Hello World worker", () => {
 	beforeAll(async () => {
@@ -104,10 +113,23 @@ describe("Hello World worker", () => {
 		expect(response.status).toBe(200);
 	});
 
+	it("rejects non-health requests without backend API key", async () => {
+		const response = await worker.fetch(
+			new IncomingRequest("http://example.com/members"),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(response.status).toBe(401);
+		expect(await response.json()).toMatchObject({
+			success: false,
+			error: "Unauthorized",
+		});
+	});
+
 	it("creates a schedule when next meeting is updated", async () => {
 		const request = new IncomingRequest("http://example.com/next-meeting", {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: authorizedHeaders({ "Content-Type": "application/json" }),
 			body: JSON.stringify({
 				date: "2099-01-23",
 				time: "18:00",
@@ -116,7 +138,7 @@ describe("Hello World worker", () => {
 			}),
 		});
 		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
+		const response = await worker.fetch(request, authorizedEnv, ctx);
 		await waitOnExecutionContext(ctx);
 		expect(response.status).toBe(200);
 
@@ -128,8 +150,10 @@ describe("Hello World worker", () => {
 		expect(responseBody.data?.eventId).toBeTruthy();
 
 		const schedulesResponse = await worker.fetch(
-			new IncomingRequest("http://example.com/schedules"),
-			env,
+			new IncomingRequest("http://example.com/schedules", {
+				headers: authorizedHeaders(),
+			}),
+			authorizedEnv,
 			createExecutionContext()
 		);
 		const schedulesBody = (await schedulesResponse.json()) as {
@@ -155,7 +179,7 @@ describe("Hello World worker", () => {
 	it("stores and returns schedule end date", async () => {
 		const request = new IncomingRequest("http://example.com/schedules", {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: authorizedHeaders({ "Content-Type": "application/json" }),
 			body: JSON.stringify({
 				year: "2099",
 				month: "2",
@@ -173,7 +197,7 @@ describe("Hello World worker", () => {
 			}),
 		});
 		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
+		const response = await worker.fetch(request, authorizedEnv, ctx);
 		await waitOnExecutionContext(ctx);
 		expect(response.status).toBe(200);
 
@@ -194,8 +218,10 @@ describe("Hello World worker", () => {
 		});
 
 		const schedulesResponse = await worker.fetch(
-			new IncomingRequest("http://example.com/schedules"),
-			env,
+			new IncomingRequest("http://example.com/schedules", {
+				headers: authorizedHeaders(),
+			}),
+			authorizedEnv,
 			createExecutionContext()
 		);
 		const schedulesBody = (await schedulesResponse.json()) as {
@@ -245,7 +271,7 @@ describe("Hello World worker", () => {
 			"http://example.com/event-attendance",
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
 				body: JSON.stringify({
 					eventId: "event-attendance-test",
 					studentNumbers: ["25D0001", "25d0001", "25d9999"],
@@ -254,7 +280,7 @@ describe("Hello World worker", () => {
 			}
 		);
 		const ctx = createExecutionContext();
-		const updateResponse = await worker.fetch(updateRequest, env, ctx);
+		const updateResponse = await worker.fetch(updateRequest, authorizedEnv, ctx);
 		await waitOnExecutionContext(ctx);
 		expect(updateResponse.status).toBe(200);
 		expect(await updateResponse.json()).toMatchObject({
@@ -269,9 +295,10 @@ describe("Hello World worker", () => {
 
 		const response = await worker.fetch(
 			new IncomingRequest(
-				"http://example.com/event-attendance?eventId=event-attendance-test"
+				"http://example.com/event-attendance?eventId=event-attendance-test",
+				{ headers: authorizedHeaders() }
 			),
-			env,
+			authorizedEnv,
 			createExecutionContext()
 		);
 		expect(response.status).toBe(200);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",


### PR DESCRIPTION
## 概要
- D1 Worker APIでhealth以外のリクエストに共有キー認証を必須化
- Next.js側で利用するD1_BACKEND_API_KEYを必須環境変数として明示
- Workerテストを認証ヘッダー前提に更新
- セマンティックバージョニングのパッチ更新

## 確認
- npm test（cloudflare/nb-portal-api）
- npm run build
- npx eslint cloudflare/nb-portal-api/src/index.ts cloudflare/nb-portal-api/test/index.spec.ts

## ロールアウト
- Cloudflare Worker dev/prod と Vercel Production/Development に D1_BACKEND_API_KEY を登録済み
- PRブランチのPreviewにも登録予定