### PR TITLE
fix: JST化以降のアクセスログ停止を修正

### DIFF
--- a/app/api/access-log/route.test.ts
+++ b/app/api/access-log/route.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    auth: vi.fn(),
+    getBackendApiHeaders: vi.fn(() => ({
+        "x-nb-portal-api-key": "test-api-key",
+    })),
+    getBackendApiUrl: vi.fn(() => "https://backend.example.test/api"),
+}));
+
+vi.mock("@/src/auth", () => ({ auth: mocks.auth }));
+vi.mock("@/src/shared/lib/server-env", () => ({
+    getBackendApiHeaders: mocks.getBackendApiHeaders,
+    getBackendApiUrl: mocks.getBackendApiUrl,
+}));
+
+import { POST } from "./route";
+
+const request = (clientTimestamp: string) =>
+    new NextRequest("https://portal.example.test/api/access-log", {
+        method: "POST",
+        headers: {
+            host: "portal.example.test",
+            origin: "https://portal.example.test",
+            "content-type": "application/json",
+            "user-agent": "vitest-browser",
+            "x-forwarded-for": "192.0.2.10, 198.51.100.20",
+        },
+        body: JSON.stringify({
+            logs: [{ path: "/calendar", clientTimestamp }],
+        }),
+    });
+
+const jsonResponse = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+describe("POST /api/access-log", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.auth.mockResolvedValue({
+            user: { name: "認証ユーザー" },
+            studentId: "26D0001",
+            displayName: "テスト部員",
+            permission: "NORMAL",
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it.each([
+        "2026-08-28T12:34:56+09:00",
+        "2026-08-28T03:34:56.000Z",
+    ])("ISO日時 %s を受理してWorkerへ転送する", async (clientTimestamp) => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse({ success: true, count: 1 })
+        );
+
+        const response = await POST(request(clientTimestamp));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ success: true, count: 1 });
+        expect(fetch).toHaveBeenCalledOnce();
+
+        const [url, options] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe(
+            "https://backend.example.test/api?path=access-logs"
+        );
+        expect(options).toMatchObject({
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "x-nb-portal-api-key": "test-api-key",
+            },
+        });
+        const body = JSON.parse(String(options?.body)) as {
+            logs: Array<Record<string, unknown>>;
+        };
+        expect(body.logs).toEqual([
+            {
+                timestamp: expect.stringMatching(
+                    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+09:00$/
+                ),
+                clientTimestamp,
+                studentId: "26D0001",
+                displayName: "テスト部員",
+                permission: "NORMAL",
+                path: "/calendar",
+                method: "GET",
+                userAgent: "vitest-browser",
+                ipHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+            },
+        ]);
+    });
+
+    it("不正な日時を400で拒否する", async () => {
+        const response = await POST(request("2026/08/28 12:34:56"));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Invalid access log payload",
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("WorkerのHTTPエラーステータスを呼び出し元へ返す", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            jsonResponse(
+                { success: false, error: "Database unavailable" },
+                500
+            )
+        );
+
+        const response = await POST(
+            request("2026-08-28T12:34:56+09:00")
+        );
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+            success: false,
+            error: "Database unavailable",
+        });
+    });
+});

--- a/app/api/access-log/route.ts
+++ b/app/api/access-log/route.ts
@@ -17,7 +17,10 @@ const accessLogSchema = z.object({
                     .min(1)
                     .max(200)
                     .regex(/^\/[A-Za-z0-9/_-]*$/),
-                clientTimestamp: z.string().datetime().optional(),
+                clientTimestamp: z
+                    .string()
+                    .datetime({ offset: true })
+                    .optional(),
             })
         )
         .min(1)
@@ -108,6 +111,7 @@ export async function POST(request: NextRequest) {
             error?: string;
         };
         return NextResponse.json(data, {
+            status: response.status,
             headers: {
                 "Cache-Control": "no-store, max-age=0",
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "2.6.5",
+    "version": "2.6.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "2.6.5",
+            "version": "2.6.6",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "2.6.5",
+    "version": "2.6.6",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",

--- a/src/features/access-log/AccessLogger.test.tsx
+++ b/src/features/access-log/AccessLogger.test.tsx
@@ -1,0 +1,54 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/calendar",
+}));
+
+import { AccessLogger } from "./AccessLogger";
+
+const STORAGE_KEY = "nb-portal-access-log-last:/calendar";
+
+describe("AccessLogger", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.clearAllMocks();
+        vi.spyOn(Date, "now").mockReturnValue(1_787_883_296_000);
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    it.each([400, 500])(
+        "APIがHTTP %sを返した場合は送信済み状態を解除して再送できる",
+        async (status) => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(new Response(null, { status }))
+                .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+            const firstRender = render(<AccessLogger />);
+            await waitFor(() =>
+                expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+            );
+            firstRender.unmount();
+
+            render(<AccessLogger />);
+            await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+            expect(localStorage.getItem(STORAGE_KEY)).toBe(
+                "1787883296000"
+            );
+        }
+    );
+
+    it("成功時は送信時刻を保持し、5分以内の再送を抑止する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            new Response(null, { status: 200 })
+        );
+
+        const firstRender = render(<AccessLogger />);
+        await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+        firstRender.unmount();
+        render(<AccessLogger />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+        expect(localStorage.getItem(STORAGE_KEY)).toBe("1787883296000");
+    });
+});

--- a/src/features/access-log/AccessLogger.tsx
+++ b/src/features/access-log/AccessLogger.tsx
@@ -47,9 +47,15 @@ export function AccessLogger() {
             }),
             cache: "no-store",
             keepalive: true,
-        }).catch(() => {
-            localStorage.removeItem(storageKey);
-        });
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    localStorage.removeItem(storageKey);
+                }
+            })
+            .catch(() => {
+                localStorage.removeItem(storageKey);
+            });
     }, [pathname]);
 
     return null;


### PR DESCRIPTION
## 概要

JST化後の `+09:00` 付き日時がAPI検証で拒否され、アクセスログがD1へ保存されていなかった問題を修正します。

## 変更内容

- `clientTimestamp` でオフセット付きISO日時を許可
- UTCの `Z` 形式も引き続き許可
- WorkerのHTTPステータスをクライアントへ維持して返却
- HTTPエラー時に送信済み状態を解除し、次回アクセスで再送可能に変更
- APIとクライアントの回帰テストを追加
- アプリversionを `2.6.6` へ更新

## 検証

- ルート: 32ファイル、198テスト成功
- Worker: 29テスト成功
- TypeScript: 成功
- ESLint: 成功
- Next.js本番ビルド: 成功

Closes #195