### PR TITLE
test: レガシー機能の特性化テストを追加

### DIFF
--- a/app/(authenticated)/absence/AbsenceFormContent.test.tsx
+++ b/app/(authenticated)/absence/AbsenceFormContent.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ submitAbsence: vi.fn() }));
+let currentQuery = "";
+
+vi.mock("next/navigation", () => ({
+    useSearchParams: () => new URLSearchParams(currentQuery),
+}));
+vi.mock("@/src/shared/api/client", () => ({
+    submitAbsence: mocks.submitAbsence,
+}));
+vi.mock("@/src/features/help", () => ({
+    HelpButton: () => <button type="button">ヘルプ</button>,
+}));
+
+import { AbsenceFormContent } from "./AbsenceFormContent";
+
+describe("AbsenceFormContent", () => {
+    beforeEach(() => {
+        currentQuery = "eventId=EVENT-001";
+        vi.clearAllMocks();
+        mocks.submitAbsence.mockResolvedValue({ success: true });
+    });
+
+    it("欠席連絡の初期値にログインユーザー情報を使う", () => {
+        render(
+            <AbsenceFormContent
+                studentId="a123456"
+                memberName="放研 太郎"
+            />
+        );
+
+        expect(screen.getByRole("heading", { name: "欠席連絡" })).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("例: 12345678")).toHaveValue("a123456");
+        expect(screen.getByPlaceholderText("例: 山田 太郎")).toHaveValue(
+            "放研 太郎"
+        );
+        expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    });
+
+    it("中抜けの時刻を含めて欠席連絡を送信し、成功後に入力をリセットする", async () => {
+        render(
+            <AbsenceFormContent
+                studentId="a123456"
+                memberName="放研 太郎"
+            />
+        );
+        const selects = screen.getAllByRole("combobox");
+        fireEvent.change(selects[0], { target: { value: "中抜け" } });
+        fireEvent.change(selects[1], { target: { value: "授業" } });
+        fireEvent.change(screen.getByPlaceholderText("補足があれば入力してください"), {
+            target: { value: "4限のみ参加" },
+        });
+        const timeInputs = document.querySelectorAll('input[type="time"]');
+        fireEvent.change(timeInputs[0], { target: { value: "15:00" } });
+        fireEvent.change(timeInputs[1], { target: { value: "16:30" } });
+
+        fireEvent.click(screen.getByRole("button", { name: "欠席連絡を送信" }));
+
+        await waitFor(() =>
+            expect(mocks.submitAbsence).toHaveBeenCalledWith({
+                eventId: "EVENT-001",
+                studentNumber: "a123456",
+                name: "放研 太郎",
+                type: "中抜け",
+                reason: "授業",
+                reasonDetail: "4限のみ参加",
+                timeStepOut: "15:00",
+                timeReturn: "16:30",
+                timeLeavingEarly: undefined,
+            })
+        );
+        expect(await screen.findByText("欠席連絡を送信しました")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("例: 12345678")).toHaveValue("a123456");
+        expect(screen.getAllByRole("combobox")[0]).toHaveValue("");
+    });
+
+    it("希望者参加では出席として登録し、欠席用入力を表示しない", async () => {
+        currentQuery = "eventId=EVENT-002&mode=ATTENDANCE";
+        render(
+            <AbsenceFormContent
+                studentId="b234567"
+                memberName="参加 花子"
+            />
+        );
+
+        expect(screen.getByRole("heading", { name: "参加登録" })).toBeInTheDocument();
+        expect(screen.queryByRole("combobox")).toBeNull();
+        fireEvent.click(screen.getByRole("button", { name: "参加登録" }));
+
+        await waitFor(() =>
+            expect(mocks.submitAbsence).toHaveBeenCalledWith({
+                eventId: "EVENT-002",
+                studentNumber: "b234567",
+                name: "参加 花子",
+                type: "出席",
+                reason: "出席",
+                reasonDetail: undefined,
+                timeStepOut: undefined,
+                timeReturn: undefined,
+                timeLeavingEarly: undefined,
+            })
+        );
+        expect(await screen.findByText("参加登録しました")).toBeInTheDocument();
+    });
+
+    it("送信例外時はエラーと入力内容を保持する", async () => {
+        mocks.submitAbsence.mockRejectedValueOnce(new Error("通信に失敗しました"));
+        render(
+            <AbsenceFormContent
+                studentId="a123456"
+                memberName="放研 太郎"
+            />
+        );
+        const selects = screen.getAllByRole("combobox");
+        fireEvent.change(selects[0], { target: { value: "欠席" } });
+        fireEvent.change(selects[1], { target: { value: "体調不良" } });
+
+        fireEvent.click(screen.getByRole("button", { name: "欠席連絡を送信" }));
+
+        expect(await screen.findByText("通信に失敗しました")).toBeInTheDocument();
+        expect(screen.getAllByRole("combobox")[0]).toHaveValue("欠席");
+        expect(screen.getAllByRole("combobox")[1]).toHaveValue("体調不良");
+    });
+});

--- a/app/(authenticated)/members/page.test.tsx
+++ b/app/(authenticated)/members/page.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/src/shared/lib/use-url-modal", async () => {
+    const React = await import("react");
+    return {
+        useUrlModal: () => {
+            const [modal, setModal] = React.useState<string | null>(null);
+            const [memberId, setMemberId] = React.useState<string | null>(null);
+            const updateModal = (
+                name: string,
+                params?: Record<string, string | null>
+            ) => {
+                setMemberId(params?.member || null);
+                setModal(name);
+            };
+
+            return {
+                modal,
+                getModalParam: (key: string) =>
+                    key === "member" ? memberId : null,
+                openModal: updateModal,
+                replaceModal: updateModal,
+                closeModal: () => {
+                    setModal(null);
+                    setMemberId(null);
+                },
+            };
+        },
+    };
+});
+
+import MembersPage from "./page";
+
+const membersData = {
+    headers: [
+        "studentNumber",
+        "name",
+        "nickname",
+        "isJoinedLine",
+        "lineName",
+        "isJoinedDiscord",
+        "isSigned",
+        "permission",
+    ],
+    members: [
+        {
+            rowNumber: 2,
+            values: [
+                "a243456",
+                "放研 太郎",
+                "たろう",
+                true,
+                "Taro LINE",
+                true,
+                true,
+                "HEAD",
+            ],
+        },
+        {
+            rowNumber: 3,
+            values: [
+                "b253456",
+                "放研 花子",
+                "はな",
+                false,
+                "Hanako LINE",
+                false,
+                false,
+                "NORMAL",
+            ],
+        },
+    ],
+};
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("MembersPage", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.stubGlobal("fetch", vi.fn());
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: membersData })
+        );
+    });
+
+    it("名簿を取得し、文字列と入学年度で絞り込む", async () => {
+        render(<MembersPage />);
+
+        expect(await screen.findByText("たろう")).toBeInTheDocument();
+        expect(screen.getByText("はな")).toBeInTheDocument();
+        expect(fetch).toHaveBeenCalledWith("/api/backend?path=members", {
+            cache: "no-store",
+        });
+
+        fireEvent.change(screen.getByPlaceholderText("検索"), {
+            target: { value: "花子" },
+        });
+        expect(screen.queryByText("たろう")).toBeNull();
+        expect(screen.getByText("はな")).toBeInTheDocument();
+
+        fireEvent.change(screen.getByRole("combobox"), {
+            target: { value: "2024" },
+        });
+        expect(screen.getByText("該当する名簿データがありません")).toBeInTheDocument();
+    });
+
+    it("部員を追加し、成功後にモーダルを閉じて一覧へ反映する", async () => {
+        const createdValues = [
+            "c263456",
+            "放研 次郎",
+            "じろう",
+            false,
+            "Jiro LINE",
+            false,
+            false,
+            "TMP_NORMAL",
+        ];
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                rowNumber: 4,
+                values: createdValues,
+            })
+        );
+        render(<MembersPage />);
+        await screen.findByText("たろう");
+
+        fireEvent.click(screen.getByRole("button", { name: "追加" }));
+        const dialog = screen.getByRole("dialog", { name: "名簿に追加" });
+        const textboxes = within(dialog).getAllByRole("textbox");
+        fireEvent.change(textboxes[0], { target: { value: "c263456" } });
+        fireEvent.change(textboxes[1], { target: { value: "放研 次郎" } });
+        fireEvent.change(textboxes[2], { target: { value: "じろう" } });
+        fireEvent.change(textboxes[3], { target: { value: "Jiro LINE" } });
+        fireEvent.click(within(dialog).getByRole("button", { name: "追加" }));
+
+        await waitFor(() => {
+            const options = vi.mocked(fetch).mock.calls[1][1] as RequestInit;
+            expect(JSON.parse(String(options.body))).toEqual({
+                values: createdValues,
+            });
+        });
+        await waitFor(() =>
+            expect(
+                screen.queryByRole("dialog", { name: "名簿に追加" })
+            ).toBeNull()
+        );
+        expect(screen.getByText("じろう")).toBeInTheDocument();
+    });
+
+    it("編集画面から確認して部員を削除し、後続行番号を詰める", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true })
+        );
+        render(<MembersPage />);
+        await screen.findByText("たろう");
+
+        fireEvent.click(screen.getByText("たろう"));
+        const editDialog = screen.getByRole("dialog", { name: "名簿を編集" });
+        fireEvent.click(within(editDialog).getByRole("button", { name: "削除" }));
+        const deleteDialog = screen.getByRole("dialog", {
+            name: "名簿から削除",
+        });
+        fireEvent.click(within(deleteDialog).getByRole("button", { name: "削除" }));
+
+        await waitFor(() =>
+            expect(fetch).toHaveBeenNthCalledWith(2, "/api/members", {
+                method: "DELETE",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ rowNumber: 2 }),
+            })
+        );
+        await waitFor(() => expect(screen.queryByText("たろう")).toBeNull());
+        expect(screen.getByText("はな")).toBeInTheDocument();
+    });
+});

--- a/app/(authenticated)/tasks/TasksClient.test.tsx
+++ b/app/(authenticated)/tasks/TasksClient.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/src/shared/lib/use-url-modal", async () => {
+    const React = await import("react");
+    return {
+        useUrlModal: () => {
+            const [modal, setModal] = React.useState<string | null>(null);
+            const [taskId, setTaskId] = React.useState<string | null>(null);
+            return {
+                modal,
+                getModalParam: (key: string) => (key === "task" ? taskId : null),
+                openModal: (
+                    name: string,
+                    params?: Record<string, string | null>
+                ) => {
+                    setTaskId(params?.task || null);
+                    setModal(name);
+                },
+                closeModal: () => {
+                    setModal(null);
+                    setTaskId(null);
+                },
+            };
+        },
+    };
+});
+
+import TasksClient from "./TasksClient";
+
+const task = {
+    id: "TASK-001",
+    title: "会議資料を作る",
+    description: "議題を整理する",
+    status: "TODO" as const,
+    dueDate: "2026-09-01",
+    createdAt: "2026-08-20T00:00:00+09:00",
+    updatedAt: "2026-08-20T00:00:00+09:00",
+    assignees: [
+        {
+            studentNumber: "a123456",
+            name: "放研 太郎",
+            displayName: "たろう",
+        },
+    ],
+};
+
+const membersData = {
+    headers: ["studentNumber", "name", "nickname"],
+    members: [
+        { rowNumber: 2, values: ["a123456", "放研 太郎", "たろう"] },
+        { rowNumber: 3, values: ["b234567", "放研 花子", "はな"] },
+    ],
+};
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("TasksClient", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", vi.fn());
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: [task] }))
+            .mockResolvedValueOnce(
+                jsonResponse({ success: true, data: membersData })
+            );
+    });
+
+    it("タスクと進捗、現在ユーザーの担当表示を読み込む", async () => {
+        render(<TasksClient currentStudentId="A123456" />);
+
+        expect(await screen.findByText("会議資料を作る")).toBeInTheDocument();
+        expect(screen.getByText("0/1 完了")).toBeInTheDocument();
+        expect(screen.getByText("たろう")).toHaveClass("badge-primary");
+        expect(fetch).toHaveBeenNthCalledWith(1, "/api/tasks", {
+            cache: "no-store",
+        });
+    });
+
+    it("担当者を選んでタスクを追加し、成功後に一覧とモーダルを更新する", async () => {
+        const created = { ...task, id: "TASK-002", title: "新しいタスク" };
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [task, created] })
+        );
+        render(<TasksClient currentStudentId="a123456" />);
+        await screen.findByText("会議資料を作る");
+
+        fireEvent.click(screen.getByRole("button", { name: "タスクを追加" }));
+        const dialog = screen.getByRole("dialog", { name: "タスクを追加" });
+        fireEvent.change(within(dialog).getByLabelText("タイトル"), {
+            target: { value: "新しいタスク" },
+        });
+        fireEvent.change(within(dialog).getByLabelText("説明"), {
+            target: { value: "内容" },
+        });
+        const assignees = within(dialog).getAllByRole("checkbox");
+        fireEvent.click(assignees[1]);
+        fireEvent.click(within(dialog).getByRole("button", { name: "保存" }));
+
+        await waitFor(() => {
+            const options = vi.mocked(fetch).mock.calls[2][1] as RequestInit;
+            expect(JSON.parse(String(options.body))).toEqual({
+                title: "新しいタスク",
+                description: "内容",
+                status: "TODO",
+                dueDate: "",
+                assigneeStudentNumbers: ["b234567"],
+            });
+        });
+        await waitFor(() =>
+            expect(
+                screen.queryByRole("dialog", { name: "タスクを追加" })
+            ).toBeNull()
+        );
+        expect(screen.getByText("新しいタスク")).toBeInTheDocument();
+    });
+
+    it("確認後にタスクを削除し、一覧から取り除く", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
+        render(<TasksClient currentStudentId="a123456" />);
+        await screen.findByText("会議資料を作る");
+
+        fireEvent.click(screen.getByRole("button", { name: "削除" }));
+        const dialog = screen.getByRole("dialog", { name: "タスクを削除" });
+        fireEvent.click(within(dialog).getByRole("button", { name: "削除" }));
+
+        await waitFor(() =>
+            expect(fetch).toHaveBeenNthCalledWith(3, "/api/tasks", {
+                method: "DELETE",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ id: "TASK-001" }),
+            })
+        );
+        await waitFor(() =>
+            expect(screen.queryByText("会議資料を作る")).toBeNull()
+        );
+        expect(screen.getByText("タスクはまだありません")).toBeInTheDocument();
+    });
+});

--- a/app/api/absence/route.test.ts
+++ b/app/api/absence/route.test.ts
@@ -1,0 +1,267 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    revalidateTag: vi.fn(),
+    sendDiscordWebhook: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
+vi.mock("@/src/shared/lib/discord", () => ({
+    sendDiscordWebhook: mocks.sendDiscordWebhook,
+}));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { DELETE, POST, PUT } from "./route";
+
+const session = {
+    user: { name: "セッション名", email: "a123456@example.com" },
+    studentId: "a123456",
+    displayName: "放研 太郎",
+};
+
+const request = (
+    method: "POST" | "PUT" | "DELETE",
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/absence", {
+        method,
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    });
+
+const scheduleResponse = (deadline = "2099-01-01") =>
+    new Response(
+        JSON.stringify({
+            success: true,
+            data: [
+                {
+                    EVENT_ID: "EVENT-001",
+                    YYYY: 2099,
+                    MM: 1,
+                    DD: 2,
+                    ATTENDANCE_DEADLINE: deadline,
+                },
+            ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+    );
+
+const backendResponse = (data: Record<string, unknown>) =>
+    new Response(JSON.stringify(data), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("/api/absence", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue(session);
+        mocks.sendDiscordWebhook.mockResolvedValue({ success: true });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("異なるOriginからの書き込みを認証前に拒否する", async () => {
+        const response = await POST(
+            request("POST", {}, { origin: "https://attacker.example.test" })
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: "CSRF validation failed" });
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("JSON以外の書き込みを拒否する", async () => {
+        const response = await POST(
+            request("POST", {}, { "content-type": "text/plain" })
+        );
+
+        expect(response.status).toBe(415);
+        expect(await response.json()).toEqual({ error: "Invalid Content-Type" });
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await POST(request("POST", {}));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+    });
+
+    it("不正な入力へ現在のバリデーション応答を返す", async () => {
+        const response = await POST(
+            request("POST", { eventId: "EVENT-001", type: "欠席" })
+        );
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "バリデーションエラー",
+            details: ["reason: 理由は必須です"],
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("送信者情報をセッション値に置き換えて登録しDiscord結果を返す", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(scheduleResponse())
+            .mockResolvedValueOnce(
+                backendResponse({
+                    success: true,
+                    data: { timestamp: "2026-08-28T12:34:56+09:00" },
+                })
+            );
+
+        const response = await POST(
+            request("POST", {
+                eventId: "EVENT-001",
+                studentNumber: "spoofed",
+                name: "",
+                type: "欠席",
+                reason: "体調不良",
+                eventTitle: "夏季活動",
+                eventDateLabel: "2026/08/28",
+                eventTimeLabel: "10:00",
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            data: {
+                timestamp: "2026-08-28T12:34:56+09:00",
+                discordNotified: true,
+            },
+        });
+        expect(fetch).toHaveBeenNthCalledWith(
+            1,
+            "https://backend.example.test/api?path=schedules",
+            {
+                method: "GET",
+                cache: "no-store",
+                headers: { "x-nb-portal-api-key": "test-api-key" },
+            }
+        );
+        expect(fetch).toHaveBeenNthCalledWith(
+            2,
+            "https://backend.example.test/api?path=absences",
+            expect.objectContaining({
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({
+                    eventId: "EVENT-001",
+                    studentNumber: "a123456",
+                    name: "放研 太郎",
+                    type: "欠席",
+                    reason: "体調不良",
+                    eventTitle: "夏季活動",
+                    eventDateLabel: "2026/08/28",
+                    eventTimeLabel: "10:00",
+                }),
+            })
+        );
+        expect(mocks.revalidateTag).toHaveBeenCalledWith("absences", "max");
+        expect(mocks.sendDiscordWebhook).toHaveBeenCalledWith({
+            embeds: [
+                {
+                    title: "放研 太郎：欠席連絡",
+                    description:
+                        "**夏季活動**\n2026/08/28 10:00\n\n種別：欠席\n理由：体調不良",
+                    color: 0xff0000,
+                    footer: { text: "2026/08/28 12:34" },
+                },
+            ],
+        });
+    });
+
+    it("出欠連絡期限を過ぎた予定は登録しない", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(scheduleResponse("2020-01-01"));
+
+        const response = await POST(
+            request("POST", {
+                eventId: "EVENT-001",
+                type: "出席",
+            })
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "この予定の出欠連絡期限を過ぎています",
+        });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(mocks.sendDiscordWebhook).not.toHaveBeenCalled();
+    });
+
+    it("更新はabsences/updateへ転送する", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(scheduleResponse())
+            .mockResolvedValueOnce(backendResponse({ success: true, data: {} }));
+
+        const response = await PUT(
+            request("PUT", {
+                eventId: "EVENT-001",
+                type: "遅刻",
+                reason: "授業",
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetch).toHaveBeenNthCalledWith(
+            2,
+            "https://backend.example.test/api?path=absences%2Fupdate",
+            expect.objectContaining({ method: "POST" })
+        );
+    });
+
+    it("削除はセッションの学籍番号を付けてabsences/deleteへ転送する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            backendResponse({ success: true, data: { deleted: true } })
+        );
+
+        const response = await DELETE(
+            request("DELETE", {
+                eventId: "EVENT-001",
+                studentNumber: "spoofed",
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=absences%2Fdelete",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    eventId: "EVENT-001",
+                    studentNumber: "a123456",
+                }),
+            })
+        );
+        expect(mocks.sendDiscordWebhook).not.toHaveBeenCalled();
+    });
+});

--- a/app/api/backend/route.test.ts
+++ b/app/api/backend/route.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { GET } from "./route";
+
+const request = (query = "") =>
+    new NextRequest(`https://portal.example.test/api/backend${query}`);
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("GET /api/backend", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({ user: { email: "a123456@example.com" } });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await GET(request("?path=schedules"));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: "Unauthorized" });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("pathがない場合は400を返す", async () => {
+        const response = await GET(request());
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            error: "path parameter is required",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("許可されていないpathを拒否する", async () => {
+        const response = await GET(request("?path=admin"));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: "Invalid path" });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["?path=schedules&date=2026%2F08%2F28", "date: 日付はYYYY-MM-DD形式で指定してください"],
+        ["?path=notifications&limit=0", "limit: Too small: expected number to be >=1"],
+        ["?path=notifications&limit=101", "limit: Too big: expected number to be <=100"],
+    ])("不正なクエリを拒否する: %s", async (query, detail) => {
+        const response = await GET(request(query));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            error: "バリデーションエラー",
+            details: [detail],
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("許可されたパスとクエリを認証情報付きで上流へ転送する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: [{ EVENT_ID: "EVENT-001" }],
+            })
+        );
+
+        const response = await GET(
+            request("?path=schedules&date=2026-08-28&limit=25&eventId=EVENT-001")
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+        expect(await response.json()).toEqual({
+            success: true,
+            data: [{ EVENT_ID: "EVENT-001" }],
+        });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=schedules&date=2026-08-28&limit=25&eventId=EVENT-001",
+            {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                cache: "no-store",
+            }
+        );
+    });
+
+    it("上流との通信失敗を500へ変換する", async () => {
+        vi.mocked(fetch).mockRejectedValueOnce(new Error("backend unavailable"));
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const response = await GET(request("?path=members"));
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: "Internal server error" });
+        consoleError.mockRestore();
+    });
+
+    it("上流がJSON以外を返した場合は500へ変換する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            new Response("Service unavailable", { status: 503 })
+        );
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const response = await GET(request("?path=health"));
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: "Internal server error" });
+        consoleError.mockRestore();
+    });
+});

--- a/app/api/discord-send/route.test.ts
+++ b/app/api/discord-send/route.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+    process.env.PUSH_API_SECRET = "test-secret";
+    return { sendDiscordWebhook: vi.fn() };
+});
+
+vi.mock("@/src/shared/lib/discord", () => ({
+    sendDiscordWebhook: mocks.sendDiscordWebhook,
+}));
+
+import { POST } from "./route";
+
+const request = (body: unknown, secret = "test-secret") =>
+    new NextRequest("https://portal.example.test/api/discord-send", {
+        method: "POST",
+        headers: {
+            authorization: `Bearer ${secret}`,
+            "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+    });
+
+describe("POST /api/discord-send", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.sendDiscordWebhook.mockResolvedValue({ success: true });
+    });
+
+    it("シークレットが一致しない場合は401を返す", async () => {
+        const response = await POST(request({ embeds: [{}] }, "wrong-secret"));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+        expect(mocks.sendDiscordWebhook).not.toHaveBeenCalled();
+    });
+
+    it("Embedがない場合は400を返す", async () => {
+        const response = await POST(request({ content: "message" }));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Invalid Discord payload",
+        });
+    });
+
+    it("既定では出欠用WebhookへEmbedと本文を送る", async () => {
+        const embeds = [{ title: "当日の出欠状況", color: 0x00aa66 }];
+
+        const response = await POST(
+            request({ target: "unknown", embeds, content: "<@&member>" })
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ success: true });
+        expect(mocks.sendDiscordWebhook).toHaveBeenCalledWith({
+            target: "attendance",
+            embeds,
+            content: "<@&member>",
+        });
+    });
+
+    it("meeting指定時は部会用Webhookを選ぶ", async () => {
+        const embeds = [{ title: "次回部会" }];
+
+        await POST(request({ target: "meeting", embeds }));
+
+        expect(mocks.sendDiscordWebhook).toHaveBeenCalledWith({
+            target: "meeting",
+            embeds,
+            content: "",
+        });
+    });
+
+    it("Discord送信失敗を502で返す", async () => {
+        mocks.sendDiscordWebhook.mockResolvedValue({
+            success: false,
+            error: "Discord unavailable",
+        });
+
+        const response = await POST(request({ embeds: [{}] }));
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Discord unavailable",
+        });
+    });
+});

--- a/app/api/discord-test/route.test.ts
+++ b/app/api/discord-test/route.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    sendDiscordWebhook: vi.fn(),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("@/src/shared/lib/discord", () => ({
+    sendDiscordWebhook: mocks.sendDiscordWebhook,
+}));
+
+import { POST } from "./route";
+
+const request = (headers: Record<string, string> = {}) =>
+    new NextRequest("https://portal.example.test/api/discord-test", {
+        method: "POST",
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            ...headers,
+        },
+    });
+
+describe("POST /api/discord-test", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-28T03:34:56Z"));
+        mocks.auth.mockResolvedValue({ user: { email: "a123456@example.com" } });
+        mocks.sendDiscordWebhook.mockResolvedValue({ success: true });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("異なるOriginからの送信を認証前に拒否する", async () => {
+        const response = await POST(
+            request({ origin: "https://attacker.example.test" })
+        );
+
+        expect(response.status).toBe(403);
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+    });
+
+    it("固定形式のテストEmbedを送信する", async () => {
+        const response = await POST(request());
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(data).toEqual({
+            success: true,
+            sentAt: "2026/8/28 12:34:56",
+        });
+        expect(mocks.sendDiscordWebhook).toHaveBeenCalledWith({
+            embeds: [
+                {
+                    title: "Discord送信テスト",
+                    color: 0x0ea5e9,
+                    fields: [
+                        { name: "送信元", value: "Next.js API", inline: true },
+                        {
+                            name: "送信日時",
+                            value: "2026/8/28 12:34:56",
+                            inline: true,
+                        },
+                    ],
+                    footer: { text: "/api/discord-test" },
+                },
+            ],
+        });
+    });
+
+    it("Discord送信失敗を502で返す", async () => {
+        mocks.sendDiscordWebhook.mockResolvedValue({
+            success: false,
+            error: "Discord unavailable",
+        });
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Discord unavailable",
+        });
+    });
+});

--- a/app/api/event-attendance/route.test.ts
+++ b/app/api/event-attendance/route.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    revalidateTag: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { GET, POST, PUT } from "./route";
+
+const writeRequest = (
+    method: "POST" | "PUT",
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/event-attendance", {
+        method,
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("GET /api/event-attendance", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "A12345678@example.com" },
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+        const request = new NextRequest(
+            "https://portal.example.test/api/event-attendance?eventId=EVENT-001"
+        );
+
+        const response = await GET(request);
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("eventIdがない場合は400を返す", async () => {
+        const response = await GET(
+            new NextRequest("https://portal.example.test/api/event-attendance")
+        );
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "eventId is required",
+        });
+    });
+
+    it("eventIdを付けて上流へ転送し、キャッシュを無効化する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: { eventId: "EVENT 001", studentNumbers: ["a123456"] },
+            })
+        );
+
+        const response = await GET(
+            new NextRequest(
+                "https://portal.example.test/api/event-attendance?eventId=EVENT%20001"
+            )
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+        expect(await response.json()).toEqual({
+            success: true,
+            data: { eventId: "EVENT 001", studentNumbers: ["a123456"] },
+        });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=event-attendance&eventId=EVENT+001",
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                cache: "no-store",
+            }
+        );
+    });
+
+    it("上流のエラーステータスと本文を保持する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Not found" }, 404)
+        );
+
+        const response = await GET(
+            new NextRequest(
+                "https://portal.example.test/api/event-attendance?eventId=UNKNOWN"
+            )
+        );
+
+        expect(response.status).toBe(404);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Not found",
+        });
+    });
+});
+
+describe("POST/PUT /api/event-attendance", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "A12345678@example.com" },
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("異なるOriginからの書き込みを認証前に拒否する", async () => {
+        const response = await POST(
+            writeRequest(
+                "POST",
+                { eventId: "EVENT-001", studentNumbers: [] },
+                { origin: "https://attacker.example.test" }
+            )
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: "CSRF validation failed" });
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await POST(
+            writeRequest("POST", {
+                eventId: "EVENT-001",
+                studentNumbers: [],
+            })
+        );
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+    });
+
+    it("不正な出席者一覧へバリデーション応答を返す", async () => {
+        const response = await POST(
+            writeRequest("POST", {
+                eventId: "EVENT-001",
+                studentNumbers: ["invalid@example.com"],
+            })
+        );
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "バリデーションエラー",
+            details: [
+                "studentNumbers.0: 学籍番号の形式を確認してください",
+            ],
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["POST", POST],
+        ["PUT", PUT],
+    ] as const)("%sは確認者を付けて出席者一覧を保存する", async (method, handler) => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: { updated: 2 } }, 201)
+        );
+
+        const response = await handler(
+            writeRequest(method, {
+                eventId: "EVENT-001",
+                studentNumbers: ["a123456", "b234567"],
+            })
+        );
+
+        expect(response.status).toBe(201);
+        expect(await response.json()).toEqual({
+            success: true,
+            data: { updated: 2 },
+        });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=event-attendance",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({
+                    eventId: "EVENT-001",
+                    studentNumbers: ["a123456", "b234567"],
+                    checkedBy: "a123456",
+                }),
+            }
+        );
+        expect(mocks.revalidateTag).toHaveBeenCalledWith(
+            "event-attendance",
+            "max"
+        );
+    });
+
+    it("上流が保存を拒否した場合はキャッシュを無効化しない", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Conflict" }, 409)
+        );
+
+        const response = await POST(
+            writeRequest("POST", {
+                eventId: "EVENT-001",
+                studentNumbers: [],
+            })
+        );
+
+        expect(response.status).toBe(409);
+        expect(mocks.revalidateTag).not.toHaveBeenCalled();
+    });
+});

--- a/app/api/items/route.test.ts
+++ b/app/api/items/route.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { DELETE, POST, PUT } from "./route";
+
+describe("/api/items", () => {
+    it.each([
+        ["POST", POST],
+        ["PUT", PUT],
+        ["DELETE", DELETE],
+    ] as const)("%sはD1未移行を示す501を返す", async (_method, handler) => {
+        const response = await handler();
+
+        expect(response.status).toBe(501);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Items are not migrated to D1 yet",
+        });
+    });
+});

--- a/app/api/members/route.test.ts
+++ b/app/api/members/route.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    revalidateTag: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { DELETE, POST, PUT } from "./route";
+
+const request = (
+    method: "POST" | "PUT" | "DELETE",
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/members", {
+        method,
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("/api/members", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "a123456@example.com" },
+            permission: "HEAD",
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("異なるOriginからの書き込みを認証前に拒否する", async () => {
+        const response = await POST(
+            request(
+                "POST",
+                { values: [] },
+                { origin: "https://attacker.example.test" }
+            )
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: "CSRF validation failed" });
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await POST(request("POST", { values: [] }));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("valuesが配列でない場合は400を返す", async () => {
+        const response = await POST(
+            request("POST", { values: "not-an-array" })
+        );
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toMatchObject({
+            success: false,
+            error: "バリデーションエラー",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("名簿行をmembersへ登録してキャッシュを無効化する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: { rowNumber: 8 } })
+        );
+        const values = ["a123456", "放研 太郎", true, null];
+
+        const response = await POST(request("POST", { values }));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            data: { rowNumber: 8 },
+        });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=members",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({ values }),
+            }
+        );
+        expect(mocks.revalidateTag).toHaveBeenCalledWith("members", "max");
+    });
+
+    it("更新時は行番号を数値へ変換してmembers/updateへ転送する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
+
+        const response = await PUT(
+            request("PUT", {
+                rowNumber: "5",
+                values: ["a123456", "更新後"],
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=members%2Fupdate",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    rowNumber: 5,
+                    values: ["a123456", "更新後"],
+                }),
+            })
+        );
+        expect(mocks.revalidateTag).toHaveBeenCalledWith("members", "max");
+    });
+
+    it("ヘッダー行の更新を拒否する", async () => {
+        const response = await PUT(
+            request("PUT", { rowNumber: 1, values: ["header"] })
+        );
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "バリデーションエラー",
+            details: ["rowNumber: ヘッダー行は更新できません"],
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("削除行をmembers/deleteへ転送する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
+
+        const response = await DELETE(request("DELETE", { rowNumber: "7" }));
+
+        expect(response.status).toBe(200);
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=members%2Fdelete",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ rowNumber: 7 }),
+            })
+        );
+        expect(mocks.revalidateTag).toHaveBeenCalledWith("members", "max");
+    });
+
+    it("上流が処理を拒否した場合はキャッシュを無効化しない", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Rejected" }, 409)
+        );
+
+        const response = await POST(request("POST", { values: [] }));
+
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Rejected",
+        });
+        expect(mocks.revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it("上流との通信失敗を500へ変換する", async () => {
+        vi.mocked(fetch).mockRejectedValueOnce(new Error("backend unavailable"));
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const response = await DELETE(request("DELETE", { rowNumber: 5 }));
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "backend unavailable",
+        });
+        consoleError.mockRestore();
+    });
+});

--- a/app/api/next-meeting/announce/route.test.ts
+++ b/app/api/next-meeting/announce/route.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+    process.env.DISCORD_MEETING_ROLE_MENTION = "<@&meeting-role>";
+    return {
+        auth: vi.fn(),
+        resolveMemberProfile: vi.fn(),
+        sendDiscordWebhook: vi.fn(),
+        getBackendApiHeaders: vi.fn(() => ({
+            "x-nb-portal-api-key": "test-api-key",
+        })),
+        getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+    };
+});
+
+vi.mock("@/src/auth", () => ({
+    auth: mocks.auth,
+    resolveMemberProfile: mocks.resolveMemberProfile,
+}));
+vi.mock("@/src/shared/lib/discord", () => ({
+    sendDiscordWebhook: mocks.sendDiscordWebhook,
+}));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { POST } from "./route";
+
+const request = (headers: Record<string, string> = {}) =>
+    new NextRequest("https://portal.example.test/api/next-meeting/announce", {
+        method: "POST",
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            ...headers,
+        },
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("POST /api/next-meeting/announce", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "a123456@example.com" },
+            studentId: "a123456",
+            permission: "HEAD",
+        });
+        mocks.resolveMemberProfile.mockResolvedValue({ permission: "HEAD" });
+        mocks.sendDiscordWebhook.mockResolvedValue({ success: true });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("異なるOriginからの送信を認証前に拒否する", async () => {
+        const response = await POST(
+            request({ origin: "https://attacker.example.test" })
+        );
+
+        expect(response.status).toBe(403);
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+    });
+
+    it("部長・副部長以外を拒否する", async () => {
+        mocks.auth.mockResolvedValue({
+            user: { email: "a123456@example.com" },
+            permission: "NORMAL",
+        });
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Forbidden",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("次回部会が未設定なら400を返す", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: null })
+        );
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "次回部会が設定されていません",
+        });
+        expect(mocks.sendDiscordWebhook).not.toHaveBeenCalled();
+    });
+
+    it("次回部会を取得して役職メンション付きEmbedを送信する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: {
+                    date: "2026-09-01",
+                    time: "18:05",
+                    mode: "DISCORD",
+                    updatedAt: "2026-08-28T12:34:56+09:00",
+                    updatedBy: "a123456",
+                    updatedByName: "部長 太郎",
+                },
+            })
+        );
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            message: "Next meeting announcement sent",
+        });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=next-meeting",
+            {
+                method: "GET",
+                cache: "no-store",
+                headers: { "x-nb-portal-api-key": "test-api-key" },
+            }
+        );
+        expect(mocks.sendDiscordWebhook).toHaveBeenCalledWith({
+            target: "meeting",
+            content: "<@&meeting-role>",
+            embeds: [
+                {
+                    title: "次回部会のお知らせ",
+                    description: "次回部会は Discord で行います。",
+                    color: 0x5865f2,
+                    fields: [
+                        {
+                            name: "日時",
+                            value: "2026/09/01(火) 18:05",
+                            inline: false,
+                        },
+                    ],
+                    footer: { text: "更新 2026/08/28 12:34 / a123456" },
+                },
+            ],
+        });
+    });
+
+    it("Discord送信失敗を502へ変換する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: {
+                    date: "2026-09-01",
+                    time: "18:00",
+                    mode: "IN_PERSON",
+                },
+            })
+        );
+        mocks.sendDiscordWebhook.mockResolvedValue({
+            success: false,
+            error: "Discord unavailable",
+        });
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Discord unavailable",
+        });
+    });
+
+    it("次回部会の取得失敗を500へ変換する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Backend unavailable" }, 503)
+        );
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Backend unavailable",
+        });
+        consoleError.mockRestore();
+    });
+});

--- a/app/api/next-meeting/route.test.ts
+++ b/app/api/next-meeting/route.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    resolveMemberProfile: vi.fn(),
+    revalidateTag: vi.fn(),
+    sendPushNotification: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({
+    auth: mocks.auth,
+    resolveMemberProfile: mocks.resolveMemberProfile,
+}));
+vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
+vi.mock("@/src/shared/lib/push-notification-server", () => ({
+    sendPushNotification: mocks.sendPushNotification,
+}));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { POST } from "./route";
+
+const request = (
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/next-meeting", {
+        method: "POST",
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("POST /api/next-meeting", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "A12345678@example.com" },
+            studentId: "a123456",
+            displayName: "部長 太郎",
+            permission: "HEAD",
+        });
+        mocks.resolveMemberProfile.mockResolvedValue({ permission: "HEAD" });
+        mocks.sendPushNotification.mockResolvedValue({ success: true, sent: 2 });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("異なるOriginからの書き込みを認証前に拒否する", async () => {
+        const response = await POST(
+            request(
+                { date: "2026-09-01", time: "18:00", mode: "IN_PERSON" },
+                { origin: "https://attacker.example.test" }
+            )
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: "CSRF validation failed" });
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await POST(request({}));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+    });
+
+    it("部長・副部長以外を拒否する", async () => {
+        mocks.auth.mockResolvedValue({
+            user: { email: "a123456@example.com" },
+            studentId: "a123456",
+            permission: "ACCOUNTANT",
+        });
+
+        const response = await POST(request({}));
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Forbidden",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("セッションに権限がなければ最新の部員情報で補う", async () => {
+        mocks.auth.mockResolvedValue({
+            user: { email: "b234567@example.com" },
+            studentId: "b234567",
+        });
+        mocks.resolveMemberProfile.mockResolvedValue({ permission: "SUB_HEAD" });
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: null }))
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: {} }));
+
+        const response = await POST(
+            request({ date: "2026-09-01", time: "18:00", mode: "IN_PERSON" })
+        );
+
+        expect(response.status).toBe(200);
+        expect(mocks.resolveMemberProfile).toHaveBeenCalledWith("b234567");
+    });
+
+    it("不正な日付・時刻・開催形式を拒否する", async () => {
+        const response = await POST(
+            request({ date: "2026/09/01", time: "18時", mode: "ONLINE" })
+        );
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "バリデーションエラー",
+            details: [
+                "date: 日付はYYYY-MM-DD形式で指定してください",
+                "time: 時刻はHH:MM形式で指定してください",
+                "mode: 開催形式はIN_PERSONまたはDISCORDです",
+            ],
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("次回部会を登録し、表示名・キャッシュ更新・Push通知を反映する", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: null }))
+            .mockResolvedValueOnce(
+                jsonResponse({
+                    success: true,
+                    data: {
+                        date: "2026-09-01",
+                        time: "18:05",
+                        mode: "DISCORD",
+                        updatedBy: "a123456",
+                    },
+                })
+            );
+
+        const response = await POST(
+            request({ date: "2026-09-01", time: "18:05", mode: "DISCORD" })
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            data: {
+                date: "2026-09-01",
+                time: "18:05",
+                mode: "DISCORD",
+                updatedBy: "a123456",
+                updatedByName: "部長 太郎",
+            },
+        });
+        expect(fetch).toHaveBeenNthCalledWith(
+            1,
+            "https://backend.example.test/api?path=next-meeting",
+            {
+                headers: { "x-nb-portal-api-key": "test-api-key" },
+                cache: "no-store",
+            }
+        );
+        expect(fetch).toHaveBeenNthCalledWith(
+            2,
+            "https://backend.example.test/api?path=next-meeting",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({
+                    date: "2026-09-01",
+                    time: "18:05",
+                    mode: "DISCORD",
+                    updatedBy: "a123456",
+                }),
+            }
+        );
+        expect(mocks.revalidateTag.mock.calls).toEqual([
+            ["next-meeting", "max"],
+            ["schedules", "max"],
+            ["notifications", "max"],
+        ]);
+        expect(mocks.sendPushNotification).toHaveBeenCalledWith(
+            "https://portal.example.test",
+            {
+                title: "次回部会が登録されました",
+                body: "2026/09/01 18:05 Discord",
+                url: "/home",
+                tag: "nb-portal-next-meeting-登録",
+            }
+        );
+    });
+
+    it("既存設定がある場合は更新通知にする", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(
+                jsonResponse({ success: true, data: { date: "2026-08-25" } })
+            )
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: {} }));
+
+        await POST(
+            request({ date: "2026-09-08", time: "18:00", mode: "IN_PERSON" })
+        );
+
+        expect(mocks.sendPushNotification).toHaveBeenCalledWith(
+            "https://portal.example.test",
+            expect.objectContaining({
+                title: "次回部会が更新されました",
+                body: "2026/09/08 18:00 対面",
+                tag: "nb-portal-next-meeting-更新",
+            })
+        );
+    });
+
+    it("上流が更新を拒否した場合はキャッシュ更新・通知を行わない", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: null }))
+            .mockResolvedValueOnce(
+                jsonResponse({ success: false, error: "Rejected" }, 409)
+            );
+
+        const response = await POST(
+            request({ date: "2026-09-01", time: "18:00", mode: "IN_PERSON" })
+        );
+
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Rejected",
+        });
+        expect(mocks.revalidateTag).not.toHaveBeenCalled();
+        expect(mocks.sendPushNotification).not.toHaveBeenCalled();
+    });
+});

--- a/app/api/push-send/route.test.ts
+++ b/app/api/push-send/route.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+    class WebPushError extends Error {
+        statusCode: number;
+
+        constructor(message: string, statusCode: number) {
+            super(message);
+            this.statusCode = statusCode;
+        }
+    }
+
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = "test-public-key";
+    process.env.VAPID_PRIVATE_KEY = "test-private-key";
+    process.env.VAPID_SUBJECT = "mailto:test@example.test";
+    process.env.PUSH_API_SECRET = "test-secret";
+
+    return {
+        WebPushError,
+        setVapidDetails: vi.fn(),
+        sendNotification: vi.fn(),
+        getBackendApiHeaders: vi.fn(() => ({
+            "x-nb-portal-api-key": "test-api-key",
+        })),
+        getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+    };
+});
+
+vi.mock("web-push", () => ({
+    default: {
+        WebPushError: mocks.WebPushError,
+        setVapidDetails: mocks.setVapidDetails,
+        sendNotification: mocks.sendNotification,
+    },
+}));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { POST } from "./route";
+
+const request = (body: Record<string, unknown>, secret = "test-secret") =>
+    new NextRequest("https://portal.example.test/api/push-send", {
+        method: "POST",
+        headers: {
+            authorization: `Bearer ${secret}`,
+            "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+const subscription = (studentId: string, endpoint: string) => ({
+    studentId,
+    endpoint,
+    p256dh: `${studentId}-p256dh`,
+    auth: `${studentId}-auth`,
+});
+
+describe("POST /api/push-send", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.sendNotification.mockResolvedValue({});
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("シークレットが一致しない場合は401を返す", async () => {
+        const response = await POST(request({ title: "通知" }, "wrong-secret"));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: "Unauthorized" });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("タイトルがない場合は400を返す", async () => {
+        const response = await POST(request({ body: "本文" }));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: "Title is required" });
+    });
+
+    it("購読者一覧を取得できない場合は500を返す", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Backend unavailable" }, 503)
+        );
+
+        const response = await POST(request({ title: "通知" }));
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+            error: "Failed to fetch subscriptions",
+        });
+        expect(mocks.sendNotification).not.toHaveBeenCalled();
+    });
+
+    it("購読者がいない場合は送信件数0で成功する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [] })
+        );
+
+        const response = await POST(request({ title: "通知" }));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            message: "No subscriptions to send to",
+            sent: 0,
+        });
+    });
+
+    it("全購読者へ既定値を含む同じ通知を送信する", async () => {
+        const subscriptions = [
+            subscription("a123456", "https://push.example.test/a"),
+            subscription("b234567", "https://push.example.test/b"),
+        ];
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: subscriptions })
+        );
+
+        const response = await POST(
+            request({ title: "予定更新", body: "部会の日程が変わりました" })
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            sent: 2,
+            failed: 0,
+            total: 2,
+        });
+        const payload = JSON.stringify({
+            title: "予定更新",
+            body: "部会の日程が変わりました",
+            url: "/notifications",
+            tag: "nb-portal-notification",
+        });
+        expect(mocks.sendNotification.mock.calls).toEqual([
+            [
+                {
+                    endpoint: "https://push.example.test/a",
+                    keys: { p256dh: "a123456-p256dh", auth: "a123456-auth" },
+                },
+                payload,
+            ],
+            [
+                {
+                    endpoint: "https://push.example.test/b",
+                    keys: { p256dh: "b234567-p256dh", auth: "b234567-auth" },
+                },
+                payload,
+            ],
+        ]);
+    });
+
+    it("個別の送信失敗を集計し、他の購読者への送信を継続する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: [
+                    subscription("a123456", "https://push.example.test/a"),
+                    subscription("b234567", "https://push.example.test/b"),
+                ],
+            })
+        );
+        mocks.sendNotification
+            .mockRejectedValueOnce(new Error("send failed"))
+            .mockResolvedValueOnce({});
+
+        const response = await POST(request({ title: "通知" }));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            sent: 1,
+            failed: 1,
+            total: 2,
+        });
+    });
+
+    it("410 Goneとなった購読をBackendから削除する", async () => {
+        const expired = subscription(
+            "a123456",
+            "https://push.example.test/expired"
+        );
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: [expired] }))
+            .mockResolvedValueOnce(jsonResponse({ success: true }));
+        mocks.sendNotification.mockRejectedValueOnce(
+            new mocks.WebPushError("expired", 410)
+        );
+
+        const response = await POST(request({ title: "通知" }));
+
+        expect(await response.json()).toEqual({
+            success: true,
+            sent: 0,
+            failed: 1,
+            total: 1,
+        });
+        expect(fetch).toHaveBeenNthCalledWith(
+            2,
+            "https://backend.example.test/api?path=push-unsubscribe",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({
+                    endpoint: "https://push.example.test/expired",
+                }),
+            }
+        );
+    });
+});

--- a/app/api/push-subscribe/route.test.ts
+++ b/app/api/push-subscribe/route.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { DELETE, POST } from "./route";
+
+const request = (
+    method: "POST" | "DELETE",
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/push-subscribe", {
+        method,
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("/api/push-subscribe", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "A12345678@example.com" },
+            studentId: "a123456",
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("異なるOriginからの登録を認証前に拒否する", async () => {
+        const response = await POST(
+            request(
+                "POST",
+                { subscription: {} },
+                { origin: "https://attacker.example.test" }
+            )
+        );
+
+        expect(response.status).toBe(403);
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("メールアドレスのないセッションを拒否する", async () => {
+        mocks.auth.mockResolvedValue({ user: {} });
+
+        const response = await POST(request("POST", { subscription: {} }));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: "Unauthorized" });
+    });
+
+    it("購読情報がない場合は400を返す", async () => {
+        const response = await POST(request("POST", {}));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            error: "Missing required fields",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("学籍番号を付けて購読情報を保存する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
+        const subscription = {
+            endpoint: "https://push.example.test/subscription",
+            keys: { p256dh: "p256dh", auth: "auth" },
+        };
+
+        const response = await POST(request("POST", { subscription }));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ success: true });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=push-subscribe",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({ subscription, studentId: "a123456" }),
+            }
+        );
+    });
+
+    it("Backendが購読保存を拒否した場合は500を返す", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Invalid subscription" }, 400)
+        );
+
+        const response = await POST(
+            request("POST", { subscription: { endpoint: "invalid" } })
+        );
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: "Invalid subscription" });
+    });
+
+    it("endpointがない削除を拒否する", async () => {
+        const response = await DELETE(request("DELETE", {}));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: "Missing endpoint" });
+    });
+
+    it("endpointを指定して購読を削除する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
+
+        const response = await DELETE(
+            request("DELETE", {
+                endpoint: "https://push.example.test/subscription",
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ success: true });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=push-unsubscribe",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    endpoint: "https://push.example.test/subscription",
+                }),
+            })
+        );
+    });
+});

--- a/app/api/schedule/route.test.ts
+++ b/app/api/schedule/route.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    revalidateTag: vi.fn(),
+    sendPushNotification: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
+vi.mock("@/src/shared/lib/push-notification-server", () => ({
+    sendPushNotification: mocks.sendPushNotification,
+}));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { DELETE, POST, PUT } from "./route";
+
+const request = (
+    method: "POST" | "PUT" | "DELETE",
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/schedule", {
+        method,
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    });
+
+const jsonResponse = (data: Record<string, unknown>, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("/api/schedule", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "A12345678@example.com" },
+        });
+        mocks.sendPushNotification.mockResolvedValue(undefined);
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("異なるOriginからの書き込みを認証前に拒否する", async () => {
+        const response = await POST(
+            request("POST", {}, { origin: "https://attacker.example.test" })
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: "CSRF validation failed" });
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await POST(request("POST", {}));
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("作成者の学籍番号を付けて予定を作成し通知する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: {
+                    eventId: "EVENT-001",
+                    title: "部会",
+                    year: 2026,
+                    month: 9,
+                    date: 1,
+                    timeHH: 18,
+                    timeMM: 5,
+                    where: "講義棟",
+                },
+            })
+        );
+
+        const response = await POST(
+            request("POST", {
+                title: "部会",
+                year: 2026,
+                month: 9,
+                date: 1,
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ success: true });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=schedules",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({
+                    title: "部会",
+                    year: 2026,
+                    month: 9,
+                    date: 1,
+                    createdBy: "a123456",
+                }),
+            }
+        );
+        expect(mocks.revalidateTag.mock.calls).toEqual([
+            ["schedules", "max"],
+            ["next-meeting", "max"],
+            ["notifications", "max"],
+        ]);
+        expect(mocks.sendPushNotification).toHaveBeenCalledWith(
+            "https://portal.example.test",
+            {
+                title: "部会「部会」が追加されました",
+                body: "2026/9/1 18:05 講義棟",
+                url: "/calendar",
+                tag: "nb-portal-schedule-created-EVENT-001",
+            }
+        );
+    });
+
+    it("更新者の学籍番号を付けてschedules/updateへ転送する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: {
+                    eventId: "EVENT-001",
+                    title: "収録",
+                    year: 2026,
+                    month: 9,
+                    date: 2,
+                },
+            })
+        );
+
+        const response = await PUT(
+            request("PUT", { eventId: "EVENT-001", title: "収録" })
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=schedules%2Fupdate",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    eventId: "EVENT-001",
+                    title: "収録",
+                    updatedBy: "a123456",
+                }),
+            })
+        );
+        expect(mocks.sendPushNotification).toHaveBeenCalledWith(
+            "https://portal.example.test",
+            expect.objectContaining({
+                title: "予定「収録」が更新されました",
+                tag: "nb-portal-schedule-updated-EVENT-001",
+            })
+        );
+    });
+
+    it("削除前の予定を取得してから削除し、その内容で通知する", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(
+                jsonResponse({
+                    success: true,
+                    data: [
+                        {
+                            EVENT_ID: "EVENT-001",
+                            TITLE: "部会",
+                            YYYY: 2026,
+                            MM: 9,
+                            DD: 3,
+                            TIME_HH: 19,
+                            TIME_MM: 0,
+                            WHERE: "部室",
+                        },
+                    ],
+                })
+            )
+            .mockResolvedValueOnce(jsonResponse({ success: true }));
+
+        const response = await DELETE(
+            request("DELETE", { eventId: "EVENT-001", title: "古い表示名" })
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetch).toHaveBeenNthCalledWith(
+            1,
+            "https://backend.example.test/api?path=schedules",
+            {
+                headers: { "x-nb-portal-api-key": "test-api-key" },
+                cache: "no-store",
+            }
+        );
+        expect(fetch).toHaveBeenNthCalledWith(
+            2,
+            "https://backend.example.test/api?path=schedules%2Fdelete",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    eventId: "EVENT-001",
+                    title: "古い表示名",
+                }),
+            })
+        );
+        expect(mocks.sendPushNotification).toHaveBeenCalledWith(
+            "https://portal.example.test",
+            {
+                title: "部会「部会」が削除されました",
+                body: "2026/9/3 19:00 部室",
+                url: "/calendar",
+                tag: "nb-portal-schedule-deleted-EVENT-001",
+            }
+        );
+    });
+
+    it("Backend APIの通信失敗を500へ変換する", async () => {
+        vi.mocked(fetch).mockRejectedValueOnce(new Error("backend unavailable"));
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const response = await POST(request("POST", { title: "部会" }));
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "backend unavailable",
+        });
+        expect(mocks.revalidateTag).not.toHaveBeenCalled();
+        expect(mocks.sendPushNotification).not.toHaveBeenCalled();
+        consoleError.mockRestore();
+    });
+});

--- a/app/api/tasks/route.test.ts
+++ b/app/api/tasks/route.test.ts
@@ -1,0 +1,231 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    revalidateTag: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { DELETE, GET, POST } from "./route";
+
+const request = (
+    method: "POST" | "DELETE",
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/tasks", {
+        method,
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("/api/tasks", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { email: "A12345678@example.com" },
+            studentId: "a123456",
+            displayName: "放研 太郎",
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("GETは未認証ユーザーへ401を返す", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        const response = await GET();
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unauthorized",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("GETはタスク一覧をno-storeで取得する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [{ id: "TASK-001" }] })
+        );
+
+        const response = await GET();
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            data: [{ id: "TASK-001" }],
+        });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=tasks",
+            {
+                method: "GET",
+                cache: "no-store",
+                headers: { "x-nb-portal-api-key": "test-api-key" },
+            }
+        );
+    });
+
+    it("GETは上流のエラーステータスを保持する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Unavailable" }, 503)
+        );
+
+        const response = await GET();
+
+        expect(response.status).toBe(503);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Unavailable",
+        });
+    });
+
+    it("異なるOriginからの作成を認証前に拒否する", async () => {
+        const response = await POST(
+            request(
+                "POST",
+                { title: "資料作成" },
+                { origin: "https://attacker.example.test" }
+            )
+        );
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: "CSRF validation failed" });
+        expect(mocks.auth).not.toHaveBeenCalled();
+    });
+
+    it("空のタイトルを拒否する", async () => {
+        const response = await POST(request("POST", { title: "" }));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "バリデーションエラー",
+            details: ["title: タイトルは必須です"],
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("既定値と操作ユーザーを付けてタスクを作成する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: { id: "TASK-001" } }, 201)
+        );
+
+        const response = await POST(
+            request("POST", {
+                title: "資料作成",
+                dueDate: "",
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            success: true,
+            data: { id: "TASK-001" },
+        });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=tasks",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({
+                    title: "資料作成",
+                    description: "",
+                    status: "TODO",
+                    dueDate: undefined,
+                    assigneeStudentNumbers: [],
+                    createdBy: "a123456",
+                    updatedBy: "a123456",
+                }),
+            }
+        );
+        expect(mocks.revalidateTag).toHaveBeenCalledWith("tasks", "max");
+    });
+
+    it("studentIdがなければメールアドレスから操作ユーザーを補う", async () => {
+        mocks.auth.mockResolvedValue({
+            user: { email: "B23456789@example.com" },
+            displayName: "表示名",
+        });
+        vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
+
+        await POST(request("POST", { title: "確認" }));
+
+        const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+        expect(JSON.parse(String(options.body))).toMatchObject({
+            createdBy: "b234567",
+            updatedBy: "b234567",
+        });
+    });
+
+    it("上流が作成を拒否した場合はステータスを保持してキャッシュを無効化しない", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Rejected" }, 422)
+        );
+
+        const response = await POST(request("POST", { title: "資料作成" }));
+
+        expect(response.status).toBe(422);
+        expect(mocks.revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it("タスクIDがない削除を拒否する", async () => {
+        const response = await DELETE(request("DELETE", {}));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "バリデーションエラー",
+            details: ["id: Invalid input: expected string, received undefined"],
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("タスクIDをtasks/deleteへ転送してキャッシュを無効化する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
+
+        const response = await DELETE(
+            request("DELETE", { id: "TASK-001", ignored: "value" })
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=tasks%2Fdelete",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+                body: JSON.stringify({ id: "TASK-001" }),
+            }
+        );
+        expect(mocks.revalidateTag).toHaveBeenCalledWith("tasks", "max");
+    });
+});

--- a/cloudflare/nb-portal-api/test/index.spec.ts
+++ b/cloudflare/nb-portal-api/test/index.spec.ts
@@ -163,6 +163,51 @@ describe("Hello World worker", () => {
 				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 			)`
 		).run();
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS tasks (
+				id TEXT PRIMARY KEY,
+				title TEXT NOT NULL,
+				description TEXT,
+				status TEXT NOT NULL DEFAULT 'TODO' CHECK (status IN ('TODO', 'IN_PROGRESS', 'DONE')),
+				due_date TEXT,
+				created_by TEXT,
+				updated_by TEXT,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`
+		).run();
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS task_assignees (
+				task_id TEXT NOT NULL,
+				student_number TEXT NOT NULL,
+				assigned_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (task_id, student_number)
+			)`
+		).run();
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS push_subscriptions (
+				endpoint TEXT PRIMARY KEY,
+				student_id TEXT NOT NULL,
+				p256dh TEXT NOT NULL,
+				auth TEXT NOT NULL,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`
+		).run();
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS access_logs (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				timestamp TEXT NOT NULL,
+				client_timestamp TEXT,
+				student_id TEXT,
+				display_name TEXT,
+				permission TEXT,
+				path TEXT NOT NULL,
+				method TEXT NOT NULL,
+				user_agent TEXT,
+				ip_hash TEXT
+			)`
+		).run();
 	});
 
 	it("responds with health status (unit style)", async () => {
@@ -196,6 +241,325 @@ describe("Hello World worker", () => {
 		expect(await response.json()).toMatchObject({
 			success: false,
 			error: "Unauthorized",
+		});
+	});
+
+	it("returns service unavailable when the backend API key is not configured", async () => {
+		const response = await fetchWorker(
+			new IncomingRequest("http://example.com/members"),
+			env,
+			createExecutionContext()
+		);
+		expect(response.status).toBe(503);
+		expect(await response.json()).toMatchObject({
+			success: false,
+			error: "Backend API key is not configured",
+		});
+	});
+
+	it("creates, verifies, updates, and soft-deletes a member", async () => {
+		const createResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/members", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({
+					values: [
+						"26D1001",
+						"試験 太郎",
+						"テスト",
+						true,
+						"test-line",
+						false,
+						true,
+						"SUB_HEAD",
+					],
+				}),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(createResponse.status).toBe(200);
+		expect(await createResponse.json()).toMatchObject({
+			success: true,
+			values: [
+				"26D1001",
+				"試験 太郎",
+				"テスト",
+				true,
+				"test-line",
+				false,
+				true,
+				"SUB_HEAD",
+			],
+		});
+
+		const verifyResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/verify-member?identifier=26D1001", {
+				headers: authorizedHeaders(),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(await verifyResponse.json()).toEqual({
+			success: true,
+			isMember: true,
+			name: "試験 太郎",
+			nickname: "テスト",
+			permission: "SUB_HEAD",
+		});
+
+		const membersResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/members", {
+				headers: authorizedHeaders(),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		const membersBody = (await membersResponse.json()) as {
+			data?: { members?: Array<{ rowNumber: number; values: unknown[] }> };
+		};
+		const member = membersBody.data?.members?.find(
+			(row) => row.values[0] === "26D1001"
+		);
+		expect(member).toBeDefined();
+
+		const updateResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/members/update", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({
+					rowNumber: member?.rowNumber,
+					values: [
+						"26D1001",
+						"試験 太郎",
+						"更新後",
+						true,
+						"test-line",
+						true,
+						true,
+						"HEAD",
+					],
+				}),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(updateResponse.status).toBe(200);
+
+		const deleteResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/members/delete", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({ rowNumber: member?.rowNumber }),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(deleteResponse.status).toBe(200);
+
+		const deletedVerifyResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/verify-member?identifier=26D1001", {
+				headers: authorizedHeaders(),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(await deletedVerifyResponse.json()).toMatchObject({
+			success: true,
+			isMember: false,
+		});
+	});
+
+	it("creates, updates, returns, and deletes a task with unique assignees", async () => {
+		await env.DB.prepare(
+			`INSERT INTO members (student_number, name, nickname, permission, is_active)
+			VALUES ('26D2001', '担当 太郎', '担当者', 'NORMAL', 1)`
+		).run();
+
+		const createResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/tasks", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({
+					id: "TASK-CHARACTERIZATION",
+					title: "特性化テスト",
+					description: "現在の挙動を固定する",
+					status: "invalid-status",
+					dueDate: "2099-12-01",
+					createdBy: "26D2001",
+					assigneeStudentNumbers: ["26D2001", "26D2001"],
+				}),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(createResponse.status).toBe(200);
+		const createBody = (await createResponse.json()) as {
+			data?: Array<Record<string, unknown>>;
+		};
+		expect(createBody.data?.find((task) => task.id === "TASK-CHARACTERIZATION")).toMatchObject({
+			title: "特性化テスト",
+			status: "TODO",
+			createdBy: "26D2001",
+			assignees: [
+				expect.objectContaining({
+					studentNumber: "26D2001",
+					displayName: "担当者",
+				}),
+			],
+		});
+
+		const updateResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/tasks/update", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({
+					id: "TASK-CHARACTERIZATION",
+					title: "更新済みタスク",
+					status: "DONE",
+					updatedBy: "26D2001",
+					assigneeStudentNumbers: [],
+				}),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		const updateBody = (await updateResponse.json()) as {
+			data?: Array<Record<string, unknown>>;
+		};
+		expect(updateBody.data?.find((task) => task.id === "TASK-CHARACTERIZATION")).toMatchObject({
+			title: "更新済みタスク",
+			status: "DONE",
+			updatedBy: "26D2001",
+			assignees: [],
+		});
+
+		const deleteResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/tasks/delete", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({ id: "TASK-CHARACTERIZATION" }),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(await deleteResponse.json()).toMatchObject({ success: true });
+
+		const getResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/tasks", {
+				headers: authorizedHeaders(),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		const getBody = (await getResponse.json()) as {
+			data?: Array<{ id: string }>;
+		};
+		expect(getBody.data?.some((task) => task.id === "TASK-CHARACTERIZATION")).toBe(false);
+	});
+
+	it("upserts, returns, and deletes a push subscription by endpoint", async () => {
+		const endpoint = "https://push.example.test/characterization";
+		for (const [studentId, p256dh, auth] of [
+			["26D3001", "first-key", "first-auth"],
+			["26D3002", "updated-key", "updated-auth"],
+		]) {
+			const response = await fetchWorker(
+				new IncomingRequest("http://example.com/push-subscribe", {
+					method: "POST",
+					headers: authorizedHeaders({ "Content-Type": "application/json" }),
+					body: JSON.stringify({
+						studentId,
+						subscription: {
+							endpoint,
+							keys: { p256dh, auth },
+						},
+					}),
+				}),
+				authorizedEnv,
+				createExecutionContext()
+			);
+			expect(response.status).toBe(200);
+		}
+
+		const getResponse = await fetchWorker(
+			new IncomingRequest("http://example.com/push-subscriptions", {
+				headers: authorizedHeaders(),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		const getBody = (await getResponse.json()) as {
+			data?: Array<Record<string, unknown>>;
+		};
+		expect(getBody.data?.filter((item) => item.endpoint === endpoint)).toEqual([
+			expect.objectContaining({
+				studentId: "26D3002",
+				p256dh: "updated-key",
+				auth: "updated-auth",
+			}),
+		]);
+
+		await fetchWorker(
+			new IncomingRequest("http://example.com/push-unsubscribe", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({ endpoint }),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		const row = await env.DB.prepare(
+			"SELECT endpoint FROM push_subscriptions WHERE endpoint = ?"
+		)
+			.bind(endpoint)
+			.first();
+		expect(row).toBeNull();
+	});
+
+	it("stores access log fields and reports the inserted count", async () => {
+		const response = await fetchWorker(
+			new IncomingRequest("http://example.com/access-logs", {
+				method: "POST",
+				headers: authorizedHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({
+					logs: [
+						{
+							timestamp: "2026-08-28T12:34:56+09:00",
+							clientTimestamp: "2026-08-28T12:34:55+09:00",
+							studentId: "26D4001",
+							displayName: "ログ試験",
+							permission: "NORMAL",
+							path: "/calendar",
+							method: "GET",
+							userAgent: "vitest",
+							ipHash: "hash",
+						},
+					],
+				}),
+			}),
+			authorizedEnv,
+			createExecutionContext()
+		);
+		expect(await response.json()).toMatchObject({ success: true, count: 1 });
+
+		const row = await env.DB.prepare(
+			`SELECT timestamp, client_timestamp, student_id, display_name, permission,
+				path, method, user_agent, ip_hash
+			FROM access_logs WHERE student_id = ?`
+		)
+			.bind("26D4001")
+			.first<Record<string, unknown>>();
+		expect(row).toEqual({
+			timestamp: "2026-08-28T12:34:56+09:00",
+			client_timestamp: "2026-08-28T12:34:55+09:00",
+			student_id: "26D4001",
+			display_name: "ログ試験",
+			permission: "NORMAL",
+			path: "/calendar",
+			method: "GET",
+			user_agent: "vitest",
+			ip_hash: "hash",
 		});
 	});
 

--- a/src/features/next-meeting/NextMeetingCard.test.tsx
+++ b/src/features/next-meeting/NextMeetingCard.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    updateNextMeeting: vi.fn(),
+    announceNextMeeting: vi.fn(),
+}));
+
+vi.mock("@/src/shared/api", () => ({
+    updateNextMeeting: mocks.updateNextMeeting,
+    announceNextMeeting: mocks.announceNextMeeting,
+}));
+vi.mock("@/src/shared/lib/use-url-modal", async () => {
+    const React = await import("react");
+    return {
+        useUrlModal: () => {
+            const [modal, setModal] = React.useState<string | null>(null);
+            return {
+                modal,
+                openModal: (name: string) => setModal(name),
+                closeModal: () => setModal(null),
+            };
+        },
+    };
+});
+
+import { NextMeetingCard } from "./NextMeetingCard";
+
+const initialMeeting = {
+    date: "2026-09-01",
+    time: "18:00",
+    mode: "IN_PERSON" as const,
+    updatedAt: "2026-08-28T12:34:56+09:00",
+    updatedByName: "部長 太郎",
+};
+
+describe("NextMeetingCard", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.updateNextMeeting.mockResolvedValue({
+            success: true,
+            data: initialMeeting,
+        });
+        mocks.announceNextMeeting.mockResolvedValue({ success: true });
+    });
+
+    it("一般部員には編集・送信操作を表示しない", () => {
+        render(
+            <NextMeetingCard
+                initialMeeting={initialMeeting}
+                permission="NORMAL"
+            />
+        );
+
+        expect(screen.getByText("2026/09/01(火) 18:00 対面")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "編集" })).toBeNull();
+        expect(screen.queryByRole("button", { name: "送信" })).toBeNull();
+    });
+
+    it("更新成功後にモーダルを閉じ、表示内容を更新する", async () => {
+        mocks.updateNextMeeting.mockResolvedValueOnce({
+            success: true,
+            data: {
+                date: "2026-09-08",
+                time: "19:30",
+                mode: "DISCORD",
+            },
+        });
+        render(
+            <NextMeetingCard
+                initialMeeting={initialMeeting}
+                permission="HEAD"
+            />
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "編集" }));
+        const dialog = screen.getByRole("dialog", { name: "次回部会を編集" });
+        const inputs = dialog.querySelectorAll("input");
+        fireEvent.change(inputs[0], { target: { value: "2026-09-08" } });
+        fireEvent.change(inputs[1], { target: { value: "19:30" } });
+        fireEvent.change(screen.getByRole("combobox"), {
+            target: { value: "DISCORD" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+        await waitFor(() =>
+            expect(mocks.updateNextMeeting).toHaveBeenCalledWith({
+                date: "2026-09-08",
+                time: "19:30",
+                mode: "DISCORD",
+            })
+        );
+        await waitFor(() =>
+            expect(
+                screen.queryByRole("dialog", { name: "次回部会を編集" })
+            ).toBeNull()
+        );
+        expect(screen.getByText("2026/09/08(火) 19:30 Discord")).toBeInTheDocument();
+        expect(screen.getByText("次回部会を更新しました")).toBeInTheDocument();
+    });
+
+    it("更新失敗時はモーダルと入力を維持してエラーを表示する", async () => {
+        mocks.updateNextMeeting.mockResolvedValueOnce({
+            success: false,
+            error: "更新できません",
+        });
+        render(
+            <NextMeetingCard
+                initialMeeting={initialMeeting}
+                permission="HEAD"
+            />
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "編集" }));
+        fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+        expect(await screen.findByText("更新できません")).toBeInTheDocument();
+        expect(
+            screen.getByRole("dialog", { name: "次回部会を編集" })
+        ).toBeInTheDocument();
+    });
+
+    it("確認後にDiscord告知を送信してモーダルを閉じる", async () => {
+        render(
+            <NextMeetingCard
+                initialMeeting={initialMeeting}
+                permission="SUB_HEAD"
+            />
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "送信" }));
+        expect(
+            screen.getByRole("dialog", { name: "次回部会連絡を送信" })
+        ).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: "送信する" }));
+
+        await waitFor(() =>
+            expect(mocks.announceNextMeeting).toHaveBeenCalledTimes(1)
+        );
+        await waitFor(() =>
+            expect(
+                screen.queryByRole("dialog", { name: "次回部会連絡を送信" })
+            ).toBeNull()
+        );
+        expect(
+            screen.getByText("次回部会連絡をDiscordに送信しました")
+        ).toBeInTheDocument();
+    });
+});

--- a/src/features/push-notification/lib/push-subscription.test.ts
+++ b/src/features/push-notification/lib/push-subscription.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    getPushSubscriptionState,
+    getServiceWorkerRegistration,
+    isPushNotificationSupported,
+    subscribeToPushNotifications,
+    unsubscribeFromPushNotifications,
+    urlBase64ToUint8Array,
+} from "./push-subscription";
+
+const setBrowserApi = (name: string, value: unknown) => {
+    Object.defineProperty(window, name, {
+        configurable: true,
+        writable: true,
+        value,
+    });
+};
+
+const setNavigatorApi = (name: string, value: unknown) => {
+    Object.defineProperty(navigator, name, {
+        configurable: true,
+        writable: true,
+        value,
+    });
+};
+
+describe("Push購読", () => {
+    const getSubscription = vi.fn();
+    const subscribe = vi.fn();
+    const registration = {
+        active: { state: "activated" },
+        installing: null,
+        waiting: null,
+        pushManager: { getSubscription, subscribe },
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setBrowserApi("PushManager", class PushManager {});
+        setBrowserApi("Notification", {
+            permission: "default",
+            requestPermission: vi.fn().mockResolvedValue("granted"),
+        });
+        setNavigatorApi("serviceWorker", {
+            getRegistration: vi.fn().mockResolvedValue(registration),
+            ready: Promise.resolve(registration),
+            register: vi.fn().mockResolvedValue(registration),
+        });
+        vi.stubGlobal("fetch", vi.fn());
+        getSubscription.mockResolvedValue(null);
+    });
+
+    it("必要な3つのブラウザAPIがあれば対応済みと判定する", () => {
+        expect(isPushNotificationSupported()).toBe(true);
+
+        Reflect.deleteProperty(window, "PushManager");
+        expect(isPushNotificationSupported()).toBe(false);
+    });
+
+    it("URL-safe Base64をArrayBufferへ変換する", () => {
+        expect(Array.from(new Uint8Array(urlBase64ToUint8Array("AQID-_8")))).toEqual(
+            [1, 2, 3, 251, 255]
+        );
+    });
+
+    it("activeなService Worker登録を優先して返す", async () => {
+        const result = await getServiceWorkerRegistration();
+
+        expect(result).toBe(registration);
+        expect(navigator.serviceWorker.getRegistration).toHaveBeenCalledWith("/");
+    });
+
+    it("通知拒否時はService Workerを確認せずdeniedを返す", async () => {
+        setBrowserApi("Notification", {
+            permission: "denied",
+            requestPermission: vi.fn(),
+        });
+
+        await expect(getPushSubscriptionState()).resolves.toBe("denied");
+        expect(navigator.serviceWorker.getRegistration).not.toHaveBeenCalled();
+    });
+
+    it("既存購読の有無を現在の購読状態へ反映する", async () => {
+        getSubscription.mockResolvedValueOnce({ endpoint: "https://push/sub" });
+        await expect(getPushSubscriptionState()).resolves.toBe("subscribed");
+
+        getSubscription.mockResolvedValueOnce(null);
+        await expect(getPushSubscriptionState()).resolves.toBe("unsubscribed");
+    });
+
+    it("既存購読を解除して新しい購読をAPIへ保存する", async () => {
+        const unsubscribe = vi.fn().mockResolvedValue(true);
+        const existing = { unsubscribe };
+        const created = {
+            toJSON: () => ({
+                endpoint: "https://push.example.test/new",
+                keys: { p256dh: "key", auth: "auth" },
+            }),
+        };
+        getSubscription.mockResolvedValue(existing);
+        subscribe.mockResolvedValue(created);
+        vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+        const result = await subscribeToPushNotifications(
+            "A12345678@example.com"
+        );
+
+        expect(result).toEqual({ subscribed: true, denied: false });
+        expect(unsubscribe).toHaveBeenCalled();
+        expect(subscribe).toHaveBeenCalledWith({
+            userVisibleOnly: true,
+            applicationServerKey: expect.any(ArrayBuffer),
+        });
+        expect(fetch).toHaveBeenCalledWith("/api/push-subscribe", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                subscription: created.toJSON(),
+                studentId: "A12345678",
+            }),
+        });
+    });
+
+    it("通知権限が許可されなければ購読しない", async () => {
+        setBrowserApi("Notification", {
+            permission: "denied",
+            requestPermission: vi.fn().mockResolvedValue("denied"),
+        });
+
+        await expect(subscribeToPushNotifications("a@example.com")).resolves.toEqual(
+            { subscribed: false, denied: true }
+        );
+        expect(subscribe).not.toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("現在の購読を解除してendpointをAPIへ送る", async () => {
+        const current = {
+            endpoint: "https://push.example.test/current",
+            unsubscribe: vi.fn().mockResolvedValue(true),
+        };
+        getSubscription.mockResolvedValue(current);
+        vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+        await unsubscribeFromPushNotifications();
+
+        expect(current.unsubscribe).toHaveBeenCalled();
+        expect(fetch).toHaveBeenCalledWith("/api/push-subscribe", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ endpoint: current.endpoint }),
+        });
+    });
+});

--- a/src/features/schedule-card/ui/ScheduleCard.test.tsx
+++ b/src/features/schedule-card/ui/ScheduleCard.test.tsx
@@ -1,0 +1,196 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    getMembers: vi.fn(),
+    getEventAttendance: vi.fn(),
+    updateEventAttendance: vi.fn(),
+}));
+
+vi.mock("@/src/shared/api/client", () => ({
+    getMembers: mocks.getMembers,
+    getEventAttendance: mocks.getEventAttendance,
+    updateEventAttendance: mocks.updateEventAttendance,
+}));
+vi.mock("@/src/shared/lib/use-url-modal", async () => {
+    const React = await import("react");
+    return {
+        useUrlModal: () => {
+            const [modal, setModal] = React.useState<string | null>(
+                "schedule-response"
+            );
+            return {
+                modal,
+                getModalParam: (key: string) =>
+                    key === "event" ? "EVENT-001" : null,
+                openModal: (name: string) => setModal(name),
+                replaceModal: (name: string) => setModal(name),
+                closeModal: () => setModal(null),
+            };
+        },
+    };
+});
+
+import ScheduleCard from "./ScheduleCard";
+
+const baseProps = {
+    eventId: "EVENT-001",
+    title: "夏季活動",
+    where: "部室",
+    absences: [],
+    currentStudentNumber: "a123456",
+    currentDisplayName: "放研 太郎",
+    startDate: "2099-09-01",
+    attendanceDeadline: "2099-09-01",
+    dateLabel: "2099/09/01",
+    timeLabel: "18:00",
+    hideCard: true,
+};
+
+const response = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("ScheduleCard", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal("fetch", vi.fn());
+        mocks.getMembers.mockResolvedValue({
+            success: true,
+            data: { headers: [], members: [] },
+        });
+        mocks.getEventAttendance.mockResolvedValue({ success: true, data: [] });
+        mocks.updateEventAttendance.mockResolvedValue({ success: true });
+    });
+
+    it("希望者参加の参加登録を出席連絡として送信する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            response({
+                success: true,
+                data: {
+                    timestamp: "2099-09-01T17:00:00+09:00",
+                    studentNumber: "a123456",
+                    name: "放研 太郎",
+                },
+            })
+        );
+        render(<ScheduleCard {...baseProps} attendanceMode="ATTENDANCE" />);
+
+        expect(screen.getByText("参加者はいません")).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: "参加登録" }));
+        fireEvent.change(screen.getByPlaceholderText("補足があれば入力してください"), {
+            target: { value: "途中から参加" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "送信" }));
+
+        await waitFor(() =>
+            expect(fetch).toHaveBeenCalledWith("/api/absence", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    eventId: "EVENT-001",
+                    eventTitle: "夏季活動",
+                    eventDateLabel: "2099/09/01",
+                    eventTimeLabel: "18:00",
+                    eventWhere: "部室",
+                    type: "出席",
+                    reasonDetail: "途中から参加",
+                }),
+            })
+        );
+        expect(await screen.findByText("参加登録しました")).toBeInTheDocument();
+        expect(screen.getByText("放研 太郎")).toBeInTheDocument();
+        expect(screen.getByText("出席")).toBeInTheDocument();
+    });
+
+    it("通常予定の欠席連絡を入力内容付きで送信する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            response({ success: true, data: { type: "遅刻", reason: "授業" } })
+        );
+        render(<ScheduleCard {...baseProps} attendanceMode="ABSENCE" />);
+
+        fireEvent.click(screen.getByRole("button", { name: "欠席連絡" }));
+        const dialog = screen.getByRole("dialog", { name: "夏季活動" });
+        const selects = dialog.querySelectorAll("select");
+        fireEvent.change(selects[0], { target: { value: "遅刻" } });
+        fireEvent.change(selects[1], { target: { value: "授業" } });
+        fireEvent.change(screen.getByPlaceholderText("補足があれば入力してください"), {
+            target: { value: "授業後に向かいます" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "送信" }));
+
+        await waitFor(() => {
+            const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+            expect(JSON.parse(String(options.body))).toEqual({
+                eventId: "EVENT-001",
+                eventTitle: "夏季活動",
+                eventDateLabel: "2099/09/01",
+                eventTimeLabel: "18:00",
+                eventWhere: "部室",
+                studentNumber: "a123456",
+                name: "放研 太郎",
+                type: "遅刻",
+                reason: "授業",
+                reasonDetail: "授業後に向かいます",
+            });
+        });
+        expect(await screen.findByText("欠席連絡を送信しました")).toBeInTheDocument();
+    });
+
+    it("当日の出席者からOB・OGを除外し、選択した学籍番号を保存する", async () => {
+        mocks.getMembers.mockResolvedValueOnce({
+            success: true,
+            data: {
+                headers: [],
+                members: [
+                    {
+                        rowNumber: 2,
+                        values: ["a123456", "放研 太郎", "たろう", "", "", "", "", "NORMAL"],
+                    },
+                    {
+                        rowNumber: 3,
+                        values: ["b234567", "放研 花子", "はな", "", "", "", "", "OBOG"],
+                    },
+                ],
+            },
+        });
+        render(<ScheduleCard {...baseProps} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "閲覧・編集" }));
+        expect(await screen.findByText("たろう")).toBeInTheDocument();
+        expect(screen.queryByText("はな")).toBeNull();
+        fireEvent.click(screen.getByRole("checkbox"));
+        fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+        await waitFor(() =>
+            expect(mocks.updateEventAttendance).toHaveBeenCalledWith({
+                eventId: "EVENT-001",
+                studentNumbers: ["a123456"],
+            })
+        );
+        await waitFor(() =>
+            expect(
+                screen.queryByPlaceholderText("名前・学籍番号で検索")
+            ).toBeNull()
+        );
+        expect(screen.getByRole("button", { name: "閲覧・編集" })).toBeInTheDocument();
+        expect(screen.getByText("たろう")).toBeInTheDocument();
+    });
+
+    it("出欠連絡期限を過ぎた予定では新規連絡を無効化する", () => {
+        render(
+            <ScheduleCard
+                {...baseProps}
+                startDate="2020-01-02"
+                attendanceDeadline="2020-01-01"
+            />
+        );
+
+        expect(
+            screen.getByText("出欠連絡期限は2020/01/01 08:00です。")
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "受付時間外" })).toBeDisabled();
+    });
+});

--- a/src/shared/api/client.test.ts
+++ b/src/shared/api/client.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    announceNextMeeting,
+    getAbsences,
+    getEventAttendance,
+    getSchedules,
+    submitAbsence,
+    updateEventAttendance,
+    updateNextMeeting,
+} from "./client";
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("クライアントAPI", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("予定一覧をno-storeでBackendプロキシから取得する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [{ EVENT_ID: "EVENT-001" }] })
+        );
+
+        const result = await getSchedules();
+
+        expect(result).toEqual({
+            success: true,
+            data: [{ EVENT_ID: "EVENT-001" }],
+        });
+        expect(fetch).toHaveBeenCalledWith("/api/backend?path=schedules", {
+            method: "GET",
+            headers: { "Content-Type": "application/json" },
+            cache: "no-store",
+        });
+    });
+
+    it("欠席者一覧へ日付条件を付ける", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [] })
+        );
+
+        await getAbsences("2026-08-28");
+
+        expect(fetch).toHaveBeenCalledWith(
+            "/api/backend?path=absences&date=2026-08-28",
+            expect.any(Object)
+        );
+    });
+
+    it("BackendプロキシのHTTPエラーを例外にする", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "Unavailable" }, 503)
+        );
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+        await expect(getSchedules()).rejects.toThrow("HTTP error! status: 503");
+    });
+
+    it("イベント出席者をeventId付きで取得する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [{ studentNumber: "a123456" }] })
+        );
+
+        const result = await getEventAttendance("EVENT 001");
+
+        expect(result.success).toBe(true);
+        expect(fetch).toHaveBeenCalledWith(
+            "/api/event-attendance?eventId=EVENT+001",
+            {
+                method: "GET",
+                headers: { "Content-Type": "application/json" },
+                cache: "no-store",
+            }
+        );
+    });
+
+    it("HTTP 200でも出席者取得が失敗ならAPI本文のエラーを投げる", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "対象がありません" })
+        );
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+        await expect(getEventAttendance("UNKNOWN")).rejects.toThrow(
+            "対象がありません"
+        );
+    });
+
+    it("出席者一覧をPUTで保存する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: { updatedAt: "timestamp" } })
+        );
+        const data = {
+            eventId: "EVENT-001",
+            studentNumbers: ["a123456", "b234567"],
+        };
+
+        await updateEventAttendance(data);
+
+        expect(fetch).toHaveBeenCalledWith("/api/event-attendance", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        });
+    });
+
+    it("次回部会の更新と告知をそれぞれのAPIへ送る", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(jsonResponse({ success: true, data: {} }))
+            .mockResolvedValueOnce(jsonResponse({ success: true }));
+        const meeting = {
+            date: "2026-09-01",
+            time: "18:00",
+            mode: "IN_PERSON" as const,
+        };
+
+        await updateNextMeeting(meeting);
+        await announceNextMeeting();
+
+        expect(fetch).toHaveBeenNthCalledWith(1, "/api/next-meeting", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(meeting),
+        });
+        expect(fetch).toHaveBeenNthCalledWith(
+            2,
+            "/api/next-meeting/announce",
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+            }
+        );
+    });
+
+    it("欠席連絡をPOSTし、HTTPエラーを例外にする", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false, error: "期限切れ" }, 403)
+        );
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+        const data = {
+            eventId: "EVENT-001",
+            studentNumber: "a123456",
+            name: "放研 太郎",
+            type: "欠席",
+            reason: "授業",
+        };
+
+        await expect(submitAbsence(data)).rejects.toThrow(
+            "HTTP error! status: 403"
+        );
+        expect(fetch).toHaveBeenCalledWith(
+            "/api/absence",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify(data),
+            })
+        );
+    });
+});

--- a/src/shared/api/server.test.ts
+++ b/src/shared/api/server.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("next/cache", () => ({
+    unstable_cache: (callback: (...args: never[]) => unknown) => callback,
+}));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import {
+    getAbsencesServer,
+    getDashboardDataServer,
+    getNextMeetingServer,
+    getSchedulesServer,
+} from "./server";
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("サーバーAPI", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({ user: { email: "a123456@example.com" } });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it("認証されていなければBackendへアクセスしない", async () => {
+        mocks.auth.mockResolvedValue(null);
+
+        await expect(getSchedulesServer()).rejects.toThrow("Unauthorized");
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("APIキー付きで予定一覧を取得する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [{ EVENT_ID: "EVENT-001" }] })
+        );
+
+        const result = await getSchedulesServer();
+
+        expect(result.success).toBe(true);
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=schedules",
+            {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-nb-portal-api-key": "test-api-key",
+                },
+            }
+        );
+    });
+
+    it("欠席者一覧へ日付条件を付ける", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, data: [] })
+        );
+
+        await getAbsencesServer("2026-08-28");
+
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=absences&date=2026-08-28",
+            expect.any(Object)
+        );
+    });
+
+    it("BackendのHTTPエラーを例外として伝える", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: false }, 503)
+        );
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+        await expect(getSchedulesServer()).rejects.toThrow(
+            "HTTP error! status: 503"
+        );
+    });
+
+    it("次回部会の更新者を名簿のニックネームで補う", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(
+                jsonResponse({
+                    success: true,
+                    data: {
+                        date: "2026-09-01",
+                        time: "18:00",
+                        mode: "IN_PERSON",
+                        updatedBy: "A123456",
+                    },
+                })
+            )
+            .mockResolvedValueOnce(
+                jsonResponse({
+                    success: true,
+                    data: {
+                        headers: ["studentNumber", "permission", "name", "nickname"],
+                        members: [
+                            {
+                                rowNumber: 2,
+                                values: ["a123456", "HEAD", "放研 太郎", "たろう"],
+                            },
+                        ],
+                    },
+                })
+            );
+
+        const result = await getNextMeetingServer();
+
+        expect(result.data).toMatchObject({
+            updatedBy: "A123456",
+            updatedByName: "たろう",
+        });
+    });
+
+    it("名簿取得だけ失敗しても次回部会は返す", async () => {
+        vi.mocked(fetch)
+            .mockResolvedValueOnce(
+                jsonResponse({
+                    success: true,
+                    data: {
+                        date: "2026-09-01",
+                        time: "18:00",
+                        mode: "IN_PERSON",
+                        updatedBy: "a123456",
+                    },
+                })
+            )
+            .mockRejectedValueOnce(new Error("members unavailable"));
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+        const result = await getNextMeetingServer();
+
+        expect(result.data).toMatchObject({
+            updatedBy: "a123456",
+            updatedByName: null,
+        });
+    });
+
+    it("ダッシュボードデータを専用パスから取得する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({
+                success: true,
+                data: { schedules: [], absences: [], nextMeeting: null },
+            })
+        );
+
+        await getDashboardDataServer();
+
+        expect(fetch).toHaveBeenCalledWith(
+            "https://backend.example.test/api?path=dashboard-data",
+            expect.any(Object)
+        );
+    });
+});

--- a/src/shared/lib/client-cache.test.ts
+++ b/src/shared/lib/client-cache.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    clearClientCache,
+    getClientCache,
+    getClientCacheEntry,
+    getStaleClientCacheEntry,
+    setClientCache,
+} from "./client-cache";
+
+describe("クライアントキャッシュ", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-28T00:00:00Z"));
+    });
+
+    it("データと保存時刻をlocalStorageへ保存する", () => {
+        setClientCache("calendar", { count: 2 });
+
+        expect(JSON.parse(localStorage.getItem("calendar") || "null")).toEqual({
+            data: { count: 2 },
+            timestamp: Date.now(),
+        });
+        expect(getClientCache("calendar", 60_000)).toEqual({ count: 2 });
+    });
+
+    it("session指定時はsessionStorageだけを使う", () => {
+        setClientCache("tasks", ["TASK-001"], { storage: "session" });
+
+        expect(localStorage.getItem("tasks")).toBeNull();
+        expect(getClientCache("tasks", 60_000, { storage: "session" })).toEqual([
+            "TASK-001",
+        ]);
+    });
+
+    it("TTLを過ぎたキャッシュは削除する", () => {
+        setClientCache("calendar", { count: 2 });
+        vi.advanceTimersByTime(60_001);
+
+        expect(getClientCacheEntry("calendar", 60_000)).toBeNull();
+        expect(localStorage.getItem("calendar")).toBeNull();
+    });
+
+    it("TTL境界ちょうどのキャッシュは有効とする", () => {
+        setClientCache("calendar", { count: 2 });
+        vi.advanceTimersByTime(60_000);
+
+        expect(getClientCache("calendar", 60_000)).toEqual({ count: 2 });
+    });
+
+    it("stale取得は通常TTLを無視し、maxAgeだけを適用する", () => {
+        setClientCache("calendar", { count: 2 });
+        vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+
+        expect(getStaleClientCacheEntry("calendar")?.data).toEqual({ count: 2 });
+        expect(
+            getStaleClientCacheEntry("calendar", {
+                maxAgeMs: 60 * 60 * 1000,
+            })
+        ).toBeNull();
+    });
+
+    it("壊れたJSONや異なる構造を削除する", () => {
+        localStorage.setItem("broken", "{");
+        localStorage.setItem("invalid", JSON.stringify({ data: "value" }));
+
+        expect(getStaleClientCacheEntry("broken")).toBeNull();
+        expect(getStaleClientCacheEntry("invalid")).toBeNull();
+        expect(localStorage.getItem("broken")).toBeNull();
+        expect(localStorage.getItem("invalid")).toBeNull();
+    });
+
+    it("指定したキャッシュだけを削除する", () => {
+        setClientCache("calendar", { count: 2 });
+        setClientCache("tasks", { count: 1 });
+
+        clearClientCache("calendar");
+
+        expect(localStorage.getItem("calendar")).toBeNull();
+        expect(localStorage.getItem("tasks")).not.toBeNull();
+    });
+});

--- a/src/shared/lib/csrf.test.ts
+++ b/src/shared/lib/csrf.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import {
+    validateContentType,
+    validateOrigin,
+    validateWriteRequest,
+} from "./csrf";
+
+const request = (
+    method: "GET" | "POST",
+    headers: Record<string, string> = {}
+) =>
+    new NextRequest("https://portal.example.test/api/test", {
+        method,
+        headers: { host: "portal.example.test", ...headers },
+        ...(method === "POST" ? { body: "{}" } : {}),
+    });
+
+describe("CSRF検証", () => {
+    it("GETはOriginとContent-Typeを要求しない", () => {
+        const getRequest = request("GET");
+        expect(validateOrigin(getRequest)).toBeNull();
+        expect(validateContentType(getRequest)).toBeNull();
+    });
+
+    it("同一Originの書き込みを受理する", () => {
+        expect(
+            validateWriteRequest(
+                request("POST", {
+                    origin: "https://portal.example.test",
+                    "content-type": "application/json; charset=utf-8",
+                })
+            )
+        ).toBeNull();
+    });
+
+    it("異なるOriginの書き込みを403で拒否する", async () => {
+        const response = validateOrigin(
+            request("POST", { origin: "https://attacker.example.test" })
+        );
+
+        expect(response?.status).toBe(403);
+        expect(await response?.json()).toEqual({ error: "CSRF validation failed" });
+    });
+
+    it("Originがなければ同一ホストのRefererを受理する", () => {
+        expect(
+            validateOrigin(
+                request("POST", {
+                    referer: "https://portal.example.test/calendar?modal=create",
+                })
+            )
+        ).toBeNull();
+    });
+
+    it("Originがなくても異なるRefererは拒否する", async () => {
+        const response = validateOrigin(
+            request("POST", { referer: "https://attacker.example.test/form" })
+        );
+
+        expect(response?.status).toBe(403);
+        expect(await response?.json()).toEqual({ error: "CSRF validation failed" });
+    });
+
+    it("OriginとRefererの両方がない書き込みは現在受理する", () => {
+        expect(validateOrigin(request("POST"))).toBeNull();
+    });
+
+    it("JSON以外のContent-Typeを415で拒否する", async () => {
+        const response = validateContentType(
+            request("POST", { "content-type": "text/plain" })
+        );
+
+        expect(response?.status).toBe(415);
+        expect(await response?.json()).toEqual({ error: "Invalid Content-Type" });
+    });
+
+    it("複合検証ではOriginエラーをContent-Typeより先に返す", async () => {
+        const response = validateWriteRequest(
+            request("POST", {
+                origin: "https://attacker.example.test",
+                "content-type": "text/plain",
+            })
+        );
+
+        expect(response?.status).toBe(403);
+        expect(await response?.json()).toEqual({ error: "CSRF validation failed" });
+    });
+});

--- a/src/shared/lib/discord.test.ts
+++ b/src/shared/lib/discord.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendDiscordWebhook } from "./discord";
+
+describe("sendDiscordWebhook", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", vi.fn());
+        vi.stubEnv(
+            "DISCORD_ATTENDANCE_WEBHOOK_URL",
+            "https://discord.example.test/attendance"
+        );
+        vi.stubEnv(
+            "DISCORD_MEETING_WEBHOOK_URL",
+            "https://discord.example.test/meeting"
+        );
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+    });
+
+    it("出欠用WebhookへEmbedと本文を送る", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+        const embeds = [{ title: "当日の出欠状況" }];
+
+        const result = await sendDiscordWebhook({
+            embeds,
+            content: "<@&member>",
+        });
+
+        expect(result).toEqual({ success: true });
+        expect(fetch).toHaveBeenCalledWith(
+            "https://discord.example.test/attendance",
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ embeds, content: "<@&member>" }),
+            }
+        );
+    });
+
+    it("meeting指定時は部会用Webhookを使い、空の本文は送らない", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+        const embeds = [{ title: "次回部会" }];
+
+        await sendDiscordWebhook({ target: "meeting", embeds, content: "" });
+
+        expect(fetch).toHaveBeenCalledWith(
+            "https://discord.example.test/meeting",
+            expect.objectContaining({ body: JSON.stringify({ embeds }) })
+        );
+    });
+
+    it("Webhook URLが未設定なら送信しない", async () => {
+        vi.stubEnv("DISCORD_MEETING_WEBHOOK_URL", "");
+
+        const result = await sendDiscordWebhook({
+            target: "meeting",
+            embeds: [{}],
+        });
+
+        expect(result).toEqual({
+            success: false,
+            error: "DISCORD_MEETING_WEBHOOK_URL is not configured",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("Discordのエラー本文を500文字まで返す", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            new Response("x".repeat(600), { status: 429 })
+        );
+
+        const result = await sendDiscordWebhook({ embeds: [{}] });
+
+        expect(result).toEqual({
+            success: false,
+            error: "Discord webhook failed: 429",
+            detail: "x".repeat(500),
+        });
+    });
+});

--- a/src/shared/lib/jst-date.test.ts
+++ b/src/shared/lib/jst-date.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+    formatJstDateInput,
+    formatJstTimestamp,
+    parseDateInput,
+} from "./jst-date";
+
+describe("JST日付処理", () => {
+    it("UTCの日付境界をJSTの日付へ変換する", () => {
+        expect(formatJstDateInput(new Date("2026-08-28T15:30:00Z"))).toBe(
+            "2026-08-29"
+        );
+    });
+
+    it("秒まで含むJSTオフセット形式へ変換する", () => {
+        expect(formatJstTimestamp(new Date("2026-08-28T03:04:05Z"))).toBe(
+            "2026-08-28T12:04:05+09:00"
+        );
+    });
+
+    it("日付入力をローカル日付として解析する", () => {
+        const date = parseDateInput("2026-02-03");
+
+        expect(date).not.toBeNull();
+        expect(date?.getFullYear()).toBe(2026);
+        expect(date?.getMonth()).toBe(1);
+        expect(date?.getDate()).toBe(3);
+    });
+
+    it("日付入力形式でなければnullを返す", () => {
+        expect(parseDateInput("2026/02/03")).toBeNull();
+        expect(parseDateInput("2026-2-3")).toBeNull();
+        expect(parseDateInput("")).toBeNull();
+    });
+
+    it("現在の実装では暦上存在しない日付を繰り上げて解析する", () => {
+        const date = parseDateInput("2026-02-30");
+
+        expect(date).not.toBeNull();
+        expect(date?.getMonth()).toBe(2);
+        expect(date?.getDate()).toBe(2);
+    });
+});

--- a/src/shared/lib/push-notification-server.test.ts
+++ b/src/shared/lib/push-notification-server.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendPushNotification } from "./push-notification-server";
+
+describe("sendPushNotification", () => {
+    beforeEach(() => {
+        vi.stubEnv("PUSH_API_SECRET", "test-secret");
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("同一オリジンのPush APIへシークレット付きで送信する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            new Response(JSON.stringify({ success: true, sent: 2 }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            })
+        );
+        const payload = {
+            title: "予定更新",
+            body: "部会の日程が変わりました",
+            url: "/calendar",
+            tag: "schedule-update",
+        };
+
+        const result = await sendPushNotification(
+            "https://portal.example.test",
+            payload
+        );
+
+        expect(result).toEqual({ success: true, sent: 2 });
+        expect(fetch).toHaveBeenCalledWith(
+            new URL("https://portal.example.test/api/push-send"),
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-secret",
+                },
+                body: JSON.stringify(payload),
+            }
+        );
+    });
+
+    it("シークレットが未設定なら送信せずnullを返す", async () => {
+        vi.stubEnv("PUSH_API_SECRET", "");
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const result = await sendPushNotification("https://portal.example.test", {
+            title: "通知",
+        });
+
+        expect(result).toBeNull();
+        expect(fetch).not.toHaveBeenCalled();
+        expect(consoleError).toHaveBeenCalled();
+    });
+
+    it("Push APIのエラー応答も呼び出し元へ返す", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            new Response(JSON.stringify({ error: "Unauthorized" }), {
+                status: 401,
+                headers: { "content-type": "application/json" },
+            })
+        );
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const result = await sendPushNotification("https://portal.example.test", {
+            title: "通知",
+        });
+
+        expect(result).toEqual({ error: "Unauthorized" });
+        expect(consoleError).toHaveBeenCalledWith("Push notification failed:", {
+            error: "Unauthorized",
+        });
+    });
+
+    it("通信例外時はnullを返す", async () => {
+        vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"));
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const result = await sendPushNotification("https://portal.example.test", {
+            title: "通知",
+        });
+
+        expect(result).toBeNull();
+        expect(consoleError).toHaveBeenCalled();
+    });
+});

--- a/src/shared/lib/schedule-deadline.test.ts
+++ b/src/shared/lib/schedule-deadline.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+    formatDateInput,
+    getAttendanceDeadlineLabel,
+    getAttendanceResponseWindow,
+    getDefaultAttendanceDeadline,
+    isAttendanceResponseAllowed,
+} from "./schedule-deadline";
+
+describe("出欠連絡期限", () => {
+    it("開始日を既定の期限日にする", () => {
+        expect(getDefaultAttendanceDeadline("2026-08-28")).toBe("2026-08-28");
+        expect(getDefaultAttendanceDeadline("2026/08/28")).toBe("");
+    });
+
+    it("期限日のJST 08:00を期限終了時刻にする", () => {
+        const window = getAttendanceResponseWindow({
+            startDate: "2026-08-30",
+            deadlineDate: "2026-08-29",
+        });
+
+        expect(window).toEqual({
+            deadlineDate: "2026-08-29",
+            deadlineEnd: new Date("2026-08-29T08:00:00+09:00"),
+        });
+        expect(getAttendanceDeadlineLabel({
+            startDate: "2026-08-30",
+            deadlineDate: "2026-08-29",
+        })).toBe("2026/08/29 08:00");
+    });
+
+    it("期限直前は受理し、期限時刻ちょうどから拒否する", () => {
+        const input = {
+            startDate: "2026-08-30",
+            deadlineDate: "2026-08-29",
+        };
+
+        expect(
+            isAttendanceResponseAllowed(
+                input,
+                new Date("2026-08-29T07:59:59.999+09:00")
+            )
+        ).toBe(true);
+        expect(
+            isAttendanceResponseAllowed(
+                input,
+                new Date("2026-08-29T08:00:00+09:00")
+            )
+        ).toBe(false);
+    });
+
+    it("開始日が不正な場合は期限なしとして受理する", () => {
+        expect(getAttendanceResponseWindow({ startDate: "" })).toBeNull();
+        expect(
+            isAttendanceResponseAllowed(
+                { startDate: "invalid" },
+                new Date("2099-01-01T00:00:00+09:00")
+            )
+        ).toBe(true);
+        expect(getAttendanceDeadlineLabel({ startDate: "invalid" })).toBe("");
+    });
+
+    it("ローカル日付を日付入力形式へ整形する", () => {
+        expect(formatDateInput(new Date(2026, 0, 2))).toBe("2026-01-02");
+    });
+});

--- a/src/shared/lib/validation.test.ts
+++ b/src/shared/lib/validation.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+    absenceDeleteSchema,
+    absenceSubmitSchema,
+    eventAttendanceUpdateSchema,
+    formatValidationErrors,
+    itemCreateSchema,
+    queryParamSchema,
+    taskUpsertSchema,
+} from "./validation";
+
+describe("absenceSubmitSchema", () => {
+    const validAbsence = {
+        eventId: "EVENT-001",
+        studentNumber: "a123456",
+        name: "放研 太郎",
+        type: "欠席" as const,
+        reason: "体調不良" as const,
+    };
+
+    it("欠席連絡の最小入力を受理する", () => {
+        expect(absenceSubmitSchema.parse(validAbsence)).toEqual(validAbsence);
+    });
+
+    it("出席連絡は理由なしでも受理する", () => {
+        const input = {
+            ...validAbsence,
+            type: "出席" as const,
+            reason: undefined,
+        };
+
+        expect(absenceSubmitSchema.parse(input)).toEqual(input);
+    });
+
+    it("出席以外で理由がない場合はreasonのエラーにする", () => {
+        const result = absenceSubmitSchema.safeParse({
+            ...validAbsence,
+            reason: undefined,
+        });
+
+        expect(result.success).toBe(false);
+        if (result.success) return;
+        expect(formatValidationErrors(result.error)).toContain(
+            "reason: 理由は必須です"
+        );
+    });
+
+    it("学籍番号に記号が含まれる場合は拒否する", () => {
+        const result = absenceSubmitSchema.safeParse({
+            ...validAbsence,
+            studentNumber: "a123456@example.com",
+        });
+
+        expect(result.success).toBe(false);
+        if (result.success) return;
+        expect(formatValidationErrors(result.error)).toContain(
+            "studentNumber: 学籍番号の形式を確認してください"
+        );
+    });
+
+    it("詳細は500文字まで受理し、501文字は拒否する", () => {
+        expect(
+            absenceSubmitSchema.safeParse({
+                ...validAbsence,
+                reasonDetail: "a".repeat(500),
+            }).success
+        ).toBe(true);
+        expect(
+            absenceSubmitSchema.safeParse({
+                ...validAbsence,
+                reasonDetail: "a".repeat(501),
+            }).success
+        ).toBe(false);
+    });
+});
+
+describe("その他の入力スキーマ", () => {
+    it("欠席連絡削除では予定IDと学籍番号を要求する", () => {
+        expect(
+            absenceDeleteSchema.parse({
+                eventId: "EVENT-001",
+                studentNumber: "a123456",
+            })
+        ).toEqual({ eventId: "EVENT-001", studentNumber: "a123456" });
+        expect(absenceDeleteSchema.safeParse({ eventId: "EVENT-001" }).success).toBe(
+            false
+        );
+    });
+
+    it("出席者一覧は300人まで受理する", () => {
+        const studentNumbers = Array.from(
+            { length: 300 },
+            (_, index) => `s${String(index).padStart(6, "0")}`
+        );
+
+        expect(
+            eventAttendanceUpdateSchema.safeParse({
+                eventId: "EVENT-001",
+                studentNumbers,
+            }).success
+        ).toBe(true);
+        expect(
+            eventAttendanceUpdateSchema.safeParse({
+                eventId: "EVENT-001",
+                studentNumbers: [...studentNumbers, "s999999"],
+            }).success
+        ).toBe(false);
+    });
+
+    it("クエリのlimitを数値へ変換し、1から100に制限する", () => {
+        expect(queryParamSchema.parse({ limit: "25" }).limit).toBe(25);
+        expect(queryParamSchema.safeParse({ limit: "0" }).success).toBe(false);
+        expect(queryParamSchema.safeParse({ limit: "101" }).success).toBe(false);
+    });
+
+    it("機材の数量を省略すると1になる", () => {
+        expect(itemCreateSchema.parse({ category: "MIC", name: "SM58" })).toEqual({
+            category: "MIC",
+            name: "SM58",
+            count: 1,
+        });
+    });
+
+    it("タスクの省略値を現在の既定値で補う", () => {
+        expect(taskUpsertSchema.parse({ title: "会議資料を作る" })).toEqual({
+            title: "会議資料を作る",
+            description: "",
+            status: "TODO",
+            assigneeStudentNumbers: [],
+        });
+    });
+});

--- a/src/shared/types/api.test.ts
+++ b/src/shared/types/api.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+    normalizeMemberPermission,
+    normalizeScheduleAttendanceMode,
+} from "./api";
+
+describe("権限の正規化", () => {
+    it.each([
+        ["head", "HEAD"],
+        [" sub-head ", "SUB_HEAD"],
+        ["SUB__HEAD", "SUB_HEAD"],
+        ["subhead", "SUB_HEAD"],
+        ["accountntat", "ACCOUNTANT"],
+        ["tmp normal", "TMP_NORMAL"],
+        ["TMP＿NORMAL", "TMP_NORMAL"],
+    ])("%sを%sへ正規化する", (input, expected) => {
+        expect(normalizeMemberPermission(input)).toBe(expected);
+    });
+
+    it("未知の権限や空値はnullにする", () => {
+        expect(normalizeMemberPermission("ADMIN")).toBeNull();
+        expect(normalizeMemberPermission(null)).toBeNull();
+    });
+});
+
+describe("予定の参加形式", () => {
+    it("ATTENDANCEだけを希望者参加として扱う", () => {
+        expect(normalizeScheduleAttendanceMode(" attendance ")).toBe(
+            "ATTENDANCE"
+        );
+    });
+
+    it("未知の値と空値は全員参加へフォールバックする", () => {
+        expect(normalizeScheduleAttendanceMode("OPTIONAL")).toBe("ABSENCE");
+        expect(normalizeScheduleAttendanceMode(undefined)).toBe("ABSENCE");
+    });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            "@": fileURLToPath(new URL(".", import.meta.url)),
+        },
+    },
     test: {
         environment: "jsdom",
         setupFiles: ["./vitest.setup.ts"],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+    cleanup();
+});


### PR DESCRIPTION
## 概要

既存機能の現在の挙動を固定する特性化テストを追加します。明確な不具合であるアクセスログAPIの日時検証問題は仕様として固定せず、Issue #195で別途扱います。

## 対象

- APIルート（予定、出欠、名簿、タスク、Discord、Push通知など）
- 共有ユーティリティとAPIクライアント／サーバー
- 主要UIフロー（出欠、予定、次回部会、名簿、タスク）
- Cloudflare Workerの認証、D1 CRUD、Push購読、アクセスログ保存

## 検証

- ルート: 30ファイル、191テスト成功
- Worker: 29テスト成功
- TypeScript: ルート・Workerともに成功
- ESLint: 成功
- Next.js本番ビルド: 成功