### PR TITLE
fix: モーダル開閉時のRouterナビゲーションを解消

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nb-portal",
-    "version": "2.6.6",
+    "version": "2.6.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nb-portal",
-            "version": "2.6.6",
+            "version": "2.6.7",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nb-portal",
-    "version": "2.6.6",
+    "version": "2.6.7",
     "private": true,
     "scripts": {
         "dev": "next dev --port 3005",

--- a/src/shared/lib/use-url-modal.test.ts
+++ b/src/shared/lib/use-url-modal.test.ts
@@ -1,22 +1,30 @@
 import { renderHook, act } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useUrlModal } from "./use-url-modal";
 
-const push = vi.fn();
-const replace = vi.fn();
 let currentQuery = "";
 
 vi.mock("next/navigation", () => ({
-    useRouter: () => ({ push, replace }),
     usePathname: () => "/items",
     useSearchParams: () => new URLSearchParams(currentQuery),
 }));
 
 describe("useUrlModal", () => {
+    let pushState: ReturnType<typeof vi.spyOn>;
+    let replaceState: ReturnType<typeof vi.spyOn>;
+
     beforeEach(() => {
         currentQuery = "filter=MIC";
-        push.mockReset();
-        replace.mockReset();
+        pushState = vi
+            .spyOn(window.history, "pushState")
+            .mockImplementation(() => undefined);
+        replaceState = vi
+            .spyOn(window.history, "replaceState")
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it("現在のモーダル名と対象パラメータを返す", () => {
@@ -36,11 +44,12 @@ describe("useUrlModal", () => {
             result.current.openModal("item-edit", { item: "MIC001" });
         });
 
-        expect(push).toHaveBeenCalledWith(
+        expect(pushState).toHaveBeenCalledWith(
+            null,
+            "",
             "/items?filter=MIC&modal=item-edit&item=MIC001",
-            { scroll: false }
         );
-        expect(replace).not.toHaveBeenCalled();
+        expect(replaceState).not.toHaveBeenCalled();
     });
 
     it("親モーダルへの遷移は現在の履歴を置き換える", () => {
@@ -53,11 +62,12 @@ describe("useUrlModal", () => {
             });
         });
 
-        expect(replace).toHaveBeenCalledWith(
+        expect(replaceState).toHaveBeenCalledWith(
+            null,
+            "",
             "/items?modal=schedule-response&event=EVENT001",
-            { scroll: false }
         );
-        expect(push).not.toHaveBeenCalled();
+        expect(pushState).not.toHaveBeenCalled();
     });
 
     it("完了後はモーダル用クエリだけを削除して履歴を置き換える", () => {
@@ -68,9 +78,11 @@ describe("useUrlModal", () => {
             result.current.closeModal(["item"]);
         });
 
-        expect(replace).toHaveBeenCalledWith("/items?filter=MIC", {
-            scroll: false,
-        });
-        expect(push).not.toHaveBeenCalled();
+        expect(replaceState).toHaveBeenCalledWith(
+            null,
+            "",
+            "/items?filter=MIC"
+        );
+        expect(pushState).not.toHaveBeenCalled();
     });
 });

--- a/src/shared/lib/use-url-modal.ts
+++ b/src/shared/lib/use-url-modal.ts
@@ -1,12 +1,11 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 type UrlModalParams = Record<string, string | null | undefined>;
 type UrlModalHistory = "push" | "replace";
 
 export const useUrlModal = () => {
-    const router = useRouter();
     const pathname = usePathname();
     const searchParams = useSearchParams();
     const modal = searchParams.get("modal");
@@ -25,7 +24,11 @@ export const useUrlModal = () => {
         });
         const query = next.toString();
         const url = query ? `${pathname}?${query}` : pathname;
-        router[history](url, { scroll: false });
+        if (history === "push") {
+            window.history.pushState(null, "", url);
+        } else {
+            window.history.replaceState(null, "", url);
+        }
     };
 
     const openModal = (name: string, params: UrlModalParams = {}) => {


### PR DESCRIPTION
## 概要

モーダルURLの更新をNext RouterからネイティブHistory APIへ変更し、開閉時のRSCナビゲーションを回避します。

## 変更内容

- `openModal`で`window.history.pushState`を使用
- モーダル間遷移と閉じる操作で`window.history.replaceState`を使用
- URL共有、既存クエリ、直接URLからの表示を維持
- History APIの使い分けを回帰テストで固定
- アプリversionを`2.6.7`へ更新

## 検証

- 全32ファイル、198テスト成功
- TypeScript成功
- ESLint成功
- `git diff --check`成功
- 本番ビルドは既存の開発サーバーが`.next`を使用中のため、このブランチでは未実行（直前のmainでは成功済み）

Refs #198

Issue #198は本番で体感速度を確認するまで開いたままにします。