### PR TITLE
Discordコマンドの表示内容を調整

### DIFF
--- a/cloudflare/nb-portal-api/package-lock.json
+++ b/cloudflare/nb-portal-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nb-portal-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nb-portal-api",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.4",
         "@types/node": "^25.9.3",

--- a/cloudflare/nb-portal-api/package.json
+++ b/cloudflare/nb-portal-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nb-portal-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/cloudflare/nb-portal-api/scripts/register-discord-commands.mjs
+++ b/cloudflare/nb-portal-api/scripts/register-discord-commands.mjs
@@ -13,7 +13,7 @@ const commands = [
 	{
 		name: "absences",
 		name_localizations: {
-			ja: "欠席",
+			ja: "欠席者",
 		},
 		description: "Show absence information for a date",
 		description_localizations: {

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -1427,17 +1427,12 @@ const formatScheduleTimeRange = (row: ScheduleRow) => {
 	return row.start_time || row.end_time || "終日";
 };
 
-const truncateText = (value: string, maxLength: number) =>
-	value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
-
 const buildScheduleField = (row: ScheduleRow) => {
 	const values = [
 		`**${row.title || "無題"}**`,
 		`時間: ${formatScheduleTimeRange(row)}`,
-		row.location ? `場所: ${row.location}` : null,
-		row.attendance_deadline ? `出欠締切: ${row.attendance_deadline}` : null,
-		row.description ? `詳細: ${truncateText(row.description, 100)}` : null,
-	].filter(Boolean);
+		`場所: ${row.location || "未定"}`,
+	];
 
 	return {
 		name: formatScheduleDateRange(row),
@@ -1934,6 +1929,7 @@ const handleDiscordApplicationCommand = async (
 	const commandName = interaction.data?.name;
 	switch (commandName) {
 		case "absences":
+		case "欠席者":
 		case "欠席":
 			return handleDiscordAbsencesCommand(interaction.data?.options, env);
 		case "schedule":

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -475,6 +475,9 @@ describe("Hello World worker", () => {
 		expect(body.data?.embeds?.[0]?.title).toBe("2099/07/04(土) の予定");
 		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).toContain("**合宿**");
 		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).toContain("時間: 終日");
+		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).toContain("場所: 校外");
+		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).not.toContain("詳細:");
+		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).not.toContain("出欠締切:");
 	});
 
 	it("returns only upcoming schedules by default for Discord schedule command", async () => {

--- a/docs/discord-bot-command-design.md
+++ b/docs/discord-bot-command-design.md
@@ -184,7 +184,7 @@ Recommended Phase 1 approach:
   - `/absences`
   - `/schedule`
 - Add Japanese localizations at launch:
-  - `/欠席`
+  - `/欠席者`
   - `/予定`
 - Keep handler logic keyed by the stable English names.
 
@@ -193,7 +193,7 @@ display for users whose Discord client locale supports the localization.
 
 ## Phase 1 Commands
 
-### `/absences`
+### `/absences` (`/欠席者`)
 
 Show absence-related submissions for a date.
 
@@ -247,8 +247,7 @@ Initial response:
   - title `YYYY/MM/DD(曜) の予定` when `date` is provided.
   - schedule entries as fields.
   - field name as the schedule date or date range.
-  - field value containing title, time, location, attendance deadline, and a
-    truncated detail.
+  - field value containing only title, time, and location.
   - color `0x0ea5e9` for normal results.
   - color `0x94a3b8` and `該当する予定はありません` when no schedules match.
 
@@ -481,12 +480,12 @@ https://nb-portal-api-production.nit-housouken.workers.dev/discord/interactions
 Manual verification checklist:
 
 - Developer Portal endpoint validation succeeds.
-- `/欠席` and `/予定` are visible in the development guild.
+- `/欠席者` and `/予定` are visible in the development guild.
 - Command responses are visible only to the command runner.
 - A member without role `585047138942189603` receives the permission error.
 - `/予定` without a date returns upcoming schedules only.
 - `/予定` with a date includes multi-day events that overlap that date.
-- `/欠席` uses the same daily absence embed style as the scheduled webhook.
+- `/欠席者` uses the same daily absence embed style as the scheduled webhook.
 
 ## Open Questions
 


### PR DESCRIPTION
## 概要
- /予定 の表示を日付・タイトル・時間・場所のみに整理
- /absences の日本語表示名を /欠席者 に変更
- Worker package version を 1.2.3 に更新

## 検証
- cd cloudflare/nb-portal-api && npm test
- cd cloudflare/nb-portal-api && npx tsc --noEmit
- cd cloudflare/nb-portal-api && npx tsc --noEmit -p test/tsconfig.json

## バージョン
- nb-portal-api: 1.2.2 -> 1.2.3
- タグ: 未使用のため作成なし