### PR TITLE
Discordコマンドの公開表示オプションを追加

### DIFF
--- a/cloudflare/nb-portal-api/package-lock.json
+++ b/cloudflare/nb-portal-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nb-portal-api",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nb-portal-api",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.4",
         "@types/node": "^25.9.3",

--- a/cloudflare/nb-portal-api/package.json
+++ b/cloudflare/nb-portal-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nb-portal-api",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/cloudflare/nb-portal-api/scripts/register-discord-commands.mjs
+++ b/cloudflare/nb-portal-api/scripts/register-discord-commands.mjs
@@ -33,6 +33,15 @@ const commands = [
 				type: 3,
 				required: false,
 			},
+			{
+				name: "public",
+				description: "Show the result in the channel",
+				description_localizations: {
+					ja: "結果をチャンネル全体に表示する",
+				},
+				type: 5,
+				required: false,
+			},
 		],
 	},
 	{
@@ -56,6 +65,15 @@ const commands = [
 					ja: "YYYY-MM-DD形式の日付",
 				},
 				type: 3,
+				required: false,
+			},
+			{
+				name: "public",
+				description: "Show the result in the channel",
+				description_localizations: {
+					ja: "結果をチャンネル全体に表示する",
+				},
+				type: 5,
 				required: false,
 			},
 		],

--- a/cloudflare/nb-portal-api/src/index.ts
+++ b/cloudflare/nb-portal-api/src/index.ts
@@ -501,6 +501,9 @@ const getDiscordOptionValue = (
 	name: string
 ) => options?.find((option) => option.name === name)?.value;
 
+const getDiscordPublicOption = (options: DiscordInteractionOption[] | undefined) =>
+	getDiscordOptionValue(options, "public") === true;
+
 const authorizeBackendRequest = async (
 	request: Request,
 	url: URL,
@@ -1873,6 +1876,7 @@ const handleDiscordAbsencesCommand = async (
 
 	const embed = await buildDailyAbsenceEmbed(env, date);
 	return discordMessage({
+		ephemeral: !getDiscordPublicOption(options),
 		embeds: [
 			embed || {
 				title: `${getDateLabel(date)} 欠席者一覧`,
@@ -1904,6 +1908,7 @@ const handleDiscordScheduleCommand = async (
 
 	const rows = await getScheduleRowsForDiscord(env, date);
 	return discordMessage({
+		ephemeral: !getDiscordPublicOption(options),
 		embeds: buildScheduleEmbeds(rows, date),
 	});
 };

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -469,15 +469,57 @@ describe("Hello World worker", () => {
 		expect(response.status).toBe(200);
 		const body = (await response.json()) as {
 			type?: number;
-			data?: { embeds?: Array<{ title?: string; fields?: Array<{ value?: string }> }> };
+			data?: {
+				flags?: number;
+				embeds?: Array<{ title?: string; fields?: Array<{ value?: string }> }>;
+			};
 		};
 		expect(body.type).toBe(4);
+		expect(body.data?.flags).toBe(64);
 		expect(body.data?.embeds?.[0]?.title).toBe("2099/07/04(土) の予定");
 		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).toContain("**合宿**");
 		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).toContain("時間: 終日");
 		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).toContain("場所: 校外");
 		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).not.toContain("詳細:");
 		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).not.toContain("出欠締切:");
+	});
+
+	it("returns Discord schedule results publicly when public option is true", async () => {
+		await env.DB.prepare(
+			`INSERT INTO schedules (
+				id, title, date, end_date, start_time, end_time, location, description,
+				color, attendance_mode, attendance_deadline, is_past
+			)
+			VALUES (
+				'discord-public-schedule', '公開予定', '2099-07-06', NULL,
+				'10:00', NULL, '部室', '', 'primary', 'ABSENCE', '2099-07-06', 0
+			)
+			ON CONFLICT(id) DO UPDATE SET
+				title = excluded.title,
+				date = excluded.date`
+		).run();
+
+		const request = await signedDiscordRequest({
+			type: 2,
+			guild_id: DISCORD_GUILD_ID,
+			member: { roles: [DISCORD_MEMBER_ROLE_ID] },
+			data: {
+				name: "schedule",
+				options: [
+					{ name: "date", type: 3, value: "2099-07-06" },
+					{ name: "public", type: 5, value: true },
+				],
+			},
+		});
+		const response = await fetchWorker(request, discordEnv(), createExecutionContext());
+		const body = (await response.json()) as {
+			data?: {
+				flags?: number;
+				embeds?: Array<{ fields?: Array<{ value?: string }> }>;
+			};
+		};
+		expect(body.data?.flags).toBeUndefined();
+		expect(body.data?.embeds?.[0]?.fields?.[0]?.value).toContain("**公開予定**");
 	});
 
 	it("returns only upcoming schedules by default for Discord schedule command", async () => {
@@ -591,12 +633,68 @@ describe("Hello World worker", () => {
 		});
 		const response = await fetchWorker(request, discordEnv(), createExecutionContext());
 		const body = (await response.json()) as {
-			data?: { embeds?: Array<{ title?: string; fields?: Array<{ name?: string; value?: string }> }> };
+			data?: {
+				flags?: number;
+				embeds?: Array<{ title?: string; fields?: Array<{ name?: string; value?: string }> }>;
+			};
 		};
+		expect(body.data?.flags).toBe(64);
 		expect(body.data?.embeds?.[0]?.title).toBe("2099/09/01(火) 欠席者一覧");
 		expect(body.data?.embeds?.[0]?.fields?.[0]).toMatchObject({
 			name: "佐藤 次郎",
 			value: "早退（19:00）",
+		});
+	});
+
+	it("returns Discord absence command publicly when public option is true", async () => {
+		await env.DB.prepare(
+			`INSERT INTO schedules (
+				id, title, date, end_date, start_time, end_time, location, description,
+				color, attendance_mode, attendance_deadline, is_past
+			)
+			VALUES (
+				'discord-public-absence-schedule', '公開部会', '2099-09-02', NULL,
+				'18:00', NULL, 'Discord', '', 'primary', 'ABSENCE', '2099-09-02', 0
+			)
+			ON CONFLICT(id) DO UPDATE SET title = excluded.title`
+		).run();
+		await env.DB.prepare(
+			`INSERT INTO absences (
+				id, event_id, student_number, name, type, reason, reason_detail,
+				time_leaving_early, time_step_out, time_return, submitted_at, updated_at
+			)
+			VALUES (
+				'discord-public-absence-row', 'discord-public-absence-schedule', '25d0003',
+				'公開 太郎', '欠席', '', '', '', '', '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+			)
+			ON CONFLICT(id) DO UPDATE SET
+				name = excluded.name,
+				type = excluded.type`
+		).run();
+
+		const request = await signedDiscordRequest({
+			type: 2,
+			guild_id: DISCORD_GUILD_ID,
+			member: { roles: [DISCORD_MEMBER_ROLE_ID] },
+			data: {
+				name: "absences",
+				options: [
+					{ name: "date", type: 3, value: "2099-09-02" },
+					{ name: "public", type: 5, value: true },
+				],
+			},
+		});
+		const response = await fetchWorker(request, discordEnv(), createExecutionContext());
+		const body = (await response.json()) as {
+			data?: {
+				flags?: number;
+				embeds?: Array<{ fields?: Array<{ name?: string; value?: string }> }>;
+			};
+		};
+		expect(body.data?.flags).toBeUndefined();
+		expect(body.data?.embeds?.[0]?.fields?.[0]).toMatchObject({
+			name: "公開 太郎",
+			value: "欠席",
 		});
 	});
 

--- a/docs/discord-bot-command-design.md
+++ b/docs/discord-bot-command-design.md
@@ -126,10 +126,11 @@ Development and production command registration should target different guilds:
 
 ### Response Visibility
 
-All Phase 1 command responses must be ephemeral so only the command invoker can
-see the result. This is required for both `/absences` and `/schedule`.
-
-Public channel responses are out of scope for Phase 1.
+Phase 1 command responses are ephemeral by default so only the command invoker
+can see the result. `/absences` and `/schedule` both accept a `public` boolean
+option. When `public=true`, successful command results are posted to the channel
+instead of being ephemeral. Authorization and validation errors remain
+ephemeral.
 
 ### Authorization
 
@@ -200,6 +201,7 @@ Show absence-related submissions for a date.
 Options:
 
 - `date`: optional string in `YYYY-MM-DD`; defaults to today's JST date.
+- `public`: optional boolean; when `true`, post the result to the channel.
 - `event`: optional event selector or event ID, deferred until autocomplete is
   needed.
 
@@ -219,7 +221,8 @@ Initial response:
   - `本日の予定はありません`
   - `本日の欠席者はいません`
 
-Default visibility: ephemeral.
+Default visibility: ephemeral. `public=true` makes successful results visible to
+the channel.
 Required role: `585047138942189603`.
 
 ### `/schedule`
@@ -230,6 +233,7 @@ Options:
 
 - `date`: optional string in `YYYY-MM-DD`; when omitted, return upcoming
   schedules only.
+- `public`: optional boolean; when `true`, post the result to the channel.
 
 Initial response:
 
@@ -251,7 +255,8 @@ Initial response:
   - color `0x0ea5e9` for normal results.
   - color `0x94a3b8` and `該当する予定はありません` when no schedules match.
 
-Default visibility: ephemeral.
+Default visibility: ephemeral. `public=true` makes successful results visible to
+the channel.
 Required role: `585047138942189603`.
 
 ## Deferred Commands


### PR DESCRIPTION
## 概要
- /absences と /schedule に public boolean optionを追加
- public=true の成功レスポンスだけチャンネル全体へ表示
- 指定なしの場合は従来通りephemeral
- 権限エラー・入力エラーはephemeralのまま
- Discordコマンド登録スクリプトと設計書を更新
- Worker APIを1.2.5へ更新

## 確認
- cd cloudflare/nb-portal-api && npm test -- --run
- cd cloudflare/nb-portal-api && npx tsc --noEmit
- cd cloudflare/nb-portal-api && npx tsc --noEmit -p test/tsconfig.json
- git diff --check