### PR TITLE
アプリ本体のバージョンを2.5.0に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",


### PR DESCRIPTION
## 概要
- 直近の機能追加に合わせてアプリ本体のバージョンを2.5.0へ更新
- Worker側は変更なしのため1.2.1のまま

## 確認
- npm run build

## タグ
- 既存の未運用タグ v1.0.0 〜 v1.6.0 はローカル・リモートとも削除済み