### PR TITLE
出欠バッジの配置を調整

### DIFF
--- a/src/features/schedule-card/ui/ScheduleCard.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.tsx
@@ -1666,13 +1666,13 @@ export default function ScheduleCard({
                                                             <div className="flex items-start justify-between gap-3">
                                                                 <div className="min-w-0 flex-1">
                                                                     <div
-                                                                        className="flex flex-wrap items-center gap-x-2 gap-y-1 text-base-content"
+                                                                        className="grid items-center gap-x-2 gap-y-1 text-base-content [grid-template-columns:minmax(5rem,8rem)_minmax(0,1fr)]"
                                                                         style={{
                                                                             fontSize:
                                                                                 "clamp(0.875rem, 2vw, 1rem)",
                                                                         }}
                                                                     >
-                                                                        <span className="font-medium break-words">
+                                                                        <span className="min-w-0 font-medium break-words">
                                                                             {
                                                                                 values.name
                                                                             }


### PR DESCRIPTION
## Summary
- 出欠一覧の名前/バッジ行を2カラム grid に変更
- 名前列に最小/最大幅を持たせ、出席/欠席バッジの開始位置を安定化

## Validation
- npx eslint src/features/schedule-card/ui/ScheduleCard.tsx

## Note
- npm run lint は既存の別ファイルの lint error で失敗するため、今回変更ファイル単体で確認