### PR TITLE
講習会資料の表示を調整

### DIFF
--- a/app/(authenticated)/documents/TrainingDocument.tsx
+++ b/app/(authenticated)/documents/TrainingDocument.tsx
@@ -316,16 +316,16 @@ export default function TrainingDocument() {
             <section className="space-y-8">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                    src="/icons/NBClogotype1.png"
+                    src="/nb_logo.png"
                     alt="日本工業大学 放送研究部 NBC"
-                    className="h-auto w-40"
+                    className="h-auto w-[150px]"
                 />
                 <div className="space-y-3 text-center">
                     <h2 className="text-3xl font-bold leading-tight">
                         NB講習会 資料
                     </h2>
                     <p className="text-right text-sm text-base-content/60">
-                        20260628版
+                        20260702版
                     </p>
                 </div>
 

--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -370,6 +370,8 @@ interface Document {
     title: string;
     category: string;
     content: React.ReactNode;
+    hidden?: boolean;
+    hideDetailTitle?: boolean;
 }
 
 const weatherFlowChart = `flowchart TD
@@ -389,6 +391,7 @@ const documents: Document[] = [
         id: "nb-training-materials",
         title: "NB講習会資料",
         category: "講習会",
+        hideDetailTitle: true,
         content: <TrainingDocument />,
     },
     {
@@ -401,6 +404,7 @@ const documents: Document[] = [
         id: "nb-daigakusai-rain-manual",
         title: "大学祭 雨天時対応マニュアル",
         category: "大学祭",
+        hidden: true,
         content: (
             <div className="space-y-6">
                 {/* 目次 */}
@@ -858,13 +862,15 @@ const documents: Document[] = [
     }
 ];
 
+const visibleDocuments = documents.filter((doc) => !doc.hidden);
+
 function DocumentsContent() {
     const searchParams = useSearchParams();
     const router = useRouter();
     const docId = searchParams.get("doc");
 
     const selectedDoc = docId
-        ? documents.find((doc) => doc.id === docId) || null
+        ? visibleDocuments.find((doc) => doc.id === docId) || null
         : null;
 
     const setSelectedDoc = (doc: Document | null) => {
@@ -875,7 +881,7 @@ function DocumentsContent() {
         }
     };
 
-    const categories = [...new Set(documents.map((doc) => doc.category))];
+    const categories = [...new Set(visibleDocuments.map((doc) => doc.category))];
 
     return (
         <div className="p-4 lg:p-6 w-full">
@@ -906,7 +912,7 @@ function DocumentsContent() {
                                     {category}
                                 </h2>
                                 <div className="grid gap-3">
-                                    {documents
+                                    {visibleDocuments
                                         .filter(
                                             (doc) => doc.category === category
                                         )
@@ -970,9 +976,11 @@ function DocumentsContent() {
 
                         <div className="card bg-base-100 shadow-xl border border-base-300">
                             <div className="card-body">
-                                <h2 className="card-title text-xl mb-4">
-                                    {selectedDoc.title}
-                                </h2>
+                                {!selectedDoc.hideDetailTitle && (
+                                    <h2 className="card-title text-xl mb-4">
+                                        {selectedDoc.title}
+                                    </h2>
+                                )}
                                 {selectedDoc.content}
                             </div>
                         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "2.6.0",
+            "version": "2.6.1",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",


### PR DESCRIPTION
## 概要
- NB講習会資料のロゴを /nb_logo.png に差し替え
- NB講習会資料の詳細カード見出しを非表示化
- 版表記を 20260702版 に更新
- 雨天時対応マニュアルを資料一覧・直接URLから非表示化
- アプリ本体の version を 2.6.0 から 2.6.1 に更新

## 検証
- npx eslint 'app/(authenticated)/documents/page.tsx' 'app/(authenticated)/documents/TrainingDocument.tsx'
- npx tsc --noEmit
- npm run build

## バージョン
- nb-portal: 2.6.0 -> 2.6.1
- タグ: 未使用のため作成なし